### PR TITLE
convert benchmark project to use BenchmarkDotNet

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ project.lock.json
 .vs
 .build/
 .testPublish/
+.idea
+BenchmarkDotNet.Artifacts*

--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -1,14 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Esprima.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Esprima.Benchmark</PackageId>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
+  <ItemGroup>
+    <None Include="..\..\test\Esprima.Tests\Fixtures\3rdparty\**" CopyToOutputDirectory="PreserveNewest" LinkBase="3rdparty" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.11" />
   </ItemGroup>
-
 </Project>

--- a/samples/Esprima.Benchmark/FileParsingBenchmark.cs
+++ b/samples/Esprima.Benchmark/FileParsingBenchmark.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Esprima.Benchmark
+{
+    [MemoryDiagnoser]
+    public class FileParsingBenchmark
+    {
+        private static readonly Dictionary<string, string> files = new Dictionary<string, string>
+        {
+            {"underscore-1.5.2", null},
+            {"backbone-1.1.0", null},
+            {"mootools-1.4.5", null},
+            {"jquery-1.9.1", null},
+            {"yui-3.12.0", null},
+            {"jquery.mobile-1.4.2", null},
+            {"angular-1.2.5", null}
+        };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            foreach (var fileName in files.Keys.ToList())
+            {
+                files[fileName] = File.ReadAllText($"3rdparty/{fileName}.js");
+            }
+        }
+
+        [ParamsSource(nameof(FileNames))]
+        public string FileName { get; set; }
+
+        public IEnumerable<string> FileNames()
+        {
+            foreach (var entry in files)
+            {
+                yield return entry.Key;
+            }
+        }
+
+        [Benchmark]
+        public void ParseProgram()
+        {
+            var parser = new JavaScriptParser(files[FileName]);
+            parser.ParseProgram();
+        }
+    }
+}

--- a/samples/Esprima.Benchmark/Program.cs
+++ b/samples/Esprima.Benchmark/Program.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+﻿using System.Reflection;
+
+using BenchmarkDotNet.Running;
 
 namespace Esprima.Benchmark
 {
@@ -10,50 +8,7 @@ namespace Esprima.Benchmark
     {
         public static void Main(string[] args)
         {
-            var scripts =new [] {
-                "underscore-1.5.2",
-                "backbone-1.1.0",
-                "mootools-1.4.5",
-                "jquery-1.9.1",
-                "yui-3.12.0",
-                "jquery.mobile-1.4.2",
-                "angular-1.2.5"
-            };
-
-            foreach(var script in scripts)
-            {
-                Bench(script);
-            }
+            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
         }
-
-        public static void Bench(string script)
-        {
-            var repeat = 120;
-            var exclude = 10;
-
-            var filename = $"../../test/Esprima.Tests/Fixtures/3rdparty/{script}.js";
-            var content = File.ReadAllText(filename);
-
-            var sw = new Stopwatch();
-            var results = new List<long>();
-
-            for(var i=0; i<repeat; i++)
-            {
-                var parser = new JavaScriptParser(content);
-                sw.Restart();
-
-                parser.ParseProgram();
-                results.Add(sw.ElapsedMilliseconds);
-            }
-
-            var average = results
-                .OrderBy(x => x)
-                .Skip(exclude)
-                .Take(repeat - exclude * 2)
-                .Average();
-
-            Console.WriteLine("{0} ({2}KB): {1} ms", script, Math.Round(average, 1), content.Length / 1024);
-        }
-
     }
 }


### PR DESCRIPTION
Here's the output that we now get.

``` ini

BenchmarkDotNet=v0.10.11, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.125)
Processor=Intel Core i7-6820HQ CPU 2.70GHz (Skylake), ProcessorCount=8
Frequency=2648436 Hz, Resolution=377.5813 ns, Timer=TSC
.NET Core SDK=2.1.2
  [Host]     : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.3 (Framework 4.6.25815.02), 64bit RyuJIT


```
|       Method |            FileName |      Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
|------------- |-------------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
| **ParseProgram** |       **angular-1.2.5** | **44.729 ms** | **0.7207 ms** | **0.9621 ms** | **3500.0000** | **1000.0000** | **312.5000** |  **19.29 MB** |
| **ParseProgram** |      **backbone-1.1.0** |  **3.817 ms** | **0.0724 ms** | **0.0743 ms** |  **539.0625** |  **265.6250** |        **-** |   **3.08 MB** |
| **ParseProgram** |        **jquery-1.9.1** | **36.866 ms** | **0.4396 ms** | **0.3671 ms** | **3062.5000** |  **937.5000** | **312.5000** |  **16.71 MB** |
| **ParseProgram** | **jquery.mobile-1.4.2** | **60.237 ms** | **1.1951 ms** | **1.0594 ms** | **4625.0000** | **1437.5000** | **500.0000** |  **25.12 MB** |
| **ParseProgram** |      **mootools-1.4.5** | **28.664 ms** | **0.1293 ms** | **0.1010 ms** | **2562.5000** |  **843.7500** | **250.0000** |  **13.84 MB** |
| **ParseProgram** |    **underscore-1.5.2** |  **3.087 ms** | **0.0634 ms** | **0.0778 ms** |  **500.0000** |  **199.2188** |        **-** |    **2.7 MB** |
| **ParseProgram** |          **yui-3.12.0** | **28.712 ms** | **0.7208 ms** | **2.0911 ms** | **2375.0000** |  **812.5000** | **250.0000** |  **12.75 MB** |
