### PR TITLE
reduce allocations and make things go faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ project.lock.json
 .vs
 .build/
 .testPublish/
+.idea
+BenchmarkDotNet.Artifacts*

--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -1,14 +1,15 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>Esprima.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Esprima.Benchmark</PackageId>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
-
+  <ItemGroup>
+    <None Include="..\..\test\Esprima.Tests\Fixtures\3rdparty\**" CopyToOutputDirectory="PreserveNewest" LinkBase="3rdparty" />
+  </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.11" />
   </ItemGroup>
-
 </Project>

--- a/samples/Esprima.Benchmark/FileParsingBenchmark.cs
+++ b/samples/Esprima.Benchmark/FileParsingBenchmark.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+
+namespace Esprima.Benchmark
+{
+    [MemoryDiagnoser]
+    public class FileParsingBenchmark
+    {
+        private static readonly Dictionary<string, string> files = new Dictionary<string, string>
+        {
+            {"underscore-1.5.2", null},
+            {"backbone-1.1.0", null},
+            {"mootools-1.4.5", null},
+            {"jquery-1.9.1", null},
+            {"yui-3.12.0", null},
+            {"jquery.mobile-1.4.2", null},
+            {"angular-1.2.5", null}
+        };
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            foreach (var fileName in files.Keys.ToList())
+            {
+                files[fileName] = File.ReadAllText($"3rdparty/{fileName}.js");
+            }
+        }
+
+        [ParamsSource(nameof(FileNames))]
+        public string FileName { get; set; }
+
+        public IEnumerable<string> FileNames()
+        {
+            foreach (var entry in files)
+            {
+                yield return entry.Key;
+            }
+        }
+
+        [Benchmark]
+        public void ParseProgram()
+        {
+            var parser = new JavaScriptParser(files[FileName]);
+            parser.ParseProgram();
+        }
+    }
+}

--- a/samples/Esprima.Benchmark/Program.cs
+++ b/samples/Esprima.Benchmark/Program.cs
@@ -1,8 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
-using System.Linq;
+﻿using System.Reflection;
+
+using BenchmarkDotNet.Running;
 
 namespace Esprima.Benchmark
 {
@@ -10,50 +8,7 @@ namespace Esprima.Benchmark
     {
         public static void Main(string[] args)
         {
-            var scripts =new [] {
-                "underscore-1.5.2",
-                "backbone-1.1.0",
-                "mootools-1.4.5",
-                "jquery-1.9.1",
-                "yui-3.12.0",
-                "jquery.mobile-1.4.2",
-                "angular-1.2.5"
-            };
-
-            foreach(var script in scripts)
-            {
-                Bench(script);
-            }
+            BenchmarkSwitcher.FromAssembly(typeof(Program).GetTypeInfo().Assembly).Run(args);
         }
-
-        public static void Bench(string script)
-        {
-            var repeat = 120;
-            var exclude = 10;
-
-            var filename = $"../../test/Esprima.Tests/Fixtures/3rdparty/{script}.js";
-            var content = File.ReadAllText(filename);
-
-            var sw = new Stopwatch();
-            var results = new List<long>();
-
-            for(var i=0; i<repeat; i++)
-            {
-                var parser = new JavaScriptParser(content);
-                sw.Restart();
-
-                parser.ParseProgram();
-                results.Add(sw.ElapsedMilliseconds);
-            }
-
-            var average = results
-                .OrderBy(x => x)
-                .Skip(exclude)
-                .Take(repeat - exclude * 2)
-                .Average();
-
-            Console.WriteLine("{0} ({2}KB): {1} ms", script, Math.Round(average, 1), content.Length / 1024);
-        }
-
     }
 }

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -75,7 +75,8 @@ namespace Esprima.Ast
 
         string PropertyKey.GetKey()
         {
-            return Convert.ToString(Value);
+            var s = Value as string;
+            return s ?? Convert.ToString(Value);
         }
     }
 }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -5,6 +5,8 @@ namespace Esprima.Ast
 {
     public class Node : INode
     {
+        private Location _location;
+
         [JsonProperty(Order = -100)]
         [JsonConverter(typeof(StringEnumConverter))]
         public Nodes Type { get; set; }
@@ -12,6 +14,10 @@ namespace Esprima.Ast
         public int[] Range { get; set; }
 
         [JsonProperty(PropertyName = "Loc")]
-        public Location Location { get; set; } = new Location();
+        public Location Location
+        {
+            get => _location  = _location ?? new Location();
+            set => _location = value;
+        }
     }
 }

--- a/src/Esprima/Character.cs
+++ b/src/Esprima/Character.cs
@@ -51,7 +51,7 @@ namespace Esprima
                    (ch >= 'A' && ch <= 'Z') ||
                    (ch >= 'a' && ch <= 'z') ||
                    (ch == '\\') ||
-                   ((ch >= 0x80) && NonAsciiIdentifierStart.IsMatch(ch.ToString()));
+                   ((ch >= 0x80) && NonAsciiIdentifierStart.IsMatch(ParserExtensions.CharToString(ch)));
         }
 
         public static bool IsIdentifierPart(char ch)
@@ -61,7 +61,7 @@ namespace Esprima
                    (ch >= 'a' && ch <= 'z') ||
                    (ch >= '0' && ch <= '9') ||
                    (ch == '\\') ||
-                   ((ch >= 0x80) && NonAsciiIdentifierPart.IsMatch(ch.ToString()));
+                   ((ch >= 0x80) && NonAsciiIdentifierPart.IsMatch(ParserExtensions.CharToString(ch)));
         }
 
         public static bool IsIdentifierStart(string ch)

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -1,10 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Esprima
 {
     public static class ParserExtensions
     {
+        private static readonly string[] charToString = new string[256];
+
+        static ParserExtensions()
+        {
+            for (var i = 0; i < charToString.Length; ++i)
+            {
+                var c = (char) i;
+                charToString[i] = c.ToString();
+            }
+        }
+
         public static string Slice(this string source, int start, int end)
         {
             var len = source.Length;
@@ -12,9 +24,537 @@ namespace Esprima
             var to = end < 0 ? Math.Max(len + end, 0) : Math.Min(end, len);
             var span = Math.Max(to - from, 0);
 
-            return source.Substring(from, span);
+            // check some common cases
+            if (span == 1)
+            {
+                return CharToString(source[from]);
+            }
+            if (span == 2)
+            {
+                if (source[from] == 'i')
+                {
+                    if (source[from + 1] == 'f')
+                    {
+                        return "if";
+                    }
+                    if (source[from + 1] == 'd')
+                    {
+                        return "id";
+                    }
+                    if (source[from + 1] == 'n')
+                    {
+                        return "in";
+                    }
+                }
+                if (source[from] == '"' && source[from + 1] == '"')
+                {
+                    return "\"\"";
+                }
+                if (source[from] == '\'' && source[from + 1] == '\'')
+                {
+                    return "''";
+                }
+                if (source[from] == 'f' && source[from + 1] == 'n')
+                {
+                    return "fn";
+                }
+                if (source[from] == 'o' && source[from + 1] == 'n')
+                {
+                    return "on";
+                }
+                if (source[from] == 'd' && source[from + 1] == 'o')
+                {
+                    return "do";
+                }
+            }
+            else if (span == 3)
+            {
+                if (source[from] == 'a')
+                {
+                    if (source[from + 1] == 'd' && source[from + 2] == 'd')
+                    {
+                        return "add";
+                    }
+                    if (source[from + 1] == 'r' && source[from + 2] == 'g')
+                    {
+                        return "arg";
+                    }
+                }
+                if (source[from] == 'f' && source[from + 1] == 'o' && source[from + 2] == 'r')
+                {
+                    return "for";
+                }
+                if (source[from] == 'v' && source[from + 1] == 'a')
+                {
+                    if (source[from + 2] == 'l')
+                    {
+                        return "val";
+                    }
+                    if (source[from + 2] == 'r')
+                    {
+                        return "var";
+                    }
+                }
+                if (source[from] == 'm')
+                {
+                    if (source[from + 1] == 'a')
+                    {
+                        if (source[from + 2] == 'p')
+                        {
+                            return "map";
+                        }
+                        if (source[from + 2] == 'x')
+                        {
+                            return "max";
+                        }
+                    }
+                    if (source[from + 1] == 'i' && source[from + 2] == 'n')
+                    {
+                        return "min";
+                    }
+                }
+                if (source[from] == 'n' && source[from + 1] == 'e' && source[from + 2] == 'w')
+                {
+                    return "new";
+                }
+                if (source[from] == 'k' && source[from + 1] == 'e' && source[from + 2] == 'y')
+                {
+                    return "key";
+                }
+                if (source[from] == 'l' && source[from + 1] == 'e' && source[from + 2] == 'n')
+                {
+                    return "len";
+                }
+                if (source[from] == 'o' && source[from + 1] == 'b' && source[from + 2] == 'j')
+                {
+                    return "obj";
+                }
+                if (source[from] == 'p' && source[from + 1] == 'o' && source[from + 2] == 'p')
+                {
+                    return "pop";
+                }
+                if (source[from] == 'u' && source[from + 1] == 'r' && source[from + 2] == 'l')
+                {
+                    return "url";
+                }
+                if (source[from] == 't' && source[from + 1] == 'r' && source[from + 2] == 'y')
+                {
+                    return "try";
+                }
+            }
+            else if (span == 4)
+            {
+                if (source[from] == 't')
+                {
+                    if (source[from + 1] == 'e')
+                    {
+                        if (source[from + 2] == 'x' && source[from + 3] == 't')
+                        {
+                            return "text";
+                        }
+                        if (source[from + 2] == 's' && source[from + 3] == 't')
+                        {
+                            return "test";
+                        }
+                    }
+                    if (source[from + 1] == 'r' && source[from + 2] == 'u' && source[from + 3] == 'e')
+                    {
+                        return "true";
+                    }
+                    if (source[from + 1] == 'h')
+                    {
+                        if (source[from + 2] == 'i' && source[from + 3] == 's')
+                        {
+                            return "this";
+                        }
+                        if (source[from + 2] == 'e' && source[from + 3] == 'n')
+                        {
+                            return "then";
+                        }
+                    }
+                    if (source[from + 1] == 'y' && source[from + 2] == 'p' && source[from + 3] == 'e')
+                    {
+                        return "type";
+                    }
+                }
+                if (source[from] == 'e')
+                {
+                    if (source[from + 1] == 'a' && source[from + 2] == 'c' && source[from + 3] == 'h')
+                    {
+                        return "each";
+                    }
+
+                    if (source[from + 1] == 'l')
+                    {
+                        if (source[from + 2] == 's' && source[from + 3] == 'e')
+                        {
+                            return "else";
+                        }
+                        if (source[from + 2] == 'e' && source[from + 3] == 'm')
+                        {
+                            return "elem";
+                        }
+                    }
+                }
+                if (source[from] == 'a')
+                {
+                    if (source[from + 1] == 'r' && source[from + 2] == 'g' && source[from + 3] == 's')
+                    {
+                        return "args";
+                    }
+                    if (source[from + 1] == 't' && source[from + 2] == 't' && source[from + 3] == 'r')
+                    {
+                        return "attr";
+                    }
+                }
+                if (source[from] == 'f')
+                {
+                    if (source[from + 1] == 'i' && source[from + 2] == 'n' && source[from + 3] == 'd')
+                    {
+                        return "find";
+                    }
+                    if (source[from + 1] == 'r' && source[from + 2] == 'o' && source[from + 3] == 'm')
+                    {
+                        return "from";
+                    }
+                }
+                if (source[from] == 'd')
+                {
+                    if (source[from + 1] == 'a' && source[from + 2] == 't' && source[from + 3] == 'a')
+                    {
+                        return "data";
+                    }
+                    if (source[from + 1] == 'o' && source[from + 2] == 'n' && source[from + 3] == 'e')
+                    {
+                        return "done";
+                    }
+                }
+                if (source[from] == 'M' && source[from + 1] == 'a' && source[from + 2] == 't' && source[from + 3] == 'h')
+                {
+                    return "Math";
+                }
+                if (source[from] == 'p' && source[from + 1] == 'u' && source[from + 2] == 's' && source[from + 3] == 'h')
+                {
+                    return "push";
+                }
+                if (source[from] == 'k' && source[from + 1] == 'e' && source[from + 2] == 'y' && source[from + 3] == 's')
+                {
+                    return "keys";
+                }
+                if (source[from] == 'b' && source[from + 1] == 'i' && source[from + 2] == 'n' && source[from + 3] == 'd')
+                {
+                    return "bind";
+                }
+                if (source[from] == 'j' && source[from + 1] == 'o' && source[from + 2] == 'i' && source[from + 3] == 'n')
+                {
+                    return "join";
+                }
+                if (source[from] == 'c' && source[from + 1] == 'a')
+                {
+                    if (source[from + 2] == 's' && source[from + 3] == 'e')
+                    {
+                        return "case";
+                    }
+                    if (source[from + 2] == 'l' && source[from + 3] == 'l')
+                    {
+                        return "call";
+                    }
+                }
+                if (source[from] == 'n')
+                {
+                    if (source[from + 1] == 'u' && source[from + 2] == 'l' && source[from + 3] == 'l')
+                    {
+                        return "null";
+                    }
+                    if (source[from + 1] == 'a' && source[from + 2] == 'm' && source[from + 3] == 'e')
+                    {
+                        return "name";
+                    }
+                    if (source[from + 1] == 'o' && source[from + 2] == 'd' && source[from + 3] == 'e')
+                    {
+                        return "node";
+                    }
+                }
+                if (source[from] == 's')
+                {
+                    if (source[from + 1] == 'e' && source[from + 2] == 'l' && source[from + 3] == 'f')
+                    {
+                        return "self";
+                    }
+                    if (source[from + 1] == 'o' && source[from + 2] == 'r' && source[from + 3] == 't')
+                    {
+                        return "sort";
+                    }
+                }
+            }
+            else if (span == 5)
+            {
+                if (source[from] == 'a' && source[from + 1] == 'p' && source[from + 2] == 'p' && source[from + 3] == 'l' && source[from + 4] == 'y')
+                {
+                    return "apply";
+                }
+                if (source[from] == 'b' && source[from + 1] == 'r' && source[from + 2] == 'e' && source[from + 3] == 'a' && source[from + 4] == 'k')
+                {
+                    return "break";
+                }
+                if (source[from] == 'm' && source[from + 1] == 'a' && source[from + 2] == 't' && source[from + 3] == 'c' && source[from + 4] == 'h')
+                {
+                    return "match";
+                }
+                if (source[from] == 'f' && source[from + 1] == 'a' && source[from + 2] == 'l' && source[from + 3] == 's' && source[from + 4] == 'e')
+                {
+                    return "false";
+                }
+                if (source[from] == 'v' && source[from + 1] == 'a' && source[from + 2] == 'l' && source[from + 3] == 'u' && source[from + 4] == 'e')
+                {
+                    return "value";
+                }
+                if (source[from] == 'e' && source[from + 1] == 'v' && source[from + 2] == 'e')
+                {
+                    if (source[from + 3] == 'r' && source[from + 4] == 'y')
+                    {
+                        return "every";
+                    }
+                    if (source[from + 3] == 'n' && source[from + 4] == 't')
+                    {
+                        return "event";
+                    }
+                }
+                if (source[from] == 'i' && source[from + 1] == 'n' && source[from + 2] == 'd' && source[from + 3] == 'e' && source[from + 4] == 'x')
+                {
+                    return "index";
+                }
+                if (source[from] == 'w' && source[from + 1] == 'h' && source[from + 2] == 'i' && source[from + 3] == 'l' && source[from + 4] == 'e')
+                {
+                    return "while";
+                }
+                if (source[from] == 't' && source[from + 1] == 'h' && source[from + 2] == 'r' && source[from + 3] == 'o' && source[from + 4] == 'w')
+                {
+                    return "throw";
+                }
+                if (source[from] == 'c' && source[from + 1] == 'a' && source[from + 2] == 't' && source[from + 3] == 'c' && source[from + 4] == 'h')
+                {
+                    return "catch";
+                }
+                if (source[from] == 's')
+                {
+                    if (source[from + 1] == 'l' && source[from + 2] == 'i' && source[from + 3] == 'c' && source[from + 4] == 'e')
+                    {
+                        return "slice";
+                    }
+                    if (source[from + 1] == 'p' && source[from + 2] == 'l' && source[from + 3] == 'i' && source[from + 4] == 't')
+                    {
+                        return "split";
+                    }
+                    if (source[from + 1] == 'h' && source[from + 2] == 'i' && source[from + 3] == 'f' && source[from + 4] == 't')
+                    {
+                        return "shift";
+                    }
+                }
+                if (source[from] == 'A' && source[from + 1] == 'r' && source[from + 2] == 'r' && source[from + 3] == 'a' && source[from + 4] == 'y')
+                {
+                    return "Array";
+                }
+            }
+            else if (span == 6)
+            {
+                if (source[from] == 'o' && source[from + 1] == 'b' && source[from + 2] == 'j' && source[from + 3] == 'e' && source[from + 4] == 'c' && source[from + 5] == 't')
+                {
+                    return "object";
+                }
+                if (source[from] == 'O' && source[from + 1] == 'b' && source[from + 2] == 'j' && source[from + 3] == 'e' && source[from + 4] == 'c' && source[from + 5] == 't')
+                {
+                    return "Object";
+                }
+                if (source[from] == 'c' && source[from + 1] == 'o' && source[from + 2] == 'n' && source[from + 3] == 'c' && source[from + 4] == 'a' && source[from + 5] == 't')
+                {
+                    return "concat";
+                }
+                if (source[from] == 'e' && source[from + 1] == 'x' && source[from + 2] == 't' && source[from + 3] == 'e' && source[from + 4] == 'n' && source[from + 5] == 'd')
+                {
+                    return "extend";
+                }
+                if (source[from] == 'f' && source[from + 1] == 'i' && source[from + 2] == 'l' && source[from + 3] == 't' && source[from + 4] == 'e' && source[from + 5] == 'r')
+                {
+                    return "filter";
+                }
+                if (source[from] == 'l' && source[from + 1] == 'e' && source[from + 2] == 'n' && source[from + 3] == 'g' && source[from + 4] == 't' && source[from + 5] == 'h')
+                {
+                    return "length";
+                }
+                if (source[from] == 'r' && source[from + 1] == 'e')
+                {
+                    if (source[from + 2] == 't' && source[from + 3] == 'u' && source[from + 4] == 'r' && source[from + 5] == 'n')
+                    {
+                        return "return";
+                    }
+                    if (source[from + 2] == 's' && source[from + 3] == 'u' && source[from + 4] == 'l' && source[from + 5] == 't')
+                    {
+                        return "result";
+                    }
+                }
+                if (source[from] == 'j' && source[from + 1] == 'Q' && source[from + 2] == 'u' && source[from + 3] == 'e' && source[from + 4] == 'r' && source[from + 5] == 'y')
+                {
+                    return "jQuery";
+                }
+                if (source[from] == 'm' && source[from + 1] == 'o' && source[from + 2] == 'b' && source[from + 3] == 'i' && source[from + 4] == 'l' && source[from + 5] == 'e')
+                {
+                    return "mobile";
+                }
+                if (source[from] == 't' && source[from + 1] == 'y' && source[from + 2] == 'p' && source[from + 3] == 'e' && source[from + 4] == 'o' && source[from + 5] == 'f')
+                {
+                    return "typeof";
+                }
+                if (source[from] == 'w' && source[from + 1] == 'i' && source[from + 2] == 'n' && source[from + 3] == 'd' && source[from + 4] == 'o' && source[from + 5] == 'w')
+                {
+                    return "window";
+                }
+                if (source[from] == 's')
+                {
+                    if (source[from + 1] == 'u' && source[from + 2] == 'b' && source[from + 3] == 's' && source[from + 4] == 't' && source[from + 5] == 'r')
+                    {
+                        return "substr";
+                    }
+                    if (source[from + 1] == 'p' && source[from + 2] == 'l' && source[from + 3] == 'i' && source[from + 4] == 'c' && source[from + 5] == 'e')
+                    {
+                        return "splice";
+                    }
+                }
+            }
+            else if (span == 7)
+            {
+                if (source[from] == 'e' && source[from + 1] == 'l' && source[from + 2] == 'e' && source[from + 3] == 'm'
+                    && source[from + 4] == 'e' && source[from + 5] == 'n' && source[from + 6] == 't')
+                {
+                    return "element";
+                }
+                if (source[from] == 'o' && source[from + 1] == 'p' && source[from + 2] == 't' && source[from + 3] == 'i'
+                    && source[from + 4] == 'o' && source[from + 5] == 'n' && source[from + 6] == 's')
+                {
+                    return "options";
+                }
+                if (source[from] == 'r' && source[from + 1] == 'e')
+                {
+                    if (source[from + 2] == 'p' && source[from + 3] == 'l' && source[from + 4] == 'a' && source[from + 5] == 'c' && source[from + 6] == 'e')
+                    {
+                        return "replace";
+                    }
+                    if (source[from + 2] == 'v' && source[from + 3] == 'e' && source[from + 4] == 'r' && source[from + 5] == 's' && source[from + 6] == 'e')
+                    {
+                        return "reverse";
+                    }
+                }
+                if (source[from] == 'f' && source[from + 1] == 'o' && source[from + 2] == 'r' && source[from + 3] == 'E'
+                    && source[from + 4] == 'a' && source[from + 5] == 'c' && source[from + 6] == 'h')
+                {
+                    return "forEach";
+                }
+                if (source[from] == 'i' && source[from + 1] == 'n' && source[from + 2] == 'd' && source[from + 3] == 'e'
+                    && source[from + 4] == 'x' && source[from + 5] == 'O' && source[from + 6] == 'f')
+                {
+                    return "indexOf";
+                }
+                if (source[from] == 'c' && source[from + 1] == 'o' && source[from + 2] == 'n' && source[from + 3] == 't'
+                    && source[from + 4] == 'e' && source[from + 5] == 'x' && source[from + 6] == 't')
+                {
+                    return "context";
+                }
+                if (source[from] == 'i' && source[from + 1] == 's' && source[from + 2] == 'A' && source[from + 3] == 'r'
+                    && source[from + 4] == 'r' && source[from + 5] == 'a' && source[from + 6] == 'y')
+                {
+                    return "isArray";
+                }
+                if (source[from] == 'u' && source[from + 1] == 'n' && source[from + 2] == 's' && source[from + 3] == 'h'
+                    && source[from + 4] == 'i' && source[from + 5] == 'f' && source[from + 6] == 't')
+                {
+                    return "unshift";
+                }
+            }
+            else if (span == 8)
+            {
+                if (source[from] == 'f' && source[from + 1] == 'u' && source[from + 2] == 'n' && source[from + 3] == 'c'
+                    && source[from + 4] == 't' && source[from + 5] == 'i' && source[from + 6] == 'o' && source[from + 7] == 'n')
+                {
+                    return "function";
+                }
+                if (source[from] == 'd' && source[from + 1] == 'o' && source[from + 2] == 'c' && source[from + 3] == 'u'
+                    && source[from + 4] == 'm' && source[from + 5] == 'e' && source[from + 6] == 'n' && source[from + 7] == 't')
+                {
+                    return "document";
+                }
+                if (source[from] == 't' && source[from + 1] == 'o' && source[from + 2] == 'S' && source[from + 3] == 't'
+                    && source[from + 4] == 'r' && source[from + 5] == 'i' && source[from + 6] == 'n' && source[from + 7] == 'g')
+                {
+                    return "toString";
+                }
+                if (source[from] == 's' && source[from + 1] == 'e' && source[from + 2] == 'l' && source[from + 3] == 'e'
+                    && source[from + 4] == 'c' && source[from + 5] == 't' && source[from + 6] == 'o' && source[from + 7] == 'r')
+                {
+                    return "selector";
+                }
+            }
+            else if (span == 9)
+            {
+                if (source[from] == 'u' && source[from + 1] == 'n' && source[from + 2] == 'd' && source[from + 3] == 'e'
+                    && source[from + 4] == 'f' && source[from + 5] == 'i' && source[from + 6] == 'n' && source[from + 7] == 'e' && source[from + 8] == 'd')
+                {
+                    return "undefined";
+                }
+                if (source[from] == 'p' && source[from + 1] == 'r' && source[from + 2] == 'o' && source[from + 3] == 't'
+                    && source[from + 4] == 'o' && source[from + 5] == 't' && source[from + 6] == 'y' && source[from + 7] == 'p' && source[from + 8] == 'e')
+                {
+                    return "prototype";
+                }
+                if (source[from] == 's' && source[from + 1] == 'u' && source[from + 2] == 'b' && source[from + 3] == 's'
+                    && source[from + 4] == 't' && source[from + 5] == 'r' && source[from + 6] == 'i' && source[from + 7] == 'n' && source[from + 8] == 'g')
+                {
+                    return "substring";
+                }
+            }
+            else if (span == 10)
+            {
+                if (source[from] == 'i' && source[from + 1] == 's' && source[from + 2] == 'F' && source[from + 3] == 'u'
+                    && source[from + 4] == 'n' && source[from + 5] == 'c' && source[from + 6] == 't' && source[from + 7] == 'i'
+                    && source[from + 8] == 'o' && source[from + 9] == 'n')
+                {
+                    return "isFunction";
+                }
+            }
+            else if (span == 11)
+            {
+                if (source[from] == 't' && source[from + 1] == 'o' && source[from + 2] == 'L' && source[from + 3] == 'o'
+                    && source[from + 4] == 'w' && source[from + 5] == 'e' && source[from + 6] == 'r' && source[from + 7] == 'C'
+                    && source[from + 8] == 'a' && source[from + 9] == 's' && source[from + 10] == 'e')
+                {
+                    return "toLowerCase";
+                }
+            }
+            else if (span == 14)
+            {
+                if (source[from] == 'h' && source[from + 1] == 'a' && source[from + 2] == 's' && source[from + 3] == 'O'
+                    && source[from + 4] == 'w' && source[from + 5] == 'n' && source[from + 6] == 'P' && source[from + 7] == 'r'
+                    && source[from + 8] == 'o' && source[from + 9] == 'p' && source[from + 10] == 'e' && source[from + 11] == 'r'
+                    && source[from + 12] == 't' && source[from + 13] == 'y')
+                {
+                    return "hasOwnProperty";
+                }
+            }
+
+            var substring = source.Substring(from, span);
+            return substring;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static string CharToString(char c)
+        {
+            if (c >= 0 && c < charToString.Length)
+            {
+                return charToString[c];
+            }
+            return c.ToString();
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static char CharCodeAt(this string source, int index)
         {
             if (index < 0 || index > source.Length - 1)
@@ -26,6 +566,7 @@ namespace Esprima
             return source[index];
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static T Pop<T>(this List<T> list)
         {
             var lastIndex = list.Count - 1;
@@ -34,6 +575,7 @@ namespace Esprima
             return last;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static void Push<T>(this List<T> list, T item)
         {
             list.Add(item);

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -18,8 +18,6 @@ namespace Esprima
 
     public class Token
     {
-        public static Token Empty = new Token();
-
         public TokenType Type;
         public string Literal;
 
@@ -27,14 +25,9 @@ namespace Esprima
         public int End; // Range[1]
         public int LineNumber;
         public int LineStart;
+
         private Location _location;
-        public Location Location
-        {
-            get
-            {
-                return _location ?? (_location = new Location());
-            }
-        }
+        public Location Location => _location ?? (_location = new Location());
 
         public int Precedence;
 
@@ -51,8 +44,24 @@ namespace Esprima
         public object Value;
         public RegexValue RegexValue;
 
-        public Token()
+        public void Clear()
         {
+            Type = TokenType.BooleanLiteral;
+            Literal = null;
+            Start = 0;
+            End = 0;
+            LineNumber = 0;
+            LineStart = 0;
+            _location = null;
+            Precedence = 0;
+            Octal = false;
+            Head = false;
+            Tail = false;
+            RawTemplate = null;
+            BooleanValue = false;
+            NumericValue = 0;
+            Value = null;
+            RegexValue = null;
         }
     }
 }


### PR DESCRIPTION
Based on addition of base benchmark I've created the pull request I've gone through code as a fun excercise what would be ways to make it run faster with less memory usage. It seems I was able to almost halve the memory usage and run duration dropped around 25-30%.

Here's my changes:

* cache Func<T> instances - memory pressure analysis showed that a lot of instances were created as code is looping in a fine level and call methods with Func<T> prameters 
* remove string.Substring / ToString allocations where possible & use common lookup  - target grammar is  known and most used words are easy to find, use shared string for known probable words
* reuse Token for object initializer parsing

I can also break to smaller pull requests if needed.

*Before*

|       Method |            FileName |      Mean |     Error |    StdDev |     Gen 0 |     Gen 1 |    Gen 2 | Allocated |
|------------- |-------------------- |----------:|----------:|----------:|----------:|----------:|---------:|----------:|
| **ParseProgram** |       **angular-1.2.5** | **44.729 ms** | **0.7207 ms** | **0.9621 ms** | **3500.0000** | **1000.0000** | **312.5000** |  **19.29 MB** |
| **ParseProgram** |      **backbone-1.1.0** |  **3.817 ms** | **0.0724 ms** | **0.0743 ms** |  **539.0625** |  **265.6250** |        **-** |   **3.08 MB** |
| **ParseProgram** |        **jquery-1.9.1** | **36.866 ms** | **0.4396 ms** | **0.3671 ms** | **3062.5000** |  **937.5000** | **312.5000** |  **16.71 MB** |
| **ParseProgram** | **jquery.mobile-1.4.2** | **60.237 ms** | **1.1951 ms** | **1.0594 ms** | **4625.0000** | **1437.5000** | **500.0000** |  **25.12 MB** |
| **ParseProgram** |      **mootools-1.4.5** | **28.664 ms** | **0.1293 ms** | **0.1010 ms** | **2562.5000** |  **843.7500** | **250.0000** |  **13.84 MB** |
| **ParseProgram** |    **underscore-1.5.2** |  **3.087 ms** | **0.0634 ms** | **0.0778 ms** |  **500.0000** |  **199.2188** |        **-** |    **2.7 MB** |
| **ParseProgram** |          **yui-3.12.0** | **28.712 ms** | **0.7208 ms** | **2.0911 ms** | **2375.0000** |  **812.5000** | **250.0000** |  **12.75 MB** |

*After*

|       Method |            FileName |      Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------- |-------------------- |----------:|----------:|----------:|----------:|---------:|---------:|----------:|
| **ParseProgram** |       **angular-1.2.5** | **34.249 ms** | **0.4522 ms** | **0.4230 ms** | **1937.5000** | **750.0000** | **250.0000** |  **10.16 MB** |
| **ParseProgram** |      **backbone-1.1.0** |  **2.829 ms** | **0.0547 ms** | **0.0585 ms** |  **285.1563** | **140.6250** |        **-** |   **1.56 MB** |
| **ParseProgram** |        **jquery-1.9.1** | **25.294 ms** | **0.5014 ms** | **1.0577 ms** | **1589.5833** | **650.0000** | **122.9167** |   **8.66 MB** |
| **ParseProgram** | **jquery.mobile-1.4.2** | **40.444 ms** | **0.8464 ms** | **0.7917 ms** | **2437.5000** | **937.5000** | **250.0000** |  **13.22 MB** |
| **ParseProgram** |      **mootools-1.4.5** | **21.072 ms** | **0.2207 ms** | **0.2064 ms** | **1312.5000** | **562.5000** | **125.0000** |   **7.14 MB** |
| **ParseProgram** |    **underscore-1.5.2** |  **2.280 ms** | **0.0447 ms** | **0.0549 ms** |  **281.2500** |  **74.2188** |        **-** |   **1.36 MB** |
| **ParseProgram** |          **yui-3.12.0** | **16.449 ms** | **0.3290 ms** | **0.3378 ms** | **1093.7500** | **531.2500** |        **-** |   **6.44 MB** |