### PR TITLE
Change Ast collections to be of concrete List<T> type

### DIFF
--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
 {
     public class ArrayExpression : Node, Expression
     {
-        public IEnumerable<ArrayExpressionElement> Elements;
+        public readonly List<ArrayExpressionElement> Elements;
 
-        public ArrayExpression(IEnumerable<ArrayExpressionElement> elements)
+        public ArrayExpression(List<ArrayExpressionElement> elements)
         {
             Type = Nodes.ArrayExpression;
             Elements = elements;

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -4,8 +4,9 @@ namespace Esprima.Ast
 {
     public class ArrayPattern : Node, BindingPattern
     {
-        public IEnumerable<ArrayPatternElement> Elements;
-        public ArrayPattern(IEnumerable<ArrayPatternElement> elements)
+        public readonly List<ArrayPatternElement> Elements;
+
+        public ArrayPattern(List<ArrayPatternElement> elements)
         {
             Type = Nodes.ArrayPattern;
             Elements = elements;

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -4,13 +4,13 @@ namespace Esprima.Ast
 {
     public class ArrowFunctionExpression : Node, Expression
     {
-        public Identifier Id;
-        public IEnumerable<INode> Params;
-        public INode Body; // : BlockStatement | Expression;
-        public bool Generator;
-        public bool Expression;
+        public readonly Identifier Id;
+        public readonly List<INode> Params;
+        public readonly INode Body; // : BlockStatement | Expression;
+        public readonly bool Generator;
+        public readonly bool Expression;
 
-        public ArrowFunctionExpression(IEnumerable<INode> parameters, INode body, bool expression)
+        public ArrowFunctionExpression(List<INode> parameters, INode body, bool expression)
         {
             Type = Nodes.ArrowFunctionExpression;
             Id = null;

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -4,9 +4,11 @@ namespace Esprima.Ast
 {
     public class ArrowParameterPlaceHolder : Node, Expression
     {
-        public IEnumerable<INode> Params;
+        public static readonly ArrowParameterPlaceHolder Empty = new ArrowParameterPlaceHolder(new List<INode>());
 
-        public ArrowParameterPlaceHolder(IEnumerable<INode> parameters)
+        public readonly List<INode> Params;
+
+        public ArrowParameterPlaceHolder(List<INode> parameters)
         {
             Type = Nodes.ArrowParameterPlaceHolder;
             Params = parameters;

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -37,11 +37,11 @@ namespace Esprima.Ast
         Expression
     {
         [JsonConverter(typeof(StringEnumConverter))]
-        public AssignmentOperator Operator;
+        public readonly AssignmentOperator Operator;
 
         // Can be something else than Expression (ObjectPattern, ArrayPattern) in case of destructuring assignment
-        public INode Left;
-        public Expression Right;
+        public readonly INode Left;
+        public readonly Expression Right;
 
         public AssignmentExpression(string op, INode left, Expression right)
         {

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -7,10 +7,10 @@
         FunctionParameter,
         PropertyValue
     {
-        public INode Left;
-        public Expression Right;
+        public readonly INode Left;
+        public INode Right;
 
-        public AssignmentPattern(INode left, Expression right)
+        public AssignmentPattern(INode left, INode right)
         {
             Type = Nodes.AssignmentPattern;
             Left = left;

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -59,9 +59,9 @@ namespace Esprima.Ast
         Expression
     {
         [JsonConverter(typeof(StringEnumConverter))]
-        public BinaryOperator Operator;
-        public Expression Left;
-        public Expression Right;
+        public readonly BinaryOperator Operator;
+        public readonly Expression Left;
+        public readonly Expression Right;
 
         public BinaryExpression(string op, Expression left, Expression right)
         {

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -1,13 +1,12 @@
-using System;
 using System.Collections.Generic;
 
 namespace Esprima.Ast
 {
     public class BlockStatement : Statement
     {
-        public IEnumerable<StatementListItem> Body;
+        public readonly List<StatementListItem> Body;
 
-        public BlockStatement(IEnumerable<StatementListItem> body)
+        public BlockStatement(List<StatementListItem> body)
         {
             Type = Nodes.BlockStatement;
             Body = body;

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public class BreakStatement : Statement
     {
-        public Identifier Label;
+        public readonly Identifier Label;
 
         public BreakStatement(Identifier label)
         {

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -6,8 +6,8 @@ namespace Esprima.Ast
     public class CallExpression : Node,
         Expression
     {
-        public Expression Callee;
-        public List<ArgumentListElement> Arguments;
+        public readonly Expression Callee;
+        public readonly List<ArgumentListElement> Arguments;
 
         [JsonIgnore]
         public bool Cached;

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class CatchClause : Statement
     {
-        public ArrayPatternElement Param; // BindingIdentifier | BindingPattern;
-        public BlockStatement Body;
+        public readonly ArrayPatternElement Param; // BindingIdentifier | BindingPattern;
+        public readonly BlockStatement Body;
 
         public CatchClause(ArrayPatternElement param, BlockStatement body)
         {

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -4,11 +4,12 @@ namespace Esprima.Ast
 {
     public class ClassBody : Node
     {
-        public IEnumerable<ClassProperty> Body;
-        public ClassBody(IEnumerable<ClassProperty> body)
-            {
-                Type = Nodes.ClassBody;
-                Body = body;
-            }
+        public readonly List<ClassProperty> Body;
+
+        public ClassBody(List<ClassProperty> body)
+        {
+            Type = Nodes.ClassBody;
+            Body = body;
         }
+    }
 }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -3,15 +3,16 @@
     public class ClassDeclaration : Node,
         Declaration
     {
-        public Identifier Id;
-        public PropertyKey SuperClass;
-        public ClassBody Body;
+        public readonly Identifier Id;
+        public readonly PropertyKey SuperClass;
+        public readonly ClassBody Body;
+
         public ClassDeclaration(Identifier id, PropertyKey superClass, ClassBody body)
-            {
-                Type = Nodes.ClassDeclaration;
-                Id = id;
-                SuperClass = superClass;
-                Body = body;
-            }
+        {
+            Type = Nodes.ClassDeclaration;
+            Id = id;
+            SuperClass = superClass;
+            Body = body;
+        }
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -1,18 +1,17 @@
 ﻿namespace Esprima.Ast
 {
-    public class ClassExpression : Node,
-        Expression
+    public class ClassExpression : Node, Expression
     {
-        public Identifier Id;
-        public PropertyKey SuperClass;
-        public ClassBody Body;
+        public readonly Identifier Id;
+        public readonly PropertyKey SuperClass;
+        public readonly ClassBody Body;
 
         public ClassExpression(Identifier id, PropertyKey superClass, ClassBody body)
-            {
-                Type = Nodes.ClassExpression;
-                Id = id;
-                SuperClass = superClass;
-                Body = body;
-            }
+        {
+            Type = Nodes.ClassExpression;
+            Id = id;
+            SuperClass = superClass;
+            Body = body;
+        }
     }
 }

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -3,9 +3,9 @@ namespace Esprima.Ast
     public class ConditionalExpression : Node,
         Expression
     {
-        public Expression Test;
-        public Expression Consequent;
-        public Expression Alternate;
+        public readonly Expression Test;
+        public readonly Expression Consequent;
+        public readonly Expression Alternate;
 
         public ConditionalExpression(Expression test, Expression consequent, Expression alternate)
         {

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public class ContinueStatement : Statement
     {
-        public Identifier Label;
+        public readonly Identifier Label;
 
         public ContinueStatement(Identifier label)
         {

--- a/src/Esprima/Ast/Declaration.cs
+++ b/src/Esprima/Ast/Declaration.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface Declaration : StatementListItem
     {

--- a/src/Esprima/Ast/Directive.cs
+++ b/src/Esprima/Ast/Directive.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
     public class Directive : ExpressionStatement
     {
         [JsonProperty("directive")]
-        public string Directiv;
+        public readonly string Directiv;
 
         public Directive(Expression expression, string directive)
             :base(expression)

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class DoWhileStatement : Statement
     {
-        public Statement Body;
-        public Expression Test;
+        public readonly Statement Body;
+        public readonly Expression Test;
 
         public DoWhileStatement(Statement body, Expression test)
         {

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -1,9 +1,9 @@
 ﻿namespace Esprima.Ast
 {
-    public class ExportAllDeclaration : Node,
-        ExportDeclaration
+    public class ExportAllDeclaration : Node, ExportDeclaration
     {
-        public Literal Source;
+        public readonly Literal Source;
+
         public ExportAllDeclaration(Literal source)
         {
             Type = Nodes.ExportAllDeclaration;

--- a/src/Esprima/Ast/ExportDeclaration.cs
+++ b/src/Esprima/Ast/ExportDeclaration.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface ExportDeclaration : Declaration
     {

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -1,9 +1,9 @@
 ﻿namespace Esprima.Ast
 {
-    public class ExportDefaultDeclaration : Node,
-        ExportDeclaration
+    public class ExportDefaultDeclaration : Node, ExportDeclaration
     {
-        public Declaration Declaration; //: BindingIdentifier | BindingPattern | ClassDeclaration | Expression | FunctionDeclaration;
+        public readonly Declaration Declaration; //: BindingIdentifier | BindingPattern | ClassDeclaration | Expression | FunctionDeclaration;
+
         public ExportDefaultDeclaration(Declaration declaration)
         {
             Type = Nodes.ExportDefaultDeclaration;

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -2,12 +2,12 @@
 
 namespace Esprima.Ast
 {
-    public class ExportNamedDeclaration : Node,
-        ExportDeclaration
+    public class ExportNamedDeclaration : Node, ExportDeclaration
     {
-        public StatementListItem Declaration;
-        public List<ExportSpecifier> Specifiers;
-        public Literal Source;
+        public readonly StatementListItem Declaration;
+        public readonly List<ExportSpecifier> Specifiers;
+        public readonly Literal Source;
+
         public ExportNamedDeclaration(StatementListItem declaration, List<ExportSpecifier> specifiers, Literal source)
         {
             Type = Nodes.ExportNamedDeclaration;

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -1,11 +1,10 @@
-﻿using System;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ExportSpecifier : Statement
     {
-        public Identifier Exported;
-        public Identifier Local;
+        public readonly Identifier Exported;
+        public readonly Identifier Local;
+
         public ExportSpecifier(Identifier local, Identifier exported)
         {
             Type = Nodes.ExportSpecifier;

--- a/src/Esprima/Ast/ExportStatement.cs
+++ b/src/Esprima/Ast/ExportStatement.cs
@@ -2,7 +2,8 @@
 {
     public class ExportStatement : Statement
     {
-        public Expression Expression;
+        public readonly Expression Expression;
+
         public ExportStatement(Expression expression)
         {
             Type = Nodes.ExpressionStatement;

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public class ExpressionStatement : Statement
     {
-        public Expression Expression;
+        public readonly Expression Expression;
 
         public ExpressionStatement(Expression expression)
         {

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -2,10 +2,10 @@ namespace Esprima.Ast
 {
     public class ForInStatement : Statement
     {
-        public INode Left;
-        public Expression Right;
-        public Statement Body;
-        public bool Each;
+        public readonly INode Left;
+        public readonly Expression Right;
+        public readonly Statement Body;
+        public readonly bool Each;
 
         public ForInStatement(INode left, Expression right, Statement body)
         {

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -2,9 +2,10 @@
 {
     public class ForOfStatement : Statement
     {
-        public INode Left;
-        public Expression Right;
-        public Statement Body;
+        public readonly INode Left;
+        public readonly Expression Right;
+        public readonly Statement Body;
+
         public ForOfStatement(INode left, Expression right, Statement body)
         {
             Type = Nodes.ForOfStatement;

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -3,10 +3,10 @@ namespace Esprima.Ast
     public class ForStatement : Statement
     {
         // can be a Statement (var i) or an Expression (i=0)
-        public INode Init;
-        public Expression Test;
-        public Expression Update;
-        public Statement Body;
+        public readonly INode Init;
+        public readonly Expression Test;
+        public readonly Expression Update;
+        public readonly Statement Body;
 
         public ForStatement(INode init, Expression test, Expression update, Statement body)
         {

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -5,11 +5,11 @@ namespace Esprima.Ast
 {
     public class FunctionDeclaration : Statement, Declaration, IFunction
     {
-        public Identifier Id { get; set; }
-        public IEnumerable<INode> Params { get; set; }
-        public BlockStatement Body { get; set; }
-        public bool Generator { get; set; }
-        public bool Expression { get; set; }
+        public Identifier Id { get; }
+        public List<INode> Params { get; }
+        public BlockStatement Body { get; }
+        public bool Generator { get; }
+        public bool Expression { get; }
 
         [JsonIgnore]
         public HoistingScope HoistingScope { get; }
@@ -19,7 +19,7 @@ namespace Esprima.Ast
 
         public FunctionDeclaration(
             Identifier id,
-            IEnumerable<INode> parameters,
+            List<INode> parameters,
             BlockStatement body,
             bool generator,
             HoistingScope hoistingScope,

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -8,11 +8,11 @@ namespace Esprima.Ast
         Expression,
         PropertyValue
     {
-        public Identifier Id { get; set; }
-        public IEnumerable<INode> Params { get; set; }
-        public BlockStatement Body { get; set; }
-        public bool Generator { get; set; }
-        public bool Expression { get; set; }
+        public Identifier Id { get; }
+        public List<INode> Params { get; }
+        public BlockStatement Body { get; }
+        public bool Generator { get; }
+        public bool Expression { get; }
 
         [JsonIgnore]
         public HoistingScope HoistingScope { get; }
@@ -22,7 +22,7 @@ namespace Esprima.Ast
 
         public FunctionExpression(
             Identifier id,
-            IEnumerable<INode> parameters,
+            List<INode> parameters,
             BlockStatement body,
             bool generator,
             HoistingScope hoistingScope,

--- a/src/Esprima/Ast/FunctionParameter.cs
+++ b/src/Esprima/Ast/FunctionParameter.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface FunctionParameter
     {

--- a/src/Esprima/Ast/IArrayPatternElement.cs
+++ b/src/Esprima/Ast/IArrayPatternElement.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface IArrayPatternElement
     {

--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -7,11 +7,11 @@ namespace Esprima.Ast
     /// </summary>
     public interface IFunction
     {
-        Identifier Id { get; set; }
-        IEnumerable<INode> Params { get; set; }
-        BlockStatement Body { get; set; }
-        bool Generator { get; set; }
-        bool Expression { get; set; }
+        Identifier Id { get; }
+        List<INode> Params { get; }
+        BlockStatement Body { get; }
+        bool Generator { get; }
+        bool Expression { get; }
         HoistingScope HoistingScope { get; }
         bool Strict { get; }
     }

--- a/src/Esprima/Ast/INode.cs
+++ b/src/Esprima/Ast/INode.cs
@@ -2,7 +2,8 @@
 
 namespace Esprima.Ast
 {
-    public interface INode
+    public interface
+        INode
     {
         Nodes Type { get; }
         int[] Range { get; set; }
@@ -14,7 +15,7 @@ namespace Esprima.Ast
         [DebuggerStepThrough]
         public static T As<T>(this object node) where T : class
         {
-            return (T)node;
+            return (T) node;
         }
     }
 }

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
         PropertyKey,
         Expression
     {
-        public string Name;
+        public readonly string Name;
 
         public Identifier(string name)
         {

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -2,9 +2,9 @@ namespace Esprima.Ast
 {
     public class IfStatement : Statement
     {
-        public Expression Test;
-        public Statement Consequent;
-        public Statement Alternate;
+        public readonly Expression Test;
+        public readonly Statement Consequent;
+        public readonly Statement Alternate;
 
         public IfStatement(Expression test, Statement consequent, Statement alternate)
         {

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -2,11 +2,11 @@
 
 namespace Esprima.Ast
 {
-    public class ImportDeclaration : Node,
-        Declaration
+    public class ImportDeclaration : Node, Declaration
     {
-        public List<ImportDeclarationSpecifier> Specifiers;
-        public Literal Source;
+        public readonly List<ImportDeclarationSpecifier> Specifiers;
+        public readonly Literal Source;
+
         public ImportDeclaration(List<ImportDeclarationSpecifier> specifiers, Literal source)
         {
             Type = Nodes.ImportDeclaration;

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface ImportDeclarationSpecifier
     {

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -1,9 +1,9 @@
 ﻿namespace Esprima.Ast
 {
-    public class ImportDefaultSpecifier : Node,
-        ImportDeclarationSpecifier
+    public class ImportDefaultSpecifier : Node, ImportDeclarationSpecifier
     {
-        public Identifier Local;
+        public readonly Identifier Local;
+
         public ImportDefaultSpecifier(Identifier local)
         {
             Type = Nodes.ImportDefaultSpecifier;

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -1,9 +1,9 @@
 ﻿namespace Esprima.Ast
 {
-    public class ImportNamespaceSpecifier : Node,
-        ImportDeclarationSpecifier
+    public class ImportNamespaceSpecifier : Node, ImportDeclarationSpecifier
     {
-        public Identifier Local;
+        public readonly Identifier Local;
+
         public ImportNamespaceSpecifier(Identifier local)
         {
             Type = Nodes.ImportNamespaceSpecifier;

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -1,10 +1,10 @@
 ﻿namespace Esprima.Ast
 {
-    public class ImportSpecifier : Node,
-        ImportDeclarationSpecifier
+    public class ImportSpecifier : Node, ImportDeclarationSpecifier
     {
-        public Identifier Local;
-        public Identifier Imported;
+        public readonly Identifier Local;
+        public readonly Identifier Imported;
+
         public ImportSpecifier(Identifier local, Identifier imported)
         {
             Type = Nodes.ImportSpecifier;

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class LabeledStatement : Statement
     {
-        public Identifier Label;
-        public Statement Body;
+        public readonly Identifier Label;
+        public readonly Statement Body;
 
         public LabeledStatement(Identifier label, Statement body)
         {
@@ -12,6 +12,5 @@ namespace Esprima.Ast
             Body = body;
             body.LabelSet = label;
         }
-
     }
 }

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -8,31 +8,24 @@ namespace Esprima.Ast
         Expression,
         PropertyKey
     {
-        [JsonIgnore]
-        public string StringValue;
-        [JsonIgnore]
-        public double NumericValue;
-        [JsonIgnore]
-        public bool BooleanValue;
-        [JsonIgnore()]
-        public Regex RegexValue;
+        [JsonIgnore] public readonly string StringValue;
+        [JsonIgnore] public readonly double NumericValue;
+        [JsonIgnore] public readonly bool BooleanValue;
+        [JsonIgnore] public readonly Regex RegexValue;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
-        public RegexValue Regex;
+        public readonly RegexValue Regex;
 
         [JsonConverter(typeof(LiteralValueConverter))]
-        public object Value;
+        public readonly object Value;
 
-        public string Raw;
+        public readonly string Raw;
 
-        [JsonIgnore]
-        public TokenType TokenType;
+        [JsonIgnore] public readonly TokenType TokenType;
 
-        [JsonIgnore]
-        public bool Integral;
+        [JsonIgnore] public readonly bool Integral;
 
-        [JsonIgnore]
-        public bool Cached;
+        [JsonIgnore] public readonly bool Cached;
 
         //[JsonIgnore]
         //public JsValue CachedValue;
@@ -74,8 +67,8 @@ namespace Esprima.Ast
             Type = Nodes.Literal;
             // value is null if a Regex object couldn't be created out of the pattern or options
             Value = value;
-            RegexValue = (Regex)value;
-            Regex = new RegexValue { Pattern = pattern, Flags = flags };
+            RegexValue = (Regex) value;
+            Regex = new RegexValue(pattern, flags);
             TokenType = TokenType.RegularExpression;
             Raw = raw;
         }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -4,11 +4,11 @@ namespace Esprima.Ast
         Expression,
         ArrayPatternElement
     {
-        public Expression Object;
-        public Expression Property;
+        public readonly Expression Object;
+        public readonly Expression Property;
 
         // true if an indexer is used and the property to be evaluated
-        public bool Computed;
+        public readonly bool Computed;
 
         protected MemberExpression(Expression obj, Expression property, bool computed)
         {

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -2,8 +2,8 @@
 {
     public class MetaProperty : Node, Expression
     {
-        public Identifier Meta;
-        public Identifier Property;
+        public readonly Identifier Meta;
+        public readonly Identifier Property;
 
         public MetaProperty(Identifier meta, Identifier property)
         {

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -2,7 +2,7 @@
 {
     public class MethodDefinition : ClassProperty
     {
-        public bool Static;
+        public readonly bool Static;
 
         public MethodDefinition(PropertyKey key, bool computed, FunctionExpression value, PropertyKind kind, bool isStatic)
         {

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -5,8 +5,8 @@ namespace Esprima.Ast
     public class NewExpression : Node,
         Expression
     {
-        public Expression Callee;
-        public List<ArgumentListElement> Arguments;
+        public readonly Expression Callee;
+        public readonly List<ArgumentListElement> Arguments;
 
         public NewExpression(Expression callee, List<ArgumentListElement> args)
         {

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -7,7 +7,7 @@ namespace Esprima.Ast
     {
         [JsonProperty(Order = -100)]
         [JsonConverter(typeof(StringEnumConverter))]
-        public Nodes Type { get; protected set; }
+        public Nodes Type { get; set; }
 
         public int[] Range { get; set; }
 

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -2,12 +2,11 @@ using System.Collections.Generic;
 
 namespace Esprima.Ast
 {
-    public class ObjectExpression : Node,
-        Expression
+    public class ObjectExpression : Node, Expression
     {
-        public IEnumerable<Property> Properties;
+        public readonly List<Property> Properties;
 
-        public ObjectExpression(IEnumerable<Property> properties)
+        public ObjectExpression(List<Property> properties)
         {
             Type = Nodes.ObjectExpression;
             Properties = properties;

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -4,8 +4,9 @@ namespace Esprima.Ast
 {
     public class ObjectPattern : Node, BindingPattern
     {
-        public IEnumerable<Property> Properties;
-        public ObjectPattern(IEnumerable<Property> properties)
+        public readonly List<Property> Properties;
+
+        public ObjectPattern(List<Property> properties)
         {
             Type = Nodes.ObjectPattern;
             Properties = properties;

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -6,18 +6,18 @@ namespace Esprima.Ast
 {
     public class Program : Statement
     {
-        public IEnumerable<StatementListItem> Body;
+        public readonly List<StatementListItem> Body;
 
         [JsonConverter(typeof(StringEnumConverter), new object[] { true })]
-        public SourceType SourceType;
+        public readonly SourceType SourceType;
 
         [JsonIgnore]
         public HoistingScope HoistingScope { get; }
 
         [JsonIgnore]
-        public bool Strict { get; set; }
+        public bool Strict { get; }
 
-        public Program(IEnumerable<StatementListItem> body, SourceType sourceType, HoistingScope hoistingScope, bool strict)
+        public Program(List<StatementListItem> body, SourceType sourceType, HoistingScope hoistingScope, bool strict)
         {
             Type = Nodes.Program;
             Body = body;

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -1,13 +1,10 @@
-using System;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-
 namespace Esprima.Ast
 {
     public class Property : ClassProperty
     {
-        public bool Method;
-        public bool Shorthand;
+        public readonly bool Method;
+        public readonly bool Shorthand;
+
         public Property(PropertyKind kind, PropertyKey key, bool computed, PropertyValue value, bool method, bool shorthand)
         {
             Type = Nodes.Property;

--- a/src/Esprima/Ast/RegexValue.cs
+++ b/src/Esprima/Ast/RegexValue.cs
@@ -1,13 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class RegexValue
     {
-        public string Pattern;
-        public string Flags;
+        public readonly string Pattern;
+        public readonly string Flags;
+
+        public RegexValue(string pattern, string flags)
+        {
+            Pattern = pattern;
+            Flags = flags;
+        }
     }
 }

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -7,7 +7,8 @@
         // for instance ...i[0] is a SpreadElement
         // which is reinterpreted to RestElement with a ComputerMemberExpression
 
-        public Expression Argument;
+        public readonly Expression Argument;
+
         public RestElement(Expression argument)
         {
             Type = Nodes.RestElement;

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public class ReturnStatement : Statement
     {
-        public Expression Argument;
+        public readonly Expression Argument;
 
         public ReturnStatement(Expression argument)
         {

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -2,12 +2,11 @@ using System.Collections.Generic;
 
 namespace Esprima.Ast
 {
-    public class SequenceExpression : Node,
-        Expression
+    public class SequenceExpression : Node, Expression
     {
-        public IList<Expression> Expressions;
+        public List<INode> Expressions { get; internal set; }
 
-        public SequenceExpression(IList<Expression> expressions)
+        public SequenceExpression(List<INode> expressions)
         {
             Type = Nodes.SequenceExpression;
             Expressions = expressions;

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -5,7 +5,8 @@
         ArrayExpressionElement,
         Expression
     {
-        public Expression Argument;
+        public readonly Expression Argument;
+
         public SpreadElement(Expression argument)
         {
             Type = Nodes.SpreadElement;

--- a/src/Esprima/Ast/Statement.cs
+++ b/src/Esprima/Ast/Statement.cs
@@ -2,10 +2,9 @@ using Newtonsoft.Json;
 
 namespace Esprima.Ast
 {
-    public class Statement : Node, INode,
-        StatementListItem
+    public class Statement : Node, INode, StatementListItem
     {
         [JsonIgnore]
-        public Identifier LabelSet { get; set; }
+        public Identifier LabelSet { get; internal set; }
     }
 }

--- a/src/Esprima/Ast/StatementListItem.cs
+++ b/src/Esprima/Ast/StatementListItem.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public interface StatementListItem
     {

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -4,10 +4,10 @@ namespace Esprima.Ast
 {
     public class SwitchCase : Node
     {
-        public Expression Test;
-        public IEnumerable<StatementListItem> Consequent;
+        public readonly Expression Test;
+        public readonly List<StatementListItem> Consequent;
 
-        public SwitchCase(Expression test, IEnumerable<StatementListItem> consequent)
+        public SwitchCase(Expression test, List<StatementListItem> consequent)
         {
             Type = Nodes.SwitchCase;
             Test = test;

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -4,10 +4,10 @@ namespace Esprima.Ast
 {
     public class SwitchStatement : Statement
     {
-        public Expression Discriminant;
-        public IEnumerable<SwitchCase> Cases;
+        public readonly Expression Discriminant;
+        public readonly List<SwitchCase> Cases;
 
-        public SwitchStatement(Expression discriminant, IEnumerable<SwitchCase> cases)
+        public SwitchStatement(Expression discriminant, List<SwitchCase> cases)
         {
             Type = Nodes.SwitchStatement;
             Discriminant = discriminant;

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -1,10 +1,10 @@
 ﻿namespace Esprima.Ast
 {
-    public class TaggedTemplateExpression : Node,
-        Expression
+    public class TaggedTemplateExpression : Node, Expression
     {
-        public Expression Tag;
-        public TemplateLiteral Quasi;
+        public readonly Expression Tag;
+        public readonly TemplateLiteral Quasi;
+
         public TaggedTemplateExpression(Expression tag, TemplateLiteral quasi)
         {
             Type = Nodes.TaggedTemplateExpression;

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -1,10 +1,9 @@
 ﻿namespace Esprima.Ast
 {
-
     public class TemplateElement : Node
     {
-        public TemplateElementValue Value;
-        public bool Tail;
+        public readonly TemplateElementValue Value;
+        public readonly bool Tail;
 
         public TemplateElement(TemplateElementValue value, bool tail)
         {

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -5,12 +5,11 @@ namespace Esprima.Ast
     public class TemplateLiteral : Node,
         Expression
     {
-        public IEnumerable<TemplateElement> Quasis;
-        public IEnumerable<Expression> Expressions;
+        public readonly List<TemplateElement> Quasis;
+        public readonly List<Expression> Expressions;
 
-        public TemplateLiteral(IEnumerable<TemplateElement> quasis, IEnumerable<Expression> expressions)
+        public TemplateLiteral(List<TemplateElement> quasis, List<Expression> expressions)
         {
-
             Type = Nodes.TemplateLiteral;
             Quasis = quasis;
             Expressions = expressions;

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public class ThrowStatement : Statement
     {
-        public Expression Argument;
+        public readonly Expression Argument;
 
         public ThrowStatement(Expression argument)
         {

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -1,12 +1,10 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class TryStatement : Statement
     {
-        public Statement Block;
-        public CatchClause Handler;
-        public Statement Finalizer;
+        public readonly Statement Block;
+        public readonly CatchClause Handler;
+        public readonly Statement Finalizer;
 
         public TryStatement(
             Statement block,

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -31,9 +31,9 @@ namespace Esprima.Ast
         Expression
     {
         [JsonConverter(typeof(StringEnumConverter), new object[] { true })]
-        public UnaryOperator Operator;
-        public Expression Argument;
-        public bool Prefix;
+        public readonly UnaryOperator Operator;
+        public readonly Expression Argument;
+        public bool Prefix { get; protected set; }
 
         public static UnaryOperator ParseUnaryOperator(string op)
         {

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -5,10 +5,10 @@ namespace Esprima.Ast
     public class VariableDeclaration : Statement,
         Declaration
     {
-        public IEnumerable<VariableDeclarator> Declarations;
-        public string Kind;
+        public readonly List<VariableDeclarator> Declarations;
+        public readonly string Kind;
 
-        public VariableDeclaration(IEnumerable<VariableDeclarator> declarations, string kind)
+        public VariableDeclaration(List<VariableDeclarator> declarations, string kind)
         {
             Type = Nodes.VariableDeclaration;
             Declarations = declarations;

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class VariableDeclarator : Node
     {
-        public ArrayPatternElement Id; // BindingIdentifier | BindingPattern;
-        public Expression Init;
+        public readonly ArrayPatternElement Id; // BindingIdentifier | BindingPattern;
+        public readonly Expression Init;
 
         public VariableDeclarator(ArrayPatternElement id, Expression init)
         {

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class WhileStatement : Statement
     {
-        public Expression Test;
-        public Statement Body;
+        public readonly Expression Test;
+        public readonly Statement Body;
 
         public WhileStatement(Expression test, Statement body)
         {
@@ -11,7 +11,5 @@ namespace Esprima.Ast
             Test = test;
             Body = body;
         }
-
-
     }
 }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -2,8 +2,8 @@ namespace Esprima.Ast
 {
     public class WithStatement : Statement
     {
-        public Expression Object;
-        public Statement Body;
+        public readonly Expression Object;
+        public readonly Statement Body;
 
         public WithStatement(Expression obj, Statement body)
         {

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -1,10 +1,10 @@
 ﻿namespace Esprima.Ast
 {
-    public class YieldExpression : Node,
-        Expression
+    public class YieldExpression : Node, Expression
     {
-        public Expression Argument;
-        public bool Delegate;
+        public readonly Expression Argument;
+        public readonly bool Delegate;
+
         public YieldExpression(Expression argument, bool delgate)
         {
             Type = Nodes.YieldExpression;

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -168,7 +168,7 @@ namespace Esprima
 
         // ECMA-262 11.4 Comments
 
-        public IEnumerable<Comment> SkipSingleLineComment(int offset)
+        public List<Comment> SkipSingleLineComment(int offset)
         {
             List<Comment> comments = null;
             int start = 0;
@@ -237,7 +237,7 @@ namespace Esprima
             return comments;
         }
 
-        public IEnumerable<Comment> SkipMultiLineComment()
+        public List<Comment> SkipMultiLineComment()
         {
             List<Comment> comments = null;
             int start = 0;
@@ -931,7 +931,7 @@ namespace Esprima
                 {
                     break;
                 }
-                
+
                 sb.Append(Source[Index++]);
             }
 
@@ -1623,7 +1623,7 @@ namespace Esprima
                 Type = TokenType.RegularExpression,
                 Value = value,
                 Literal = body.Literal + flags.Literal,
-                RegexValue = new RegexValue { Pattern = (string)body.Value, Flags = (string)flags.Value },
+                RegexValue = new RegexValue((string) body.Value, (string) flags.Value),
                 LineNumber = LineNumber,
                 LineStart = LineStart,
                 Start = start,


### PR DESCRIPTION
Jint performance would benefit from knowing list are of concrete type with known size. Changed things to be read-only/set-only where possible to create more guarantees for caller about stable state.

Maybe as an separate improvement should investigate using properties instead of fields for uniformity.