### PR TITLE
Cache common literal values and use calculated fields

### DIFF
--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -8,9 +8,35 @@ namespace Esprima.Ast
         Expression,
         PropertyKey
     {
-        [JsonIgnore] public readonly string StringValue;
+        // common literals that can be cached
+        private static readonly Literal StringEmpty = new Literal("", "", cached: true);
+        private static readonly Literal StringDoubleQuoteEmpty = new Literal("", "\"\"", cached: true);
+        private static readonly Literal StringSingleQuoteEmpty = new Literal("", "''", cached: true);
+        private static readonly Literal StringDoubleQuoteSpace = new Literal(" ", "\" \"", cached: true);
+        private static readonly Literal StringSingleQuoteSpace = new Literal(" ", "' '", cached: true);
+
+        private static readonly Literal NumericZero = new Literal(0, "0", cached: true);
+        private static readonly Literal NumericOne = new Literal(1, "1", cached: true);
+        private static readonly Literal NumericTwo = new Literal(2, "2", cached: true);
+        private static readonly Literal NumericThree = new Literal(3, "3", cached: true);
+        private static readonly Literal NumericFour = new Literal(4, "4", cached: true);
+        private static readonly Literal NumericFive = new Literal(5, "5", cached: true);
+        private static readonly Literal NumericSix = new Literal(6, "6", cached: true);
+        private static readonly Literal NumericSeven = new Literal(7, "7", cached: true);
+        private static readonly Literal NumericEight = new Literal(8, "8", cached: true);
+        private static readonly Literal NumericNine = new Literal(9, "9", cached: true);
+        private static readonly Literal NumericTen = new Literal(10, "10", cached: true);
+        private static readonly Literal NumericEleven = new Literal(11, "11", cached: true);
+        private static readonly Literal NumericHundred = new Literal(100, "100", cached: true);
+
+        public static readonly Literal Null = new Literal("null");
+
+        public static readonly Literal BooleanFalse = new Literal(false);
+        public static readonly Literal BooleanTrue = new Literal(true);
+
+        [JsonIgnore] public string StringValue => Value as string;
         [JsonIgnore] public readonly double NumericValue;
-        [JsonIgnore] public readonly bool BooleanValue;
+        [JsonIgnore] public bool BooleanValue => NumericValue != 0;
         [JsonIgnore] public readonly Regex RegexValue;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
@@ -23,43 +49,51 @@ namespace Esprima.Ast
 
         [JsonIgnore] public readonly TokenType TokenType;
 
-        [JsonIgnore] public readonly bool Integral;
-
         [JsonIgnore] public readonly bool Cached;
 
-        //[JsonIgnore]
-        //public JsValue CachedValue;
+        public Literal(string value, string raw) : this(value, raw, false)
+        {
+        }
 
-        public Literal(string value, string raw)
+        private Literal(string value, string raw, bool cached)
         {
             Type = Nodes.Literal;
-            Value = StringValue = value;
+            Value = value;
             TokenType = TokenType.StringLiteral;
             Raw = raw;
+            Cached = cached;
         }
 
-        public Literal(bool value, string raw)
+        private Literal(bool value)
         {
             Type = Nodes.Literal;
-            Value = BooleanValue = value;
+            Value = value;
+            NumericValue = value ? 1.0 : 0.0;
             TokenType = TokenType.BooleanLiteral;
-            Raw = raw;
+            Raw = value ? "true" : "false";
+            Cached = true;
         }
 
-        public Literal(double value, string raw)
+        public Literal(double value, string raw) : this(value, raw, false)
+        {
+        }
+
+        private Literal(double value, string raw, bool cached)
         {
             Type = Nodes.Literal;
             Value = NumericValue = value;
             TokenType = TokenType.NumericLiteral;
             Raw = raw;
+            Cached = cached;
         }
 
-        public Literal(string raw)
+        private Literal(string raw)
         {
             Type = Nodes.Literal;
             Value = null;
             TokenType = TokenType.NullLiteral;
             Raw = raw;
+            Cached = true;
         }
 
         public Literal(string pattern, string flags, object value, string raw)
@@ -73,6 +107,88 @@ namespace Esprima.Ast
             Raw = raw;
         }
 
+        internal static Literal CreateStringLiteral(string value, string raw)
+        {
+            if (value == "" && raw == "")
+            {
+                return StringEmpty;
+            }
+            if (value == "" && raw == "\"\"")
+            {
+                return StringDoubleQuoteEmpty;
+            }
+            if (value == "" && raw == "''")
+            {
+                return StringSingleQuoteEmpty;
+            }
+            if (value == " " && raw == "\" \"")
+            {
+                return StringDoubleQuoteSpace;
+            }
+            if (value == " " && raw == "' '")
+            {
+                return StringSingleQuoteSpace;
+            }
+
+            return new Literal(value, raw);
+        }
+
+        internal static Literal CreateNumericLiteral(double value, string raw)
+        {
+            if (value == 0 && raw == "0")
+            {
+                return NumericZero;
+            }
+            if (value == 1 && raw == "1")
+            {
+                return NumericOne;
+            }
+            if (value == 2 && raw == "2")
+            {
+                return NumericTwo;
+            }
+            if (value == 3 && raw == "3")
+            {
+                return NumericThree;
+            }
+            if (value == 4 && raw == "4")
+            {
+                return NumericFour;
+            }
+            if (value == 5 && raw == "5")
+            {
+                return NumericFive;
+            }
+            if (value == 6 && raw == "6")
+            {
+                return NumericSix;
+            }
+            if (value == 7 && raw == "7")
+            {
+                return NumericSeven;
+            }
+            if (value == 8 && raw == "8")
+            {
+                return NumericEight;
+            }
+            if (value == 9 && raw == "9")
+            {
+                return NumericNine;
+            }
+            if (value == 10 && raw == "10")
+            {
+                return NumericTen;
+            }
+            if (value == 11 && raw == "11")
+            {
+                return NumericEleven;
+            }
+            if (value == 100 && raw == "100")
+            {
+                return NumericHundred;
+            }
+            return new Literal(value, raw);
+        }
         string PropertyKey.GetKey()
         {
             var s = Value as string;

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -530,7 +530,7 @@ namespace Esprima
                     _context.IsBindingElement = false;
                     token = NextToken();
                     raw = GetTokenRaw(token);
-                    expr = Finalize(node, new Literal((string)token.Value, raw));
+                    expr = Finalize(node, Literal.CreateStringLiteral((string)token.Value, raw));
                     break;
                 case TokenType.NumericLiteral:
 
@@ -543,16 +543,15 @@ namespace Esprima
                     _context.IsBindingElement = false;
                     token = NextToken();
                     raw = GetTokenRaw(token);
-                    expr = Finalize(node, new Literal(token.NumericValue, raw));
+                    expr = Finalize(node, Literal.CreateNumericLiteral(token.NumericValue, raw));
                     break;
                 case TokenType.BooleanLiteral:
 
                     _context.IsAssignmentTarget = false;
                     _context.IsBindingElement = false;
                     token = NextToken();
-                    token.BooleanValue = ("true".Equals(token.Value));
-                    raw = GetTokenRaw(token);
-                    expr = Finalize(node, new Literal(token.BooleanValue, raw));
+                    token.BooleanValue = "true".Equals(token.Value);
+                    expr = Finalize(node, token.BooleanValue ? Literal.BooleanTrue : Literal.BooleanFalse);
                     break;
                 case TokenType.NullLiteral:
 
@@ -560,8 +559,7 @@ namespace Esprima
                     _context.IsBindingElement = false;
                     token = NextToken();
                     token.Value = null;
-                    raw = GetTokenRaw(token);
-                    expr = Finalize(node, new Literal(raw));
+                    expr = Finalize(node, Literal.Null);
                     break;
                 case TokenType.Template:
 
@@ -746,7 +744,7 @@ namespace Esprima
             {
                 case TokenType.StringLiteral:
                     var raw = GetTokenRaw(token);
-                    key = Finalize(node, new Literal((string)token.Value, raw));
+                    key = Finalize(node, Literal.CreateStringLiteral((string)token.Value, raw));
                     break;
                 case TokenType.NumericLiteral:
                     if (_context.Strict && token.Octal)
@@ -754,7 +752,7 @@ namespace Esprima
                         TolerateUnexpectedToken(token, Messages.StrictOctalLiteral);
                     }
                     raw = GetTokenRaw(token);
-                    key = Finalize(node, new Literal(token.NumericValue, raw));
+                    key = Finalize(node, Literal.CreateNumericLiteral(token.NumericValue, raw));
                     break;
 
                 case TokenType.Identifier:
@@ -3771,7 +3769,7 @@ namespace Esprima
 
             var token = NextToken();
             var raw = GetTokenRaw(token);
-            return Finalize(node, new Literal((string)token.Value, raw));
+            return Finalize(node, Literal.CreateStringLiteral((string)token.Value, raw));
         }
 
         // import {<foo as bar>} ...;


### PR DESCRIPTION
Literals still show up in Jint memory traces so I decided to check what could be done on Esprima's side.

Now common values are cached and Cached flag is actually set. This flag is [checked in Jint](https://github.com/sebastienros/jint/blob/dev/Jint/Runtime/ExpressionIntepreter.cs#L613) for fast path but it's always been false. 

Changed StringValue and BooleanValue fields to be calculated as they don't need to be stored,

## Before

|       Method |            FileName |      Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------- |-------------------- |----------:|----------:|----------:|----------:|---------:|---------:|----------:|
| **ParseProgram** |       **angular-1.2.5** | **33.514 ms** | **0.6201 ms** | **0.5800 ms** | **1937.5000** | **750.0000** | **250.0000** |  **10.15 MB** |
| **ParseProgram** |      **backbone-1.1.0** |  **2.757 ms** | **0.0086 ms** | **0.0081 ms** |  **285.1563** | **140.6250** |        **-** |   **1.56 MB** |
| **ParseProgram** |        **jquery-1.9.1** | **23.621 ms** | **0.1113 ms** | **0.0987 ms** | **1593.7500** | **656.2500** | **125.0000** |   **8.65 MB** |
| **ParseProgram** | **jquery.mobile-1.4.2** | **39.104 ms** | **0.2125 ms** | **0.1884 ms** | **2437.5000** | **937.5000** | **250.0000** |  **13.21 MB** |
| **ParseProgram** |      **mootools-1.4.5** | **19.600 ms** | **0.1156 ms** | **0.1025 ms** | **1343.7500** | **593.7500** | **125.0000** |   **7.12 MB** |
| **ParseProgram** |    **underscore-1.5.2** |  **2.148 ms** | **0.0033 ms** | **0.0029 ms** |  **292.9688** |  **58.5938** |        **-** |   **1.35 MB** |
| **ParseProgram** |          **yui-3.12.0** | **15.159 ms** | **0.2897 ms** | **0.2568 ms** | **1093.7500** | **531.2500** |        **-** |   **6.43 MB** |


## After

|       Method |            FileName |      Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------- |-------------------- |----------:|----------:|----------:|----------:|---------:|---------:|----------:|
| **ParseProgram** |       **angular-1.2.5** | **32.400 ms** | **0.1298 ms** | **0.1214 ms** | **1937.5000** | **750.0000** | **250.0000** |  **10.02 MB** |
| **ParseProgram** |      **backbone-1.1.0** |  **2.619 ms** | **0.0038 ms** | **0.0036 ms** |  **281.2500** | **140.6250** |        **-** |   **1.54 MB** |
| **ParseProgram** |        **jquery-1.9.1** | **22.082 ms** | **0.0936 ms** | **0.0876 ms** | **1562.5000** | **625.0000** | **125.0000** |   **8.51 MB** |
| **ParseProgram** | **jquery.mobile-1.4.2** | **38.272 ms** | **0.2246 ms** | **0.2101 ms** | **2437.5000** | **937.5000** | **250.0000** |  **13.02 MB** |
| **ParseProgram** |      **mootools-1.4.5** | **17.815 ms** | **0.0673 ms** | **0.0562 ms** | **1250.0000** | **562.5000** |  **62.5000** |   **7.03 MB** |
| **ParseProgram** |    **underscore-1.5.2** |  **2.109 ms** | **0.0037 ms** | **0.0034 ms** |  **281.2500** | **101.5625** |        **-** |   **1.33 MB** |
| **ParseProgram** |          **yui-3.12.0** | **14.769 ms** | **0.0279 ms** | **0.0233 ms** | **1078.1250** | **531.2500** |        **-** |   **6.34 MB** |

