### PR TITLE
Improve ScanNumericLiteral performance

### DIFF
--- a/samples/Esprima.Benchmark/EvaluationBenchmark.cs
+++ b/samples/Esprima.Benchmark/EvaluationBenchmark.cs
@@ -1,0 +1,43 @@
+﻿using BenchmarkDotNet.Attributes;
+using Esprima;
+
+namespace Jint.Benchmark
+{
+    [MemoryDiagnoser]
+    public class EvaluationBenchmark
+    {
+        private const string Script = @"
+            var o = {};
+            o.Foo = 'bar';
+            o.Baz = 42.0001;
+            o.Blah = o.Foo + o.Baz;
+
+            if(o.Blah != 'bar42.0001') throw TypeError;
+
+            function fib(n){
+                if(n<2) {
+                    return n;
+                }
+
+                return fib(n-1) + fib(n-2);
+            }
+
+            if(fib(3) != 2) throw TypeError;
+
+            var done = true;
+        ";
+
+        [Params(200)]
+        public int N { get; set; }
+
+        [Benchmark]
+        public void ParseProgram()
+        {
+            for (int i = 0; i < N; ++i)
+            {
+                var parser = new JavaScriptParser(Script);
+                parser.ParseProgram();
+            }
+        }
+    }
+}

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1026,11 +1026,13 @@ namespace Esprima
                         ++Index;
                         return ScanHexLiteral(start);
                     }
+
                     if (ch == 'b' || ch == 'B')
                     {
                         ++Index;
                         return ScanBinaryLiteral(start);
                     }
+
                     if (ch == 'o' || ch == 'O')
                     {
                         return ScanOctalLiteral(ch, start);
@@ -1049,6 +1051,7 @@ namespace Esprima
                 {
                     sb.Append(Source[Index++]);
                 }
+
                 ch = Source.CharCodeAt(Index);
             }
 
@@ -1059,6 +1062,7 @@ namespace Esprima
                 {
                     sb.Append(Source[Index++]);
                 }
+
                 ch = Source.CharCodeAt(Index);
             }
 
@@ -1071,6 +1075,7 @@ namespace Esprima
                 {
                     sb.Append(Source[Index++]);
                 }
+
                 if (Character.IsDecimalDigit(Source.CharCodeAt(Index)))
                 {
                     while (Character.IsDecimalDigit(Source.CharCodeAt(Index)))
@@ -1100,30 +1105,31 @@ namespace Esprima
 
             var number = sb.ToString();
 
-            try
+            if (long.TryParse(
+                number,
+                NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture,
+                out var l))
             {
-                var l = long.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
-
                 token.NumericValue = l;
                 token.Value = l;
             }
-            catch (OverflowException)
+            else if (double.TryParse(
+                number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign,
+                CultureInfo.InvariantCulture,
+                out var d))
             {
-                try
-                {
-                    var d = double.Parse(number, NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent | NumberStyles.AllowLeadingSign, CultureInfo.InvariantCulture);
+                token.NumericValue = d;
+                token.Value = d;
+            }
+            else
+            {
+                d = number.TrimStart().StartsWith("-")
+                    ? double.NegativeInfinity
+                    : double.PositiveInfinity;
 
-                    token.NumericValue = d;
-                    token.Value = d;
-
-                }
-                catch (OverflowException)
-                {
-                    var d = number.TrimStart().StartsWith("-") ? double.NegativeInfinity : double.PositiveInfinity;
-
-                    token.NumericValue = d;
-                    token.Value = d;
-                }
+                token.NumericValue = d;
+                token.Value = d;
             }
 
             return token;


### PR DESCRIPTION
Should not try/catch, use Try*-else instead.

## Before

### Esprima

|       Method |   N |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
|------------- |---- |---------:|----------:|----------:|---------:|----------:|
| ParseProgram | 200 | 11.59 ms | 0.0685 ms | 0.0572 ms | 953.1250 |   3.84 MB |

## After 

### Esprima

|       Method |   N |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
|------------- |---- |---------:|----------:|----------:|---------:|----------:|
| ParseProgram | 200 | 4.116 ms | 0.0153 ms | 0.0143 ms | 937.5000 |   3.78 MB |

### Jint - EvaluationBenchmark

| Method |  N |     Mean |     Error |    StdDev |    Gen 0 | Allocated |
|------- |--- |---------:|----------:|----------:|---------:|----------:|
|   Jint | 20 | 793.8 us | 0.9599 us | 0.8509 us | 136.7188 | 562.97 KB |