### PR TITLE
Add caching field for literal and lib upgrade

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ build_script:
   - dotnet --version
   - dotnet pack -c Release
 test_script:
-  - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Release -f netcoreapp2.0
+  - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Release -f netcoreapp2.1
 artifacts:
   - path: 'src\**\*.nupkg'
 deploy:  

--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -3,13 +3,13 @@
     <AssemblyName>Esprima.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>Esprima.Benchmark</PackageId>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\test\Esprima.Tests\Fixtures\3rdparty\**" CopyToOutputDirectory="PreserveNewest" LinkBase="3rdparty" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.11" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.10.14" />
   </ItemGroup>
 </Project>

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -11,7 +11,7 @@ namespace Esprima.Ast
         [JsonIgnore] public string StringValue => TokenType == TokenType.StringLiteral ? Value as string : null;
         [JsonIgnore] public readonly double NumericValue;
         [JsonIgnore] public bool BooleanValue => TokenType == TokenType.BooleanLiteral && NumericValue != 0;
-        [JsonIgnore] public readonly Regex RegexValue;
+        [JsonIgnore] public Regex RegexValue => TokenType == TokenType.RegularExpression ? (Regex) Value : null;
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public readonly RegexValue Regex;
@@ -22,6 +22,8 @@ namespace Esprima.Ast
         public readonly string Raw;
 
         [JsonIgnore] public readonly TokenType TokenType;
+
+        [JsonIgnore] public object CachedValue;
 
         public Literal(string value, string raw)
         {
@@ -61,7 +63,6 @@ namespace Esprima.Ast
             Type = Nodes.Literal;
             // value is null if a Regex object couldn't be created out of the pattern or options
             Value = value;
-            RegexValue = (Regex) value;
             Regex = new RegexValue(pattern, flags);
             TokenType = TokenType.RegularExpression;
             Raw = raw;

--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -1,5 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Description>Standard-compliant ECMAScript 2016 parser (also popularly known as JavaScript or ES6).</Description>
     <Copyright>Sebastien Ros</Copyright>
@@ -18,10 +17,9 @@
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/sebastienros/esprima-dotnet</RepositoryUrl>
     <Version>1.0.0-beta-$(BuildNumber)</Version>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
-
 </Project>

--- a/test/Esprima.Tests/Esprima.Tests.csproj
+++ b/test/Esprima.Tests/Esprima.Tests.csproj
@@ -1,21 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AssemblyName>Esprima.Tests</AssemblyName>
     <PackageId>Esprima.Tests</PackageId>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
   </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
This basically brings back the old caching field that was there commented out as JsValue was no longer part of the lib. With this caching field we can speed up some scenarios in Jint. Memory usage should stay the same as RegEx can use the Value field.

Also brought libs up to date.