### PR TITLE
Fix null Test in VisitForStatement in EsprimaVisitor

### DIFF
--- a/src/Esprima/Utils/EsprimaVisitor.cs
+++ b/src/Esprima/Utils/EsprimaVisitor.cs
@@ -226,7 +226,10 @@ namespace Esprima.Utils
                     VisitExpression(forStatement.Init.As<Expression>());
                 }
             }
-            VisitExpression(forStatement.Test);
+            if (forStatement.Test != null)
+            {
+                VisitExpression(forStatement.Test);
+            }
             VisitStatement(forStatement.Body);
             if (forStatement.Update != null)
             {

--- a/test/Esprima.Tests/VisitorTests.cs
+++ b/test/Esprima.Tests/VisitorTests.cs
@@ -42,5 +42,15 @@ namespace Esprima.Tests
             EsprimaVisitor visitor = new EsprimaVisitor();
             visitor.VisitProgram(program);
         }
+        
+        [Fact]
+        public void CanVisitForWithNoTest()
+        {
+            var parser = new JavaScriptParser(@"for (var a = []; ; ) { }");
+            var program = parser.ParseProgram();
+
+            EsprimaVisitor visitor = new EsprimaVisitor();
+            visitor.VisitProgram(program);
+        }
     }
 }


### PR DESCRIPTION
The Test property of a ForStatement might be null.