### PR TITLE
Fix Symbol.iterator static member as object property key

### DIFF
--- a/src/Esprima/Ast/StaticMemberExpression.cs
+++ b/src/Esprima/Ast/StaticMemberExpression.cs
@@ -1,9 +1,14 @@
 ﻿namespace Esprima.Ast
 {
-    public class StaticMemberExpression : MemberExpression
+    public class StaticMemberExpression : MemberExpression, PropertyKey
     {
         public StaticMemberExpression(Expression obj, Expression property) : base(obj, property, false)
         {
+        }
+
+        public string GetKey()
+        {
+            return ((PropertyKey) Object).GetKey() + "." + ((PropertyKey) Property).GetKey();
         }
     }
 }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -90,6 +90,28 @@ namespace Esprima.Tests
             Assert.Equal(labeledStatement.Label, body.LabelSet);
         }
 
+        [Fact]
+        public void CanBuildObjectWithSymbolIteratorMember()
+        {
+            var parser = new JavaScriptParser("var iterable  = { [Symbol.iterator]: undefined };");
+            var program = parser.ParseProgram();
+            var variableDeclaration = program.Body.First().As<VariableDeclaration>();
+            var declarations = variableDeclaration.Declarations;
+
+            Assert.Single(declarations);
+
+            var oe = declarations[0].Init as ObjectExpression;
+            Assert.NotNull(oe);
+            Assert.Single(oe.Properties);
+
+            var property = oe.Properties[0];
+            Assert.Equal("Symbol.iterator", property.Key.GetKey());
+            
+            var identifier = property.Value as Identifier;
+            Assert.NotNull(identifier);
+            Assert.Equal("undefined", identifier.Name);
+        }
+
         [Theory]
         [InlineData(1.189008226412092e+38, "0x5973772948c653ac1971f1576e03c4d4")]
         [InlineData(18446744073709552000d, "0xffffffffffffffff")]


### PR DESCRIPTION
I'm not entirely sure if I got this right, but found about this problem when checking Test262 cases and Esprima crashed for the given sample script.