### PR TITLE
Convert HoistingScope properties to fields

### DIFF
--- a/src/Esprima/HoistingScope.cs
+++ b/src/Esprima/HoistingScope.cs
@@ -8,7 +8,7 @@ namespace Esprima
     /// </summary>
     public class HoistingScope
     {
-        public List<FunctionDeclaration> FunctionDeclarations { get; } = new List<FunctionDeclaration>();
-        public List<VariableDeclaration> VariableDeclarations { get; } = new List<VariableDeclaration>();
+        public List<FunctionDeclaration> FunctionDeclarations = new List<FunctionDeclaration>();
+        public List<VariableDeclaration> VariableDeclarations = new List<VariableDeclaration>();
     }
 }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -466,7 +466,7 @@ namespace Esprima
             return result;
         }
 
-        private T InheritCoverGrammar<T>(Func<T> parseFunction)
+        private T InheritCoverGrammar<T>(Func<T> parseFunction) where T : class, INode
         {
             var previousIsBindingElement = _context.IsBindingElement;
             var previousIsAssignmentTarget = _context.IsAssignmentTarget;


### PR DESCRIPTION
Even these two getters show up in performance profiling for script-intensive scenarios. Let's change to direct field access.