### PR TITLE
Swap ThrowError with CreateError as IErrorHandler extension

### DIFF
--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -32,9 +32,18 @@ namespace Esprima
             }
         }
 
-        public void ThrowError(int index, int line, int column, string message)
+        public ParserException CreateError(int index, int line, int col, string description)
         {
-            throw this.CreateError(index, line, column, message);
+            var msg = $"Line {line}': {description}";
+            var error = new ParserException(msg)
+            {
+                Index = index,
+                Column = col,
+                LineNumber = line,
+                Description = description,
+                Source = Source
+            };
+            return error;
         }
 
         public void TolerateError(int index, int line, int col, string description)

--- a/src/Esprima/ErrorHandlerExtensions.cs
+++ b/src/Esprima/ErrorHandlerExtensions.cs
@@ -2,18 +2,9 @@
 {
     public static class ErrorHandlerExtensions
     {
-        public static ParserException CreateError(this IErrorHandler handler, int index, int line, int col, string description)
+        public static void ThrowError(this IErrorHandler handler, int index, int line, int column, string message)
         {
-            var msg = $"Line {line}': {description}";
-            var error = new ParserException(msg)
-            {
-                Index = index,
-                Column = col,
-                LineNumber = line,
-                Description = description,
-                Source = handler.Source
-            };
-            return error;
+            throw handler.CreateError(index, line, column, message);
         }
     }
 }

--- a/src/Esprima/IErrorHandler.cs
+++ b/src/Esprima/IErrorHandler.cs
@@ -6,7 +6,7 @@
         bool Tolerant { get; set; }
         void RecordError(ParserException error);
         void Tolerate(ParserException error);
-        void ThrowError(int index, int line, int column, string message);
+        ParserException CreateError(int index, int line, int column, string message);
         void TolerateError(int index, int line, int column, string message);
     }
 }


### PR DESCRIPTION
This PR swaps `CreateError` with `ThrowError` as an extension of `IErrorHandler`.

## Rationale

`CreateError` should be a member of the `IErrorHandler` interface and a decision of the implementation and `ThrowError` is the mere boilerplate and can (practically) never vary, so it's more naturally expressed as an extension. In fact, I think `ThrowError` shouldn't exist because it interferes with the C# compiler's ability to do control and data flow analysis. That's a different story and if it makes sense, I can retire it in a separate PR.