### PR TITLE
Explicit throw via error factory to simplify callers

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -2112,25 +2112,13 @@ namespace Esprima
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private VariableDeclarationKind ParseVariableDeclarationKind(string kindString)
         {
-            VariableDeclarationKind kind;
             switch (kindString)
             {
-                case "const":
-                    kind = VariableDeclarationKind.Const;
-                    break;
-                case "let":
-                    kind = VariableDeclarationKind.Let;
-                    break;
-                case "var":
-                    kind = VariableDeclarationKind.Var;
-                    break;
-                default:
-                    ThrowError("Unknown declaration kind '{0}'", kindString);
-                    kind = VariableDeclarationKind.Let;
-                    break;
+                case "const": return VariableDeclarationKind.Const;
+                case "let"  : return VariableDeclarationKind.Let;
+                case "var"  : return VariableDeclarationKind.Var;
+                default     : throw CreateError("Unknown declaration kind '{0}'", kindString);
             }
-
-            return kind;
         }
 
         // https://tc39.github.io/ecma262/#sec-destructuring-binding-patterns
@@ -4125,12 +4113,17 @@ namespace Esprima
 
         private void ThrowError(string messageFormat, params object[] values)
         {
+            throw CreateError(messageFormat, values);
+        }
+
+        private ParserException CreateError(string messageFormat, params object[] values)
+        {
             string msg = string.Format(messageFormat, values);
 
             int index = _lastMarker.Index;
             int line = _lastMarker.LineNumber;
             int column = _lastMarker.Index - _lastMarker.LineStart + 1;
-            throw _errorHandler.CreateError(index, line, column, msg);
+            return _errorHandler.CreateError(index, line, column, msg);
         }
 
         private void TolerateError(string messageFormat, params object[] values)


### PR DESCRIPTION
Throwing explicitly at the call site (rather than hiding the `throw` in a called helper) avoids hindering the data flow analysis by the C# compiler and therefore simplifies implementation of methods, like `ParseVariableDeclarationKind` in this PR. While I could have done a sweeping change by replacing all calls to `ThrowError` with `throw CreateError(...)`, I refrained from doing so to keep most of the code base intact for now. If welcome, I can make the broader change.

A similar change could be also be made to `Scanner`.

This was alluded to in PR #62.

All tests are still green. ✅ 
