### PR TITLE
Fix bug when writing AST JSON without location info

### DIFF
--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -133,12 +133,13 @@ namespace Esprima.Utils
                 _writer = writer ?? throw new ArgumentNullException(nameof(writer));
                 _stack = new ObservableStack<INode>();
 
+                _stack.Pushed += _ => _writer.StartObject();
+                _stack.Popped += _ => _writer.EndObject();
+
                 if (includeLineColumn || includeRange)
                 {
                     _stack.Pushed += node =>
                     {
-                        writer.StartObject();
-
                         if (locationMembersPlacement == LocationMembersPlacement.Start)
                         {
                             WriteLocationInfo(node);
@@ -152,8 +153,6 @@ namespace Esprima.Utils
                         {
                             WriteLocationInfo(node);
                         }
-
-                        writer.EndObject();
                     };
                 }
 


### PR DESCRIPTION
This PR fixes a bug in AST JSON writing when no location information is requested.

```
Unhandled Exception: System.InvalidOperationException: Member must be within an object.
   at Esprima.Utils.JsonTextWriter.Member(String name) in A:\esprima-dotnet\src\Esprima\Utils\JsonTextWriter.cs:line 79
   at Esprima.Utils.AstJson.Visitor.Member(String name) in A:\esprima-otnet\src\Esprima\Utils\AstJson.cs:line 201
   at Esprima.Utils.AstJson.Visitor.Member[T](String name, List`1 list, Func`2 nodeSelector) in A:\esprima-dotnet\src\Esprima\Utils\AstJson.cs:line 246
   ...
```

Unfortunately this bug slipped in PR #61 because none of the unit tests ever write the AST JSON without location information.