### PR TITLE
Make Range a more wholesome implementation

### DIFF
--- a/src/Esprima/Ast/Range.cs
+++ b/src/Esprima/Ast/Range.cs
@@ -1,14 +1,32 @@
 ﻿namespace Esprima.Ast
 {
-    public struct Range
+    using System;
+    using System.Globalization;
+
+    public readonly struct Range : IEquatable<Range>
     {
         public readonly int Start;
         public readonly int End;
 
         public Range(int start, int end)
         {
-            Start = start;
-            End = end;
+            Start = start >= 0 ? start : throw new ArgumentOutOfRangeException(nameof(start));
+            End = end > start ? end : throw new ArgumentOutOfRangeException(nameof(end));
         }
+
+        public bool Equals(Range other) =>
+            Start == other.Start && End == other.End;
+
+        public override bool Equals(object obj) =>
+            obj is Range other && Equals(other);
+
+        public override int GetHashCode() =>
+            unchecked((Start * 397) ^ End);
+
+        public override string ToString() =>
+            string.Format(CultureInfo.InvariantCulture, "{0}...{1}", Start, End);
+
+        public static bool operator ==(Range left, Range right) => left.Equals(right);
+        public static bool operator !=(Range left, Range right) => !left.Equals(right);
     }
 }


### PR DESCRIPTION
This PR makes `Range` a more wholesome implementation that you'd expect from a public value type by adding the following:

- Validation of start and end at construction
- Implementation for `object` members (`GetHashCode`, `Equals` & `ToString`).
- Support for `IEquatable<Range>`
- Implementation for equality operators (`==` and `!=`).
