### PR TITLE
Make Node.Type read-only

### DIFF
--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<ArrayExpressionElement> Elements;
 
-        public ArrayExpression(List<ArrayExpressionElement> elements)
+        public ArrayExpression(List<ArrayExpressionElement> elements) :
+            base(Nodes.ArrayExpression)
         {
-            Type = Nodes.ArrayExpression;
             Elements = elements;
         }
     }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<ArrayPatternElement> Elements;
 
-        public ArrayPattern(List<ArrayPatternElement> elements)
+        public ArrayPattern(List<ArrayPatternElement> elements) :
+            base(Nodes.ArrayPattern)
         {
-            Type = Nodes.ArrayPattern;
             Elements = elements;
         }
     }

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -12,9 +12,9 @@ namespace Esprima.Ast
 
         public HoistingScope HoistingScope;
 
-        public ArrowFunctionExpression(List<INode> parameters, INode body, bool expression, HoistingScope hoistingScope)
+        public ArrowFunctionExpression(List<INode> parameters, INode body, bool expression, HoistingScope hoistingScope) :
+            base(Nodes.ArrowFunctionExpression)
         {
-            Type = Nodes.ArrowFunctionExpression;
             Id = null;
             Params = parameters;
             Body = body;

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
 
         public readonly List<INode> Params;
 
-        public ArrowParameterPlaceHolder(List<INode> parameters)
+        public ArrowParameterPlaceHolder(List<INode> parameters) :
+            base(Nodes.ArrowParameterPlaceHolder)
         {
-            Type = Nodes.ArrowParameterPlaceHolder;
             Params = parameters;
         }
     }

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -42,9 +42,9 @@ namespace Esprima.Ast
         public readonly INode Left;
         public readonly Expression Right;
 
-        public AssignmentExpression(string op, INode left, Expression right)
+        public AssignmentExpression(string op, INode left, Expression right) :
+            base(Nodes.AssignmentExpression)
         {
-            Type = Nodes.AssignmentExpression;
             Operator = AssignmentExpression.ParseAssignmentOperator(op);
             Left = left;
             Right = right;

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -10,9 +10,9 @@
         public readonly INode Left;
         public INode Right;
 
-        public AssignmentPattern(INode left, INode right)
+        public AssignmentPattern(INode left, INode right) :
+            base(Nodes.AssignmentPattern)
         {
-            Type = Nodes.AssignmentPattern;
             Left = left;
             Right = right;
         }

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -62,11 +62,13 @@ namespace Esprima.Ast
         public readonly Expression Left;
         public readonly Expression Right;
 
-        public BinaryExpression(string op, Expression left, Expression right)
+        public BinaryExpression(string op, Expression left, Expression right) :
+            this(ParseBinaryOperator(op), left, right) {}
+
+        private BinaryExpression(BinaryOperator op, Expression left, Expression right) :
+            base(op == BinaryOperator.LogicalAnd || op == BinaryOperator.LogicalOr ? Nodes.LogicalExpression : Nodes.BinaryExpression)
         {
-            Operator = ParseBinaryOperator(op);
-            var logical = Operator == BinaryOperator.LogicalAnd || Operator == BinaryOperator.LogicalOr;
-            Type = logical ? Nodes.LogicalExpression : Nodes.BinaryExpression;
+            Operator = op;
             Left = left;
             Right = right;
         }

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<StatementListItem> Body;
 
-        public BlockStatement(List<StatementListItem> body)
+        public BlockStatement(List<StatementListItem> body) :
+            base(Nodes.BlockStatement)
         {
-            Type = Nodes.BlockStatement;
             Body = body;
         }
     }

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
     {
         public readonly Identifier Label;
 
-        public BreakStatement(Identifier label)
+        public BreakStatement(Identifier label) :
+            base(Nodes.BreakStatement)
         {
-            Type = Nodes.BreakStatement;
             Label = label;
         }
     }

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -12,9 +12,9 @@ namespace Esprima.Ast
         public bool CanBeCached = true;
         public object CachedArguments;
 
-        public CallExpression(Expression callee, List<ArgumentListElement> args)
+        public CallExpression(Expression callee, List<ArgumentListElement> args) :
+            base(Nodes.CallExpression)
         {
-            Type = Nodes.CallExpression;
             Callee = callee;
             Arguments = args;
         }

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly ArrayPatternElement Param; // BindingIdentifier | BindingPattern;
         public readonly BlockStatement Body;
 
-        public CatchClause(ArrayPatternElement param, BlockStatement body)
+        public CatchClause(ArrayPatternElement param, BlockStatement body) :
+            base(Nodes.CatchClause)
         {
-            Type = Nodes.CatchClause;
             Param = param;
             Body = body;
         }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<ClassProperty> Body;
 
-        public ClassBody(List<ClassProperty> body)
+        public ClassBody(List<ClassProperty> body) :
+            base(Nodes.ClassBody)
         {
-            Type = Nodes.ClassBody;
             Body = body;
         }
     }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -7,9 +7,9 @@
         public readonly Expression SuperClass; // Identifier || CallExpression
         public readonly ClassBody Body;
 
-        public ClassDeclaration(Identifier id, Expression superClass, ClassBody body)
+        public ClassDeclaration(Identifier id, Expression superClass, ClassBody body) :
+            base(Nodes.ClassDeclaration)
         {
-            Type = Nodes.ClassDeclaration;
             Id = id;
             SuperClass = superClass;
             Body = body;

--- a/src/Esprima/Ast/ClassElement.cs
+++ b/src/Esprima/Ast/ClassElement.cs
@@ -22,5 +22,7 @@ namespace Esprima.Ast
         public Expression Key; // Identifier, Literal, '[' Expression ']'
         public bool Computed;
         public PropertyValue Value;
+
+        protected ClassProperty(Nodes type) : base(type) {}
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -6,9 +6,9 @@
         public readonly Expression SuperClass;
         public readonly ClassBody Body;
 
-        public ClassExpression(Identifier id, Expression superClass, ClassBody body)
+        public ClassExpression(Identifier id, Expression superClass, ClassBody body) :
+            base(Nodes.ClassExpression)
         {
-            Type = Nodes.ClassExpression;
             Id = id;
             SuperClass = superClass;
             Body = body;

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -7,9 +7,9 @@ namespace Esprima.Ast
         public readonly Expression Consequent;
         public readonly Expression Alternate;
 
-        public ConditionalExpression(Expression test, Expression consequent, Expression alternate)
+        public ConditionalExpression(Expression test, Expression consequent, Expression alternate) :
+            base(Nodes.ConditionalExpression)
         {
-            Type = Nodes.ConditionalExpression;
             Test = test;
             Consequent = consequent;
             Alternate = alternate;

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
     {
         public readonly Identifier Label;
 
-        public ContinueStatement(Identifier label)
+        public ContinueStatement(Identifier label) :
+            base(Nodes.ContinueStatement)
         {
-            Type = Nodes.ContinueStatement;
             Label = label;
         }
     }

--- a/src/Esprima/Ast/DebuggerStatement.cs
+++ b/src/Esprima/Ast/DebuggerStatement.cs
@@ -2,9 +2,7 @@ namespace Esprima.Ast
 {
     public class DebuggerStatement: Statement
     {
-        public DebuggerStatement()
-        {
-            Type = Nodes.DebuggerStatement;
-        }
+        public DebuggerStatement() :
+            base(Nodes.DebuggerStatement) {}
     }
 }

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly Statement Body;
         public readonly Expression Test;
 
-        public DoWhileStatement(Statement body, Expression test)
+        public DoWhileStatement(Statement body, Expression test) :
+            base(Nodes.DoWhileStatement)
         {
-            Type = Nodes.DoWhileStatement;
             Body = body;
             Test = test;
         }

--- a/src/Esprima/Ast/EmptyStatement.cs
+++ b/src/Esprima/Ast/EmptyStatement.cs
@@ -2,9 +2,7 @@ namespace Esprima.Ast
 {
     public class EmptyStatement : Statement
     {
-        public EmptyStatement()
-        {
-            Type = Nodes.EmptyStatement;
-        }
+        public EmptyStatement() :
+            base(Nodes.EmptyStatement) {}
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -4,9 +4,9 @@
     {
         public readonly Literal Source;
 
-        public ExportAllDeclaration(Literal source)
+        public ExportAllDeclaration(Literal source) :
+            base(Nodes.ExportAllDeclaration)
         {
-            Type = Nodes.ExportAllDeclaration;
             Source = source;
         }
     }

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -4,9 +4,9 @@
     {
         public readonly Declaration Declaration; //: BindingIdentifier | BindingPattern | ClassDeclaration | Expression | FunctionDeclaration;
 
-        public ExportDefaultDeclaration(Declaration declaration)
+        public ExportDefaultDeclaration(Declaration declaration) :
+            base(Nodes.ExportDefaultDeclaration)
         {
-            Type = Nodes.ExportDefaultDeclaration;
             Declaration = declaration;
         }
     }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
         public readonly List<ExportSpecifier> Specifiers;
         public readonly Literal Source;
 
-        public ExportNamedDeclaration(StatementListItem declaration, List<ExportSpecifier> specifiers, Literal source)
+        public ExportNamedDeclaration(StatementListItem declaration, List<ExportSpecifier> specifiers, Literal source) :
+            base(Nodes.ExportNamedDeclaration)
         {
-            Type = Nodes.ExportNamedDeclaration;
             Declaration = declaration;
             Specifiers = specifiers;
             Source = source;

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -5,9 +5,9 @@
         public readonly Identifier Exported;
         public readonly Identifier Local;
 
-        public ExportSpecifier(Identifier local, Identifier exported)
+        public ExportSpecifier(Identifier local, Identifier exported) :
+            base(Nodes.ExportSpecifier)
         {
-            Type = Nodes.ExportSpecifier;
             Exported = exported;
             Local = local;
         }

--- a/src/Esprima/Ast/ExportStatement.cs
+++ b/src/Esprima/Ast/ExportStatement.cs
@@ -4,9 +4,9 @@
     {
         public readonly Expression Expression;
 
-        public ExportStatement(Expression expression)
+        public ExportStatement(Expression expression) :
+            base(Nodes.ExpressionStatement)
         {
-            Type = Nodes.ExpressionStatement;
             Expression = expression;
         }
     }

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
     {
         public readonly Expression Expression;
 
-        public ExpressionStatement(Expression expression)
+        public ExpressionStatement(Expression expression) :
+            base(Nodes.ExpressionStatement)
         {
-            Type = Nodes.ExpressionStatement;
             Expression = expression;
         }
     }

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -7,9 +7,9 @@ namespace Esprima.Ast
         public readonly Statement Body;
         public readonly bool Each;
 
-        public ForInStatement(INode left, Expression right, Statement body)
+        public ForInStatement(INode left, Expression right, Statement body) :
+            base(Nodes.ForInStatement)
         {
-            Type = Nodes.ForInStatement;
             Left = left;
             Right = right;
             Body = body;

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -6,9 +6,9 @@
         public readonly Expression Right;
         public readonly Statement Body;
 
-        public ForOfStatement(INode left, Expression right, Statement body)
+        public ForOfStatement(INode left, Expression right, Statement body) :
+            base(Nodes.ForOfStatement)
         {
-            Type = Nodes.ForOfStatement;
             Left = left;
             Right = right;
             Body = body;

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
         public readonly Expression Update;
         public readonly Statement Body;
 
-        public ForStatement(INode init, Expression test, Expression update, Statement body)
+        public ForStatement(INode init, Expression test, Expression update, Statement body) :
+            base(Nodes.ForStatement)
         {
-            Type = Nodes.ForStatement;
             Init = init;
             Test = test;
             Update = update;

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -19,10 +19,9 @@ namespace Esprima.Ast
             BlockStatement body,
             bool generator,
             HoistingScope hoistingScope,
-            bool strict
-            )
+            bool strict) :
+            base(Nodes.FunctionDeclaration)
         {
-            Type = Nodes.FunctionDeclaration;
             Id = id;
             Params = parameters;
             Body = body;

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -22,10 +22,9 @@ namespace Esprima.Ast
             BlockStatement body,
             bool generator,
             HoistingScope hoistingScope,
-            bool strict
-            )
+            bool strict) :
+            base(Nodes.FunctionExpression)
         {
-            Type = Nodes.FunctionExpression;
             Id = id;
             Params = parameters;
             Body = body;

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly string Name;
 
-        public Identifier(string name)
+        public Identifier(string name) :
+            base(Nodes.Identifier)
         {
-            Type = Nodes.Identifier;
             Name = name;
         }
     }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
         public readonly Statement Consequent;
         public readonly Statement Alternate;
 
-        public IfStatement(Expression test, Statement consequent, Statement alternate)
+        public IfStatement(Expression test, Statement consequent, Statement alternate) :
+            base(Nodes.IfStatement)
         {
-            Type = Nodes.IfStatement;
             Test = test;
             Consequent = consequent;
             Alternate = alternate;

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -7,9 +7,9 @@ namespace Esprima.Ast
         public readonly List<ImportDeclarationSpecifier> Specifiers;
         public readonly Literal Source;
 
-        public ImportDeclaration(List<ImportDeclarationSpecifier> specifiers, Literal source)
+        public ImportDeclaration(List<ImportDeclarationSpecifier> specifiers, Literal source) :
+            base(Nodes.ImportDeclaration)
         {
-            Type = Nodes.ImportDeclaration;
             Specifiers = specifiers;
             Source = source;
         }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -4,9 +4,9 @@
     {
         public readonly Identifier Local;
 
-        public ImportDefaultSpecifier(Identifier local)
+        public ImportDefaultSpecifier(Identifier local) :
+            base(Nodes.ImportDefaultSpecifier)
         {
-            Type = Nodes.ImportDefaultSpecifier;
             Local = local;
         }
     }

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -4,9 +4,9 @@
     {
         public readonly Identifier Local;
 
-        public ImportNamespaceSpecifier(Identifier local)
+        public ImportNamespaceSpecifier(Identifier local) :
+            base(Nodes.ImportNamespaceSpecifier)
         {
-            Type = Nodes.ImportNamespaceSpecifier;
             Local = local;
         }
     }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -5,9 +5,9 @@
         public readonly Identifier Local;
         public readonly Identifier Imported;
 
-        public ImportSpecifier(Identifier local, Identifier imported)
+        public ImportSpecifier(Identifier local, Identifier imported) :
+            base(Nodes.ImportSpecifier)
         {
-            Type = Nodes.ImportSpecifier;
             Local = local;
             Imported = imported;
         }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly Identifier Label;
         public readonly Statement Body;
 
-        public LabeledStatement(Identifier label, Statement body)
+        public LabeledStatement(Identifier label, Statement body) :
+            base(Nodes.LabeledStatement)
         {
-            Type = Nodes.LabeledStatement;
             Label = label;
             Body = body;
             body.LabelSet = label;

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -16,47 +16,37 @@ namespace Esprima.Ast
         public readonly TokenType TokenType;
         public object CachedValue;
 
-        public Literal(string value, string raw)
+        private Literal(TokenType tokenType, object value, string raw) :
+            base(Nodes.Literal)
         {
-            Type = Nodes.Literal;
+            TokenType = tokenType;
             Value = value;
-            TokenType = TokenType.StringLiteral;
             Raw = raw;
         }
 
-        public Literal(bool value, string raw)
+        public Literal(string value, string raw) :
+            this(TokenType.StringLiteral, value, raw) {}
+
+        public Literal(bool value, string raw) :
+            this(TokenType.BooleanLiteral, value, raw)
         {
-            Type = Nodes.Literal;
-            Value = value;
             NumericValue = value ? 1 : 0;
-            TokenType = TokenType.BooleanLiteral;
-            Raw = raw;
         }
 
-        public Literal(double value, string raw)
+        public Literal(double value, string raw) :
+            this(TokenType.NumericLiteral, value, raw)
         {
-            Type = Nodes.Literal;
-            Value = NumericValue = value;
-            TokenType = TokenType.NumericLiteral;
-            Raw = raw;
+            NumericValue = value;
         }
 
-        public Literal(string raw)
-        {
-            Type = Nodes.Literal;
-            Value = null;
-            TokenType = TokenType.NullLiteral;
-            Raw = raw;
-        }
+        public Literal(string raw) :
+            this(TokenType.NullLiteral, null, raw) {}
 
-        public Literal(string pattern, string flags, object value, string raw)
+        public Literal(string pattern, string flags, object value, string raw) :
+            this(TokenType.RegularExpression, value, raw)
         {
-            Type = Nodes.Literal;
             // value is null if a Regex object couldn't be created out of the pattern or options
-            Value = value;
             Regex = new RegexValue(pattern, flags);
-            TokenType = TokenType.RegularExpression;
-            Raw = raw;
         }
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -10,10 +10,9 @@ namespace Esprima.Ast
         // true if an indexer is used and the property to be evaluated
         public readonly bool Computed;
 
-        protected MemberExpression(Expression obj, Expression property, bool computed)
+        protected MemberExpression(Expression obj, Expression property, bool computed) :
+            base(Nodes.MemberExpression)
         {
-            Type = Nodes.MemberExpression;
-
             Object = obj;
             Property = property;
             Computed = computed;

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -5,9 +5,9 @@
         public readonly Identifier Meta;
         public readonly Identifier Property;
 
-        public MetaProperty(Identifier meta, Identifier property)
+        public MetaProperty(Identifier meta, Identifier property) :
+            base(Nodes.MetaProperty)
         {
-            Type = Nodes.MetaProperty;
             Meta = meta;
             Property = property;
         }

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -4,9 +4,9 @@
     {
         public readonly bool Static;
 
-        public MethodDefinition(Expression key, bool computed, FunctionExpression value, PropertyKind kind, bool isStatic)
+        public MethodDefinition(Expression key, bool computed, FunctionExpression value, PropertyKind kind, bool isStatic) :
+            base(Nodes.MethodDefinition)
         {
-            Type = Nodes.MethodDefinition;
             Static = isStatic;
             Key = key;
             Computed = computed;

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
         public readonly Expression Callee;
         public readonly List<ArgumentListElement> Arguments;
 
-        public NewExpression(Expression callee, List<ArgumentListElement> args)
+        public NewExpression(Expression callee, List<ArgumentListElement> args) :
+            base(Nodes.NewExpression)
         {
-            Type = Nodes.NewExpression;
             Callee = callee;
             Arguments = args;
         }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -4,7 +4,7 @@
     {
         private Location _location;
 
-        public Nodes Type { get; set; }
+        public Nodes Type { get; }
         public Range Range { get; set; }
 
         public Location Location
@@ -12,5 +12,8 @@
             get => _location  = _location ?? new Location();
             set => _location = value;
         }
+
+        protected Node(Nodes type) =>
+            Type = type;
     }
 }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<Property> Properties;
 
-        public ObjectExpression(List<Property> properties)
+        public ObjectExpression(List<Property> properties) :
+            base(Nodes.ObjectExpression)
         {
-            Type = Nodes.ObjectExpression;
             Properties = properties;
         }
     }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public readonly List<Property> Properties;
 
-        public ObjectPattern(List<Property> properties)
+        public ObjectPattern(List<Property> properties) :
+            base(Nodes.ObjectPattern)
         {
-            Type = Nodes.ObjectPattern;
             Properties = properties;
         }
     }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
         public HoistingScope HoistingScope { get; }
         public bool Strict { get; }
 
-        public Program(List<StatementListItem> body, SourceType sourceType, HoistingScope hoistingScope, bool strict)
+        public Program(List<StatementListItem> body, SourceType sourceType, HoistingScope hoistingScope, bool strict) :
+            base(Nodes.Program)
         {
-            Type = Nodes.Program;
             Body = body;
             SourceType = sourceType;
             HoistingScope = hoistingScope;

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly bool Method;
         public readonly bool Shorthand;
 
-        public Property(PropertyKind kind, Expression key, bool computed, PropertyValue value, bool method, bool shorthand)
+        public Property(PropertyKind kind, Expression key, bool computed, PropertyValue value, bool method, bool shorthand) :
+            base(Nodes.Property)
         {
-            Type = Nodes.Property;
             Key = key;
             Computed = computed;
             Value = value;

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -9,9 +9,9 @@
 
         public readonly INode Argument; // BindingIdentifier | BindingPattern
 
-        public RestElement(INode argument)
+        public RestElement(INode argument) :
+            base(Nodes.RestElement)
         {
-            Type = Nodes.RestElement;
             Argument = argument;
         }
     }

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
     {
         public readonly Expression Argument;
 
-        public ReturnStatement(Expression argument)
+        public ReturnStatement(Expression argument) :
+            base(Nodes.ReturnStatement)
         {
-            Type = Nodes.ReturnStatement;
             Argument = argument;
         }
 

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -6,9 +6,9 @@ namespace Esprima.Ast
     {
         public List<Expression> Expressions { get; internal set; }
 
-        public SequenceExpression(List<Expression> expressions)
+        public SequenceExpression(List<Expression> expressions) :
+            base(Nodes.SequenceExpression)
         {
-            Type = Nodes.SequenceExpression;
             Expressions = expressions;
         }
     }

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -7,9 +7,9 @@
     {
         public readonly Expression Argument;
 
-        public SpreadElement(Expression argument)
+        public SpreadElement(Expression argument) :
+            base(Nodes.SpreadElement)
         {
-            Type = Nodes.SpreadElement;
             Argument = argument;
         }
     }

--- a/src/Esprima/Ast/Statement.cs
+++ b/src/Esprima/Ast/Statement.cs
@@ -2,6 +2,8 @@ namespace Esprima.Ast
 {
     public class Statement : Node, INode, StatementListItem
     {
+        protected Statement(Nodes type) : base(type) {}
+
         public Identifier LabelSet { get; internal set; }
     }
 }

--- a/src/Esprima/Ast/Super.cs
+++ b/src/Esprima/Ast/Super.cs
@@ -2,9 +2,7 @@
 {
     public class Super : Node, Expression
     {
-        public Super()
-        {
-            Type = Nodes.Super;
-        }
+        public Super() :
+            base(Nodes.Super) {}
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -7,9 +7,9 @@ namespace Esprima.Ast
         public readonly Expression Test;
         public readonly List<StatementListItem> Consequent;
 
-        public SwitchCase(Expression test, List<StatementListItem> consequent)
+        public SwitchCase(Expression test, List<StatementListItem> consequent) :
+            base(Nodes.SwitchCase)
         {
-            Type = Nodes.SwitchCase;
             Test = test;
             Consequent = consequent;
         }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -7,9 +7,9 @@ namespace Esprima.Ast
         public readonly Expression Discriminant;
         public readonly List<SwitchCase> Cases;
 
-        public SwitchStatement(Expression discriminant, List<SwitchCase> cases)
+        public SwitchStatement(Expression discriminant, List<SwitchCase> cases) :
+            base(Nodes.SwitchStatement)
         {
-            Type = Nodes.SwitchStatement;
             Discriminant = discriminant;
             Cases = cases;
         }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -5,9 +5,9 @@
         public readonly Expression Tag;
         public readonly TemplateLiteral Quasi;
 
-        public TaggedTemplateExpression(Expression tag, TemplateLiteral quasi)
+        public TaggedTemplateExpression(Expression tag, TemplateLiteral quasi) :
+            base(Nodes.TaggedTemplateExpression)
         {
-            Type = Nodes.TaggedTemplateExpression;
             Tag = tag;
             Quasi = quasi;
         }

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -5,9 +5,9 @@
         public readonly TemplateElementValue Value;
         public readonly bool Tail;
 
-        public TemplateElement(TemplateElementValue value, bool tail)
+        public TemplateElement(TemplateElementValue value, bool tail) :
+            base(Nodes.TemplateElement)
         {
-            Type = Nodes.TemplateElement;
             Value = value;
             Tail = tail;
         }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
         public readonly List<TemplateElement> Quasis;
         public readonly List<Expression> Expressions;
 
-        public TemplateLiteral(List<TemplateElement> quasis, List<Expression> expressions)
+        public TemplateLiteral(List<TemplateElement> quasis, List<Expression> expressions) :
+            base(Nodes.TemplateLiteral)
         {
-            Type = Nodes.TemplateLiteral;
             Quasis = quasis;
             Expressions = expressions;
         }

--- a/src/Esprima/Ast/ThisExpression.cs
+++ b/src/Esprima/Ast/ThisExpression.cs
@@ -3,9 +3,7 @@ namespace Esprima.Ast
     public class ThisExpression : Node,
         Expression
     {
-        public ThisExpression()
-        {
-            Type = Nodes.ThisExpression;
-        }
+        public ThisExpression() :
+            base(Nodes.ThisExpression) {}
     }
 }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -4,9 +4,9 @@ namespace Esprima.Ast
     {
         public readonly Expression Argument;
 
-        public ThrowStatement(Expression argument)
+        public ThrowStatement(Expression argument) :
+            base(Nodes.ThrowStatement)
         {
-            Type = Nodes.ThrowStatement;
             Argument = argument;
         }
     }

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -9,9 +9,9 @@ namespace Esprima.Ast
         public TryStatement(
             Statement block,
             CatchClause handler,
-            Statement finalizer)
+            Statement finalizer) :
+            base(Nodes.TryStatement)
         {
-            Type = Nodes.TryStatement;
             Block = block;
             Handler = handler;
             Finalizer = finalizer;

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -59,12 +59,14 @@ namespace Esprima.Ast
                     throw new ArgumentOutOfRangeException("Invalid unary operator: " + op);
 
             }
-
-
         }
-        public UnaryExpression(string op, Expression arg)
+
+        public UnaryExpression(string op, Expression arg) :
+            this(Nodes.UnaryExpression, op, arg) {}
+
+        protected UnaryExpression(Nodes type, string op, Expression arg) :
+            base(type)
         {
-            Type = Nodes.UnaryExpression;
             Operator = ParseUnaryOperator(op);
             Argument = arg;
             Prefix = true;

--- a/src/Esprima/Ast/UpdateExpression.cs
+++ b/src/Esprima/Ast/UpdateExpression.cs
@@ -2,9 +2,9 @@ namespace Esprima.Ast
 {
     public class UpdateExpression : UnaryExpression
     {
-        public UpdateExpression(string op, Expression arg, bool prefix) : base(op, arg)
+        public UpdateExpression(string op, Expression arg, bool prefix) :
+            base(Nodes.UpdateExpression, op, arg)
         {
-            Type = Nodes.UpdateExpression;
             Prefix = prefix;
         }
     }

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
         public readonly List<VariableDeclarator> Declarations;
         public readonly VariableDeclarationKind Kind;
 
-        public VariableDeclaration(List<VariableDeclarator> declarations, VariableDeclarationKind kind)
+        public VariableDeclaration(List<VariableDeclarator> declarations, VariableDeclarationKind kind) :
+            base(Nodes.VariableDeclaration)
         {
-            Type = Nodes.VariableDeclaration;
             Declarations = declarations;
             Kind = kind;
         }

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly ArrayPatternElement Id; // BindingIdentifier | BindingPattern;
         public readonly Expression Init;
 
-        public VariableDeclarator(ArrayPatternElement id, Expression init)
+        public VariableDeclarator(ArrayPatternElement id, Expression init) :
+            base(Nodes.VariableDeclarator)
         {
-            Type = Nodes.VariableDeclarator;
             Id = id;
             Init = init;
         }

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly Expression Test;
         public readonly Statement Body;
 
-        public WhileStatement(Expression test, Statement body)
+        public WhileStatement(Expression test, Statement body) :
+            base(Nodes.WhileStatement)
         {
-            Type = Nodes.WhileStatement;
             Test = test;
             Body = body;
         }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -5,9 +5,9 @@ namespace Esprima.Ast
         public readonly Expression Object;
         public readonly Statement Body;
 
-        public WithStatement(Expression obj, Statement body)
+        public WithStatement(Expression obj, Statement body) :
+            base(Nodes.WithStatement)
         {
-            Type = Nodes.WithStatement;
             Object = obj;
             Body = body;
         }

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -5,9 +5,9 @@
         public readonly Expression Argument;
         public readonly bool Delegate;
 
-        public YieldExpression(Expression argument, bool delgate)
+        public YieldExpression(Expression argument, bool delgate) :
+            base(Nodes.YieldExpression)
         {
-            Type = Nodes.YieldExpression;
             Argument = argument;
             Delegate = delgate;
         }


### PR DESCRIPTION
This PR changes `Node.Type` to be read-only (in advancement of #66). It did not need to be read-write. It was only set by sub-classes so this PR introduces a protected constructor in `Node` that is then used by subclasses to initialize the node's type.

Making `Node.Type` abstract would have been another option and would have reduced the size of most nodes by one field but I am guessing you want to avoid virtual members for performance reasons so initialization via a protected constructor seemed to be the right thing to do here. Yet another option was to make `Type` setter protected but this wouldn't have enforced initialization of `Type` and leaving it open to modification (even if by subclasses) seemed unnecessary.

---
All tests are passing. ✅ 