### PR TITLE
 Make Position & Location whole read-only value types

### DIFF
--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -2,15 +2,9 @@
 {
     public class Node : INode
     {
-        private Location _location;
-
         public Nodes Type { get; set; }
         public Range Range { get; set; }
 
-        public Location Location
-        {
-            get => _location  = _location ?? new Location();
-            set => _location = value;
-        }
+        public Location Location { get; set; }
     }
 }

--- a/src/Esprima/Exception.cs
+++ b/src/Esprima/Exception.cs
@@ -1,0 +1,11 @@
+namespace Esprima
+{
+    using System;
+
+    static class Exception<T> where T : Exception, new()
+    {
+        static string _message;
+
+        public static string DefaultMessage => _message ?? (_message = new T().Message);
+    }
+}

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -206,11 +206,13 @@ namespace Esprima
 
             if (_config.Loc)
             {
-                t.Location.Start = new Position(_startMarker.LineNumber,
-                                                _startMarker.Index - _startMarker.LineStart);
+                var start = new Position(_startMarker.LineNumber,
+                                         _startMarker.Index - _startMarker.LineStart);
 
-                t.Location.End = new Position(_scanner.LineNumber,
-                                              _scanner.Index - _scanner.LineStart);
+                var end   = new Position(_scanner.LineNumber,
+                                         _scanner.Index - _scanner.LineStart);
+
+                t.Location = t.Location.WithPosition(start, end);
             }
 
             if (token.RegexValue != null)
@@ -300,14 +302,11 @@ namespace Esprima
 
             if (_config.Loc)
             {
-                node.Location.Start = new Position(meta.Line, meta.Column);
-                node.Location.End = new Position(_lastMarker.LineNumber,
-                                                 _lastMarker.Index - _lastMarker.LineStart);
+                var start = new Position(meta.Line, meta.Column);
+                var end   = new Position(_lastMarker.LineNumber,
+                                         _lastMarker.Index - _lastMarker.LineStart);
 
-                if (_errorHandler.Source != null)
-                {
-                    node.Location.Source = _errorHandler.Source;
-                }
+                node.Location = new Location(start, end, _errorHandler.Source);
             }
 
             _action?.Invoke(node);
@@ -1035,7 +1034,7 @@ namespace Esprima
                     var newArgument = ReinterpretExpressionAsPattern(expr.As<SpreadElement>().Argument);
                     node = new RestElement(newArgument.As<Expression>());
                     node.Range = expr.Range;
-                    node.Location = _config.Loc ? expr.Location : null;
+                    node.Location = _config.Loc ? expr.Location : default;
 
                     break;
                 case Nodes.ArrayExpression:
@@ -1056,7 +1055,7 @@ namespace Esprima
 
                     node = new ArrayPattern(elements);
                     node.Range = expr.Range;
-                    node.Location = _config.Loc ? expr.Location : null;
+                    node.Location = _config.Loc ? expr.Location : default;
 
                     break;
                 case Nodes.ObjectExpression:
@@ -1069,14 +1068,14 @@ namespace Esprima
                     }
                     node = new ObjectPattern(properties);
                     node.Range = expr.Range;
-                    node.Location = _config.Loc ? expr.Location : null;
+                    node.Location = _config.Loc ? expr.Location : default;
 
                     break;
                 case Nodes.AssignmentExpression:
                     var assignmentExpression = expr.As<AssignmentExpression>();
                     node = new AssignmentPattern(assignmentExpression.Left, assignmentExpression.Right);
                     node.Range = expr.Range;
-                    node.Location = _config.Loc ? expr.Location : null;
+                    node.Location = _config.Loc ? expr.Location : default;
 
                     break;
                 default:
@@ -1790,7 +1789,7 @@ namespace Esprima
 
                         assignment.Right = new Identifier("yield")
                         {
-                            Location = _config.Loc ? assignment.Right.Location : null,
+                            Location = _config.Loc ? assignment.Right.Location : default,
                             Range = assignment.Right.Range
                         };
                     }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -206,11 +206,11 @@ namespace Esprima
 
             if (_config.Loc)
             {
-                t.Location.Start.Line = _startMarker.LineNumber;
-                t.Location.Start.Column = _startMarker.Index - _startMarker.LineStart;
+                t.Location.Start = new Position(_startMarker.LineNumber,
+                                                _startMarker.Index - _startMarker.LineStart);
 
-                t.Location.End.Line = _scanner.LineNumber;
-                t.Location.End.Column = _scanner.Index - _scanner.LineStart;
+                t.Location.End = new Position(_scanner.LineNumber,
+                                              _scanner.Index - _scanner.LineStart);
             }
 
             if (token.RegexValue != null)
@@ -300,10 +300,10 @@ namespace Esprima
 
             if (_config.Loc)
             {
-                node.Location.Start.Line = meta.Line;
-                node.Location.Start.Column = meta.Column;
-                node.Location.End.Line = _lastMarker.LineNumber;
-                node.Location.End.Column = _lastMarker.Index - _lastMarker.LineStart;
+                node.Location.Start = new Position(meta.Line, meta.Column);
+                node.Location.End = new Position(_lastMarker.LineNumber,
+                                                 _lastMarker.Index - _lastMarker.LineStart);
+
                 if (_errorHandler.Source != null)
                 {
                     node.Location.Source = _errorHandler.Source;
@@ -3192,7 +3192,7 @@ namespace Esprima
             var parameters = new List<Token>();
 
             INode param = Match("...")
-                ? ParseRestElement(parameters) 
+                ? ParseRestElement(parameters)
                 : ParsePatternWithDefault(parameters);
 
             for (var i = 0; i < parameters.Count; i++)
@@ -3764,9 +3764,9 @@ namespace Esprima
             ExpectKeyword("class");
 
             var id = (identifierIsOptional && (_lookahead.Type != TokenType.Identifier))
-                ? null 
+                ? null
                 : ParseVariableIdentifier();
-            
+
             Expression superClass = null;
             if (MatchKeyword("extends"))
             {
@@ -3787,7 +3787,7 @@ namespace Esprima
             _context.Strict = true;
             ExpectKeyword("class");
             var id = (_lookahead.Type == TokenType.Identifier)
-                ? ParseVariableIdentifier() 
+                ? ParseVariableIdentifier()
                 : null;
 
             Expression superClass = null;

--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -1,10 +1,63 @@
 ﻿namespace Esprima
 {
-    public class Location
-    {
-        public Position Start;
-        public Position End;
+    using System;
 
-        public string Source;
+    public readonly struct Location : IEquatable<Location>
+    {
+        public Position Start  { get; }
+        public Position End    { get; }
+        public string   Source { get; }
+
+        public Location(Position start, Position end) :
+            this(start, end, null) {}
+
+        public Location(Position start, Position end, string source)
+        {
+            Start  = start;
+
+            End    = start == default && end != default
+                     || end == default && start != default
+                     || end.Line < start.Line
+                     || start.Line > 0 && start.Line == end.Line && end.Column <= start.Column
+                   ? throw new ArgumentOutOfRangeException(nameof(end), end,
+                         Exception<ArgumentOutOfRangeException>.DefaultMessage)
+                   : end;
+            Source = source;
+        }
+
+        public Location WithPosition(Position start, Position end) =>
+            new Location(start, end, Source);
+
+        public override bool Equals(object obj) =>
+            obj is Location other && Equals(other);
+
+        public bool Equals(Location other) =>
+            Start.Equals(other.Start)
+            && End.Equals(other.End)
+            && string.Equals(Source, other.Source);
+
+        public override int GetHashCode() =>
+            unchecked(  (Start.GetHashCode() * 397)
+                      ^ (End.GetHashCode() * 397)
+                      ^ (Source?.GetHashCode() ?? 0));
+
+        public override string ToString() =>
+            $"{Start}...{End}{(Source is string s ? ": " + s : null)}";
+
+        public static bool operator ==(Location left, Location right) => left.Equals(right);
+        public static bool operator !=(Location left, Location right) => !left.Equals(right);
+
+        public void Deconstruct(out Position start, out Position end)
+        {
+            start = Start;
+            end   = End;
+        }
+
+        public void Deconstruct(out Position start, out Position end, out string source)
+        {
+            start  = Start;
+            end    = End;
+            source = Source;
+        }
     }
 }

--- a/src/Esprima/Position.cs
+++ b/src/Esprima/Position.cs
@@ -1,8 +1,55 @@
 ﻿namespace Esprima
 {
-    public struct Position
+    using System;
+    using System.Globalization;
+
+    /// <summary>
+    /// Represents a source position as line number and column offset, where
+    /// the first line is 1 and first column is 0.
+    /// </summary>
+    /// <remarks>
+    /// A position where <see cref="Line"/> and <see cref="Column"/> are zero
+    /// is an allowed (and the default) value but considered an invalid
+    /// position.
+    /// </remarks>
+
+    public readonly struct Position : IEquatable<Position>
     {
-        public int Line;
-        public int Column;
+        public int Line   { get; }
+        public int Column { get; }
+
+        public Position(int line, int column)
+        {
+            Line = line >= 0 ? line
+                 : throw new ArgumentOutOfRangeException(nameof(line), line, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+
+            Column = line > 0 && column >= 0
+                     || line == 0 && column == 0 // if line is 0 then column MUST BE 0!
+                   ? column
+                   : throw new ArgumentOutOfRangeException(nameof(column), column, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+        }
+
+        public override bool Equals(object obj) =>
+            obj is Position other && Equals(other);
+
+        public bool Equals(Position other) =>
+            Line == other.Line && Column == other.Column;
+
+        public override int GetHashCode() =>
+            unchecked((Line * 397) ^ Column);
+
+        public override string ToString()
+            => Line.ToString(CultureInfo.InvariantCulture)
+             + ","
+             + Column.ToString(CultureInfo.InvariantCulture);
+
+        public static bool operator ==(Position left, Position right) => left.Equals(right);
+        public static bool operator !=(Position left, Position right) => !left.Equals(right);
+
+        public void Deconstruct(out int line, out int column)
+        {
+            line = Line;
+            column = Column;
+        }
     }
 }

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -26,8 +26,7 @@ namespace Esprima
         public int LineNumber;
         public int LineStart;
 
-        private Location _location;
-        public Location Location => _location ?? (_location = new Location());
+        public Location Location;
 
         public int Precedence;
 
@@ -52,7 +51,7 @@ namespace Esprima
             End = 0;
             LineNumber = 0;
             LineStart = 0;
-            _location = null;
+            Location = default;
             Precedence = 0;
             Octal = false;
             Head = false;

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Esprima.Tests
+{
+    using System;
+
+    public class LocationTests
+    {
+        [Theory]
+        [InlineData(0, 0, 0, 0)]
+        [InlineData(1, 0, 2, 0)]
+        [InlineData(1, 4, 2, 0)]
+        [InlineData(1, 4, 2, 5)]
+        public void Construction(int startLine, int startColumn, int endLine, int endColumn)
+        {
+            var start = new Position(startLine, startColumn);
+            var end = new Position(endLine, endColumn);
+            var (actualStart, actualEnd) = new Location(start, end);
+            Assert.Equal(start, actualStart);
+            Assert.Equal(end, actualEnd);
+        }
+
+        [Theory]
+        [InlineData(1, 0, 1, 0)]
+        [InlineData(2, 0, 1, 0)]
+        [InlineData(1, 1, 1, 0)]
+        public void InvalidStartAndEnd(int startLine, int startColumn, int endLine, int endColumn)
+        {
+            var start = new Position(startLine, startColumn);
+            var end = new Position(endLine, endColumn);
+            var e = Assert.Throws<ArgumentOutOfRangeException>(() =>
+                        new Location(start, end));
+            Assert.Equal("end", e.ParamName);
+            Assert.Equal(end, e.ActualValue);
+        }
+    }
+}


### PR DESCRIPTION
This PR does for `Position` and `Location` what PR #65 did for `Range`. What's more, it refactors `Location` into a `struct` as opposed to a `class`, which should help to create less GC pressure.

Given that a `struct` always has a default constructor/value, there are some things to note:

- `Position` can be initialised with `(0, 0)` but this does not represent a _semantically_ valid position because while `Column` can be 0, `Line` cannot.
- `Location` can be initialised where the start and end positions are `(0, 0)` but it does not represent a _semantically_ valid location.
- FWIW, all other invalid values for `Position` and `Location` are validated and impossible to construct.

These are not design flaws per se but a consequence of using `struct`.

Finally, `Location.Start` and `Location.End` are not validated with respect to `Source`, if available, but if reviewers feel that it should be added for sake of comprehensive validation then I can do that.

This PR addresses issues raised in #66.

