### PR TITLE
Protect AstVisitor members

### DIFF
--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -284,7 +284,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitProgram(Program program)
+            protected override void VisitProgram(Program program)
             {
                 using (StartNodeObject(program))
                 {
@@ -293,10 +293,10 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitUnknownNode(INode node) =>
+            protected override void VisitUnknownNode(INode node) =>
                 throw new NotSupportedException("Unknown node type: " + node.Type);
 
-            public override void VisitCatchClause(CatchClause catchClause)
+            protected override void VisitCatchClause(CatchClause catchClause)
             {
                 using (StartNodeObject(catchClause))
                 {
@@ -305,7 +305,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+            protected override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
             {
                 using (StartNodeObject(functionDeclaration))
                 {
@@ -317,7 +317,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitWithStatement(WithStatement withStatement)
+            protected override void VisitWithStatement(WithStatement withStatement)
             {
                 using (StartNodeObject(withStatement))
                 {
@@ -326,7 +326,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitWhileStatement(WhileStatement whileStatement)
+            protected override void VisitWhileStatement(WhileStatement whileStatement)
             {
                 using (StartNodeObject(whileStatement))
                 {
@@ -335,7 +335,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+            protected override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
             {
                 using (StartNodeObject(variableDeclaration))
                 {
@@ -344,7 +344,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitTryStatement(TryStatement tryStatement)
+            protected override void VisitTryStatement(TryStatement tryStatement)
             {
                 using (StartNodeObject(tryStatement))
                 {
@@ -354,13 +354,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitThrowStatement(ThrowStatement throwStatement)
+            protected override void VisitThrowStatement(ThrowStatement throwStatement)
             {
                 using (StartNodeObject(throwStatement))
                     Member("argument", throwStatement.Argument);
             }
 
-            public override void VisitSwitchStatement(SwitchStatement switchStatement)
+            protected override void VisitSwitchStatement(SwitchStatement switchStatement)
             {
                 using (StartNodeObject(switchStatement))
                 {
@@ -369,7 +369,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitSwitchCase(SwitchCase switchCase)
+            protected override void VisitSwitchCase(SwitchCase switchCase)
             {
                 using (StartNodeObject(switchCase))
                 {
@@ -378,13 +378,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitReturnStatement(ReturnStatement returnStatement)
+            protected override void VisitReturnStatement(ReturnStatement returnStatement)
             {
                 using (StartNodeObject(returnStatement))
                     Member("argument", returnStatement.Argument);
             }
 
-            public override void VisitLabeledStatement(LabeledStatement labeledStatement)
+            protected override void VisitLabeledStatement(LabeledStatement labeledStatement)
             {
                 using (StartNodeObject(labeledStatement))
                 {
@@ -393,7 +393,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitIfStatement(IfStatement ifStatement)
+            protected override void VisitIfStatement(IfStatement ifStatement)
             {
                 using (StartNodeObject(ifStatement))
                 {
@@ -403,13 +403,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitEmptyStatement(EmptyStatement emptyStatement) =>
+            protected override void VisitEmptyStatement(EmptyStatement emptyStatement) =>
                 EmptyNodeObject(emptyStatement);
 
-            public override void VisitDebuggerStatement(DebuggerStatement debuggerStatement) =>
+            protected override void VisitDebuggerStatement(DebuggerStatement debuggerStatement) =>
                 EmptyNodeObject(debuggerStatement);
 
-            public override void VisitExpressionStatement(ExpressionStatement expressionStatement)
+            protected override void VisitExpressionStatement(ExpressionStatement expressionStatement)
             {
                 using (StartNodeObject(expressionStatement))
                 {
@@ -422,7 +422,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitForStatement(ForStatement forStatement)
+            protected override void VisitForStatement(ForStatement forStatement)
             {
                 using (StartNodeObject(forStatement))
                 {
@@ -433,7 +433,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitForInStatement(ForInStatement forInStatement)
+            protected override void VisitForInStatement(ForInStatement forInStatement)
             {
                 using (StartNodeObject(forInStatement))
                 {
@@ -444,7 +444,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+            protected override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
             {
                 using (StartNodeObject(doWhileStatement))
                 {
@@ -453,7 +453,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+            protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
             {
                 using (StartNodeObject(arrowFunctionExpression))
                 {
@@ -465,7 +465,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitUnaryExpression(UnaryExpression unaryExpression)
+            protected override void VisitUnaryExpression(UnaryExpression unaryExpression)
             {
                 using (StartNodeObject(unaryExpression))
                 {
@@ -475,25 +475,25 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitUpdateExpression(UpdateExpression updateExpression) =>
+            protected override void VisitUpdateExpression(UpdateExpression updateExpression) =>
                 VisitUnaryExpression(updateExpression);
 
-            public override void VisitThisExpression(ThisExpression thisExpression) =>
+            protected override void VisitThisExpression(ThisExpression thisExpression) =>
                 EmptyNodeObject(thisExpression);
 
-            public override void VisitSequenceExpression(SequenceExpression sequenceExpression)
+            protected override void VisitSequenceExpression(SequenceExpression sequenceExpression)
             {
                 using (StartNodeObject(sequenceExpression))
                     Member("expressions", sequenceExpression.Expressions);
             }
 
-            public override void VisitObjectExpression(ObjectExpression objectExpression)
+            protected override void VisitObjectExpression(ObjectExpression objectExpression)
             {
                 using (StartNodeObject(objectExpression))
                     Member("properties", objectExpression.Properties);
             }
 
-            public override void VisitNewExpression(NewExpression newExpression)
+            protected override void VisitNewExpression(NewExpression newExpression)
             {
                 using (StartNodeObject(newExpression))
                 {
@@ -502,7 +502,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitMemberExpression(MemberExpression memberExpression)
+            protected override void VisitMemberExpression(MemberExpression memberExpression)
             {
                 using (StartNodeObject(memberExpression))
                 {
@@ -512,10 +512,10 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitLogicalExpression(BinaryExpression binaryExpression) =>
+            protected override void VisitLogicalExpression(BinaryExpression binaryExpression) =>
                 VisitBinaryExpression(binaryExpression);
 
-            public override void VisitLiteral(Literal literal)
+            protected override void VisitLiteral(Literal literal)
             {
                 using (StartNodeObject(literal))
                 {
@@ -554,13 +554,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitIdentifier(Identifier identifier)
+            protected override void VisitIdentifier(Identifier identifier)
             {
                 using (StartNodeObject(identifier))
                     Member("name", identifier.Name);
             }
 
-            public override void VisitFunctionExpression(IFunction function)
+            protected override void VisitFunctionExpression(IFunction function)
             {
                 using (StartNodeObject((Node) function))
                 {
@@ -572,7 +572,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitClassExpression(ClassExpression classExpression)
+            protected override void VisitClassExpression(ClassExpression classExpression)
             {
                 using (StartNodeObject(classExpression))
                 {
@@ -582,19 +582,19 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+            protected override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
             {
                 using (StartNodeObject(exportDefaultDeclaration))
                     Member("declaration", exportDefaultDeclaration.Declaration.As<INode>());
             }
 
-            public override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+            protected override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
             {
                 using (StartNodeObject(exportAllDeclaration))
                     Member("source", exportAllDeclaration.Source);
             }
 
-            public override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+            protected override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
             {
                 using (StartNodeObject(exportNamedDeclaration))
                 {
@@ -604,7 +604,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+            protected override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
             {
                 using (StartNodeObject(exportSpecifier))
                 {
@@ -613,7 +613,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitImportDeclaration(ImportDeclaration importDeclaration)
+            protected override void VisitImportDeclaration(ImportDeclaration importDeclaration)
             {
                 using (StartNodeObject(importDeclaration))
                 {
@@ -622,19 +622,19 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+            protected override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
             {
                 using (StartNodeObject(importNamespaceSpecifier))
                     Member("local", importNamespaceSpecifier.Local);
             }
 
-            public override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+            protected override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
             {
                 using (StartNodeObject(importDefaultSpecifier))
                     Member("local", importDefaultSpecifier.Local);
             }
 
-            public override void VisitImportSpecifier(ImportSpecifier importSpecifier)
+            protected override void VisitImportSpecifier(ImportSpecifier importSpecifier)
             {
                 using (StartNodeObject(importSpecifier))
                 {
@@ -643,7 +643,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitMethodDefinition(MethodDefinition methodDefinition)
+            protected override void VisitMethodDefinition(MethodDefinition methodDefinition)
             {
                 using (StartNodeObject(methodDefinition))
                 {
@@ -655,7 +655,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitForOfStatement(ForOfStatement forOfStatement)
+            protected override void VisitForOfStatement(ForOfStatement forOfStatement)
             {
                 using (StartNodeObject(forOfStatement))
                 {
@@ -665,7 +665,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitClassDeclaration(ClassDeclaration classDeclaration)
+            protected override void VisitClassDeclaration(ClassDeclaration classDeclaration)
             {
                 using (StartNodeObject(classDeclaration))
                 {
@@ -675,13 +675,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitClassBody(ClassBody classBody)
+            protected override void VisitClassBody(ClassBody classBody)
             {
                 using (StartNodeObject(classBody))
                     Member("body", classBody.Body);
             }
 
-            public override void VisitYieldExpression(YieldExpression yieldExpression)
+            protected override void VisitYieldExpression(YieldExpression yieldExpression)
             {
                 using (StartNodeObject(yieldExpression))
                 {
@@ -690,7 +690,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+            protected override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
             {
                 using (StartNodeObject(taggedTemplateExpression))
                 {
@@ -699,10 +699,10 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitSuper(Super super) =>
+            protected override void VisitSuper(Super super) =>
                 EmptyNodeObject(super);
 
-            public override void VisitMetaProperty(MetaProperty metaProperty)
+            protected override void VisitMetaProperty(MetaProperty metaProperty)
             {
                 using (StartNodeObject(metaProperty))
                 {
@@ -711,7 +711,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
+            protected override void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
             {
                 // Seems that ArrowParameterPlaceHolder nodes never appear
                 // in the final tree and only used during the construction of
@@ -720,19 +720,19 @@ namespace Esprima.Utils
                 throw new NotImplementedException();
             }
 
-            public override void VisitObjectPattern(ObjectPattern objectPattern)
+            protected override void VisitObjectPattern(ObjectPattern objectPattern)
             {
                 using (StartNodeObject(objectPattern))
                     Member("properties", objectPattern.Properties);
             }
 
-            public override void VisitSpreadElement(SpreadElement spreadElement)
+            protected override void VisitSpreadElement(SpreadElement spreadElement)
             {
                 using (StartNodeObject(spreadElement))
                     Member("argument", spreadElement.Argument);
             }
 
-            public override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+            protected override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
             {
                 using (StartNodeObject(assignmentPattern))
                 {
@@ -741,13 +741,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitArrayPattern(ArrayPattern arrayPattern)
+            protected override void VisitArrayPattern(ArrayPattern arrayPattern)
             {
                 using (StartNodeObject(arrayPattern))
                     Member("elements", arrayPattern.Elements);
             }
 
-            public override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+            protected override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
             {
                 using (StartNodeObject(variableDeclarator))
                 {
@@ -756,7 +756,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+            protected override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
             {
                 using (StartNodeObject(templateLiteral))
                 {
@@ -765,7 +765,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitTemplateElement(TemplateElement templateElement)
+            protected override void VisitTemplateElement(TemplateElement templateElement)
             {
                 using (StartNodeObject(templateElement))
                 {
@@ -778,13 +778,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitRestElement(RestElement restElement)
+            protected override void VisitRestElement(RestElement restElement)
             {
                 using (StartNodeObject(restElement))
                     Member("argument", restElement.Argument);
             }
 
-            public override void VisitProperty(Property property)
+            protected override void VisitProperty(Property property)
             {
                 using (StartNodeObject(property))
                 {
@@ -797,7 +797,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+            protected override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
             {
                 using (StartNodeObject(conditionalExpression))
                 {
@@ -807,7 +807,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitCallExpression(CallExpression callExpression)
+            protected override void VisitCallExpression(CallExpression callExpression)
             {
                 using (StartNodeObject(callExpression))
                 {
@@ -820,7 +820,7 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitBinaryExpression(BinaryExpression binaryExpression)
+            protected override void VisitBinaryExpression(BinaryExpression binaryExpression)
             {
                 using (StartNodeObject(binaryExpression))
                 {
@@ -830,13 +830,13 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitArrayExpression(ArrayExpression arrayExpression)
+            protected override void VisitArrayExpression(ArrayExpression arrayExpression)
             {
                 using (StartNodeObject(arrayExpression))
                     Member("elements", arrayExpression.Elements);
             }
 
-            public override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+            protected override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
             {
                 using (StartNodeObject(assignmentExpression))
                 {
@@ -846,19 +846,19 @@ namespace Esprima.Utils
                 }
             }
 
-            public override void VisitContinueStatement(ContinueStatement continueStatement)
+            protected override void VisitContinueStatement(ContinueStatement continueStatement)
             {
                 using (StartNodeObject(continueStatement))
                     Member("label", continueStatement.Label);
             }
 
-            public override void VisitBreakStatement(BreakStatement breakStatement)
+            protected override void VisitBreakStatement(BreakStatement breakStatement)
             {
                 using (StartNodeObject(breakStatement))
                     Member("label", breakStatement.Label);
             }
 
-            public override void VisitBlockStatement(BlockStatement blockStatement)
+            protected override void VisitBlockStatement(BlockStatement blockStatement)
             {
                 using (StartNodeObject(blockStatement))
                     Member("body", blockStatement.Body, e => (Statement) e);

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -9,7 +9,7 @@ namespace Esprima.Utils
     {
         public bool IsStrictMode { get; set; } = false;
 
-        public virtual void VisitProgram(Program program)
+        protected virtual void VisitProgram(Program program)
         {
             foreach (var statement in program.Body)
             {
@@ -17,7 +17,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitStatement(Statement statement)
+        protected virtual void VisitStatement(Statement statement)
         {
             switch (statement.Type)
             {
@@ -93,18 +93,18 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitUnknownNode(INode node)
+        protected virtual void VisitUnknownNode(INode node)
         {
             throw new NotImplementedException($"AST visitor doesn't support nodes of type {node.Type}, you can override VisitUnknownNode to handle this case.");
         }
 
-        public virtual void VisitCatchClause(CatchClause catchClause)
+        protected virtual void VisitCatchClause(CatchClause catchClause)
         {
             VisitIdentifier(catchClause.Param.As<Identifier>());
             VisitStatement(catchClause.Body);
         }
 
-        public virtual void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        protected virtual void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
         {
             foreach (var p in functionDeclaration.Params)
             {
@@ -114,19 +114,19 @@ namespace Esprima.Utils
             VisitBlockStatement(functionDeclaration.Body);
         }
 
-        public virtual void VisitWithStatement(WithStatement withStatement)
+        protected virtual void VisitWithStatement(WithStatement withStatement)
         {
             VisitExpression(withStatement.Object);
             VisitStatement(withStatement.Body);
         }
 
-        public virtual void VisitWhileStatement(WhileStatement whileStatement)
+        protected virtual void VisitWhileStatement(WhileStatement whileStatement)
         {
             VisitExpression(whileStatement.Test);
             VisitStatement(whileStatement.Body);
         }
 
-        public virtual void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        protected virtual void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
         {
             foreach (var declaration in variableDeclaration.Declarations)
             {
@@ -134,7 +134,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitTryStatement(TryStatement tryStatement)
+        protected virtual void VisitTryStatement(TryStatement tryStatement)
         {
             VisitStatement(tryStatement.Block);
             if (tryStatement.Handler != null)
@@ -150,12 +150,12 @@ namespace Esprima.Utils
 
         }
 
-        public virtual void VisitThrowStatement(ThrowStatement throwStatement)
+        protected virtual void VisitThrowStatement(ThrowStatement throwStatement)
         {
             VisitExpression(throwStatement.Argument);
         }
 
-        public virtual void VisitSwitchStatement(SwitchStatement switchStatement)
+        protected virtual void VisitSwitchStatement(SwitchStatement switchStatement)
         {
             VisitExpression(switchStatement.Discriminant);
             foreach (var c in switchStatement.Cases)
@@ -164,7 +164,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitSwitchCase(SwitchCase switchCase)
+        protected virtual void VisitSwitchCase(SwitchCase switchCase)
         {
             if (switchCase.Test != null)
             {
@@ -177,19 +177,19 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitReturnStatement(ReturnStatement returnStatement)
+        protected virtual void VisitReturnStatement(ReturnStatement returnStatement)
         {
             if (returnStatement.Argument == null)
                 return;
             VisitExpression(returnStatement.Argument);
         }
 
-        public virtual void VisitLabeledStatement(LabeledStatement labeledStatement)
+        protected virtual void VisitLabeledStatement(LabeledStatement labeledStatement)
         {
             VisitStatement(labeledStatement.Body);
         }
 
-        public virtual void VisitIfStatement(IfStatement ifStatement)
+        protected virtual void VisitIfStatement(IfStatement ifStatement)
         {
             VisitExpression(ifStatement.Test);
             VisitStatement(ifStatement.Consequent);
@@ -199,20 +199,20 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitEmptyStatement(EmptyStatement emptyStatement)
+        protected virtual void VisitEmptyStatement(EmptyStatement emptyStatement)
         {
         }
 
-        public virtual void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        protected virtual void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
         {
         }
 
-        public virtual void VisitExpressionStatement(ExpressionStatement expressionStatement)
+        protected virtual void VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
             VisitExpression(expressionStatement.Expression);
         }
 
-        public virtual void VisitForStatement(ForStatement forStatement)
+        protected virtual void VisitForStatement(ForStatement forStatement)
         {
             if (forStatement.Init != null)
             {
@@ -236,7 +236,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitForInStatement(ForInStatement forInStatement)
+        protected virtual void VisitForInStatement(ForInStatement forInStatement)
         {
             Identifier identifier = forInStatement.Left.Type == Nodes.VariableDeclaration
                 ? forInStatement.Left.As<VariableDeclaration>().Declarations.First().Id.As<Identifier>()
@@ -246,13 +246,13 @@ namespace Esprima.Utils
             VisitStatement(forInStatement.Body);
         }
 
-        public virtual void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        protected virtual void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
         {
             VisitStatement(doWhileStatement.Body.As<Statement>());
             VisitExpression(doWhileStatement.Test);
         }
 
-        public virtual void VisitExpression(Expression expression)
+        protected virtual void VisitExpression(Expression expression)
         {
             switch (expression.Type)
             {
@@ -313,7 +313,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+        protected virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
             //Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
             var statement =
@@ -329,20 +329,20 @@ namespace Esprima.Utils
             VisitFunctionExpression(func);
         }
 
-        public virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
         {
             VisitExpression(unaryExpression.Argument);
         }
 
-        public virtual void VisitUpdateExpression(UpdateExpression updateExpression)
+        protected virtual void VisitUpdateExpression(UpdateExpression updateExpression)
         {
         }
 
-        public virtual void VisitThisExpression(ThisExpression thisExpression)
+        protected virtual void VisitThisExpression(ThisExpression thisExpression)
         {
         }
 
-        public virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
+        protected virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
             foreach (var e in sequenceExpression.Expressions)
             {
@@ -350,7 +350,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitObjectExpression(ObjectExpression objectExpression)
+        protected virtual void VisitObjectExpression(ObjectExpression objectExpression)
         {
             foreach (var p in objectExpression.Properties)
             {
@@ -358,7 +358,7 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitNewExpression(NewExpression newExpression)
+        protected virtual void VisitNewExpression(NewExpression newExpression)
         {
             foreach (var e in newExpression.Arguments)
             {
@@ -367,25 +367,25 @@ namespace Esprima.Utils
             VisitExpression(newExpression.Callee);
         }
 
-        public virtual void VisitMemberExpression(MemberExpression memberExpression)
+        protected virtual void VisitMemberExpression(MemberExpression memberExpression)
         {
             VisitExpression(memberExpression.Object);
         }
 
-        public virtual void VisitLogicalExpression(BinaryExpression binaryExpression)
+        protected virtual void VisitLogicalExpression(BinaryExpression binaryExpression)
         {
             VisitBinaryExpression(binaryExpression);
         }
 
-        public virtual void VisitLiteral(Literal literal)
+        protected virtual void VisitLiteral(Literal literal)
         {
         }
 
-        public virtual void VisitIdentifier(Identifier identifier)
+        protected virtual void VisitIdentifier(Identifier identifier)
         {
         }
 
-        public virtual void VisitFunctionExpression(IFunction function)
+        protected virtual void VisitFunctionExpression(IFunction function)
         {
             foreach (var param in function.Params)
             {
@@ -602,98 +602,98 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitClassExpression(ClassExpression classExpression)
+        protected virtual void VisitClassExpression(ClassExpression classExpression)
         {
         }
 
-        public virtual void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected virtual void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
         {
         }
 
-        public virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+        protected virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
         }
 
-        public virtual void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+        protected virtual void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
         {
         }
 
-        public virtual void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+        protected virtual void VisitExportSpecifier(ExportSpecifier exportSpecifier)
         {
         }
 
-        public virtual void VisitImportDeclaration(ImportDeclaration importDeclaration)
+        protected virtual void VisitImportDeclaration(ImportDeclaration importDeclaration)
         {
         }
 
-        public virtual void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        protected virtual void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
         {
         }
 
-        public virtual void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+        protected virtual void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
         }
 
-        public virtual void VisitImportSpecifier(ImportSpecifier importSpecifier)
+        protected virtual void VisitImportSpecifier(ImportSpecifier importSpecifier)
         {
         }
 
-        public virtual void VisitMethodDefinition(MethodDefinition methodDefinitions)
+        protected virtual void VisitMethodDefinition(MethodDefinition methodDefinitions)
         {
         }
 
-        public virtual void VisitForOfStatement(ForOfStatement forOfStatement)
+        protected virtual void VisitForOfStatement(ForOfStatement forOfStatement)
         {
             VisitExpression(forOfStatement.Right);
             Visit(forOfStatement.Left);
             VisitStatement(forOfStatement.Body);
         }
 
-        public virtual void VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected virtual void VisitClassDeclaration(ClassDeclaration classDeclaration)
         {
         }
 
-        public virtual void VisitClassBody(ClassBody classBody)
+        protected virtual void VisitClassBody(ClassBody classBody)
         {
         }
 
-        public virtual void VisitYieldExpression(YieldExpression yieldExpression)
+        protected virtual void VisitYieldExpression(YieldExpression yieldExpression)
         {
         }
 
-        public virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        protected virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
         }
 
-        public virtual void VisitSuper(Super super)
+        protected virtual void VisitSuper(Super super)
         {
         }
 
-        public virtual void VisitMetaProperty(MetaProperty metaProperty)
+        protected virtual void VisitMetaProperty(MetaProperty metaProperty)
         {
         }
 
-        public virtual void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
+        protected virtual void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
         {
         }
 
-        public virtual void VisitObjectPattern(ObjectPattern objectPattern)
+        protected virtual void VisitObjectPattern(ObjectPattern objectPattern)
         {
         }
 
-        public virtual void VisitSpreadElement(SpreadElement spreadElement)
+        protected virtual void VisitSpreadElement(SpreadElement spreadElement)
         {
         }
 
-        public virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
         }
 
-        public virtual void VisitArrayPattern(ArrayPattern arrayPattern)
+        protected virtual void VisitArrayPattern(ArrayPattern arrayPattern)
         {
         }
 
-        public virtual void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        protected virtual void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
         {
             VisitIdentifier(variableDeclarator.Id.As<Identifier>());
             if (variableDeclarator.Init != null)
@@ -702,19 +702,19 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        protected virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
         }
 
-        public virtual void VisitTemplateElement(TemplateElement templateElement)
+        protected virtual void VisitTemplateElement(TemplateElement templateElement)
         {
         }
 
-        public virtual void VisitRestElement(RestElement restElement)
+        protected virtual void VisitRestElement(RestElement restElement)
         {
         }
 
-        public virtual void VisitProperty(Property property)
+        protected virtual void VisitProperty(Property property)
         {
             switch (property.Kind)
             {
@@ -737,14 +737,14 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected virtual void VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
             VisitExpression(conditionalExpression.Test);
             VisitExpression(conditionalExpression.Consequent);
             VisitExpression(conditionalExpression.Alternate);
         }
 
-        public virtual void VisitCallExpression(CallExpression callExpression)
+        protected virtual void VisitCallExpression(CallExpression callExpression)
         {
             VisitExpression(callExpression.Callee);
             if (callExpression.Cached == false)
@@ -756,13 +756,13 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected virtual void VisitBinaryExpression(BinaryExpression binaryExpression)
         {
             VisitExpression(binaryExpression.Left.As<Expression>());
             VisitExpression(binaryExpression.Right.As<Expression>());
         }
 
-        public virtual void VisitArrayExpression(ArrayExpression arrayExpression)
+        protected virtual void VisitArrayExpression(ArrayExpression arrayExpression)
         {
             foreach (var expr in arrayExpression.Elements)
             {
@@ -770,21 +770,21 @@ namespace Esprima.Utils
             }
         }
 
-        public virtual void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected virtual void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
             VisitExpression(assignmentExpression.Left.As<Expression>());
             VisitExpression(assignmentExpression.Right.As<Expression>());
         }
 
-        public virtual void VisitContinueStatement(ContinueStatement continueStatement)
+        protected virtual void VisitContinueStatement(ContinueStatement continueStatement)
         {
         }
 
-        public virtual void VisitBreakStatement(BreakStatement breakStatement)
+        protected virtual void VisitBreakStatement(BreakStatement breakStatement)
         {
         }
 
-        public virtual void VisitBlockStatement(BlockStatement blockStatement)
+        protected virtual void VisitBlockStatement(BlockStatement blockStatement)
         {
             foreach (var statement in blockStatement.Body)
             {

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -9,11 +9,211 @@ namespace Esprima.Utils
     {
         public bool IsStrictMode { get; set; } = false;
 
-        protected virtual void VisitProgram(Program program)
+        public virtual void Visit(INode node)
         {
-            foreach (var statement in program.Body)
+            switch (node.Type)
             {
-                VisitStatement((Statement)statement);
+                case Nodes.AssignmentExpression:
+                    VisitAssignmentExpression(node.As<AssignmentExpression>());
+                    break;
+                case Nodes.ArrayExpression:
+                    VisitArrayExpression(node.As<ArrayExpression>());
+                    break;
+                case Nodes.BlockStatement:
+                    VisitBlockStatement(node.As<BlockStatement>());
+                    break;
+                case Nodes.BinaryExpression:
+                    VisitBinaryExpression(node.As<BinaryExpression>());
+                    break;
+                case Nodes.BreakStatement:
+                    VisitBreakStatement(node.As<BreakStatement>());
+                    break;
+                case Nodes.CallExpression:
+                    VisitCallExpression(node.As<CallExpression>());
+                    break;
+                case Nodes.CatchClause:
+                    VisitCatchClause(node.As<CatchClause>());
+                    break;
+                case Nodes.ConditionalExpression:
+                    VisitConditionalExpression(node.As<ConditionalExpression>());
+                    break;
+                case Nodes.ContinueStatement:
+                    VisitContinueStatement(node.As<ContinueStatement>());
+                    break;
+                case Nodes.DoWhileStatement:
+                    VisitDoWhileStatement(node.As<DoWhileStatement>());
+                    break;
+                case Nodes.DebuggerStatement:
+                    VisitDebuggerStatement(node.As<DebuggerStatement>());
+                    break;
+                case Nodes.EmptyStatement:
+                    VisitEmptyStatement(node.As<EmptyStatement>());
+                    break;
+                case Nodes.ExpressionStatement:
+                    VisitExpressionStatement(node.As<ExpressionStatement>());
+                    break;
+                case Nodes.ForStatement:
+                    VisitForStatement(node.As<ForStatement>());
+                    break;
+                case Nodes.ForInStatement:
+                    VisitForInStatement(node.As<ForInStatement>());
+                    break;
+                case Nodes.FunctionDeclaration:
+                    VisitFunctionDeclaration(node.As<FunctionDeclaration>());
+                    break;
+                case Nodes.FunctionExpression:
+                    VisitFunctionExpression(node.As<FunctionExpression>());
+                    break;
+                case Nodes.Identifier:
+                    VisitIdentifier(node.As<Identifier>());
+                    break;
+                case Nodes.IfStatement:
+                    VisitIfStatement(node.As<IfStatement>());
+                    break;
+                case Nodes.Literal:
+                    VisitLiteral(node.As<Literal>());
+                    break;
+                case Nodes.LabeledStatement:
+                    VisitLabeledStatement(node.As<LabeledStatement>());
+                    break;
+                case Nodes.LogicalExpression:
+                    VisitLogicalExpression(node.As<BinaryExpression>());
+                    break;
+                case Nodes.MemberExpression:
+                    VisitMemberExpression(node.As<MemberExpression>());
+                    break;
+                case Nodes.NewExpression:
+                    VisitNewExpression(node.As<NewExpression>());
+                    break;
+                case Nodes.ObjectExpression:
+                    VisitObjectExpression(node.As<ObjectExpression>());
+                    break;
+                case Nodes.Program:
+                    VisitProgram(node.As<Esprima.Ast.Program>());
+                    break;
+                case Nodes.Property:
+                    VisitProperty(node.As<Property>());
+                    break;
+                case Nodes.RestElement:
+                    VisitRestElement(node.As<RestElement>());
+                    break;
+                case Nodes.ReturnStatement:
+                    VisitReturnStatement(node.As<ReturnStatement>());
+                    break;
+                case Nodes.SequenceExpression:
+                    VisitSequenceExpression(node.As<SequenceExpression>());
+                    break;
+                case Nodes.SwitchStatement:
+                    VisitSwitchStatement(node.As<SwitchStatement>());
+                    break;
+                case Nodes.SwitchCase:
+                    VisitSwitchCase(node.As<SwitchCase>());
+                    break;
+                case Nodes.TemplateElement:
+                    VisitTemplateElement(node.As<TemplateElement>());
+                    break;
+                case Nodes.TemplateLiteral:
+                    VisitTemplateLiteral(node.As<TemplateLiteral>());
+                    break;
+                case Nodes.ThisExpression:
+                    VisitThisExpression(node.As<ThisExpression>());
+                    break;
+                case Nodes.ThrowStatement:
+                    VisitThrowStatement(node.As<ThrowStatement>());
+                    break;
+                case Nodes.TryStatement:
+                    VisitTryStatement(node.As<TryStatement>());
+                    break;
+                case Nodes.UnaryExpression:
+                    VisitUnaryExpression(node.As<UnaryExpression>());
+                    break;
+                case Nodes.UpdateExpression:
+                    VisitUpdateExpression(node.As<UpdateExpression>());
+                    break;
+                case Nodes.VariableDeclaration:
+                    VisitVariableDeclaration(node.As<VariableDeclaration>());
+                    break;
+                case Nodes.VariableDeclarator:
+                    VisitVariableDeclarator(node.As<VariableDeclarator>());
+                    break;
+                case Nodes.WhileStatement:
+                    VisitWhileStatement(node.As<WhileStatement>());
+                    break;
+                case Nodes.WithStatement:
+                    VisitWithStatement(node.As<WithStatement>());
+                    break;
+                case Nodes.ArrayPattern:
+                    VisitArrayPattern(node.As<ArrayPattern>());
+                    break;
+                case Nodes.AssignmentPattern:
+                    VisitAssignmentPattern(node.As<AssignmentPattern>());
+                    break;
+                case Nodes.SpreadElement:
+                    VisitSpreadElement(node.As<SpreadElement>());
+                    break;
+                case Nodes.ObjectPattern:
+                    VisitObjectPattern(node.As<ObjectPattern>());
+                    break;
+                case Nodes.ArrowParameterPlaceHolder:
+                    VisitArrowParameterPlaceHolder(node.As<ArrowParameterPlaceHolder>());
+                    break;
+                case Nodes.MetaProperty:
+                    VisitMetaProperty(node.As<MetaProperty>());
+                    break;
+                case Nodes.Super:
+                    VisitSuper(node.As<Super>());
+                    break;
+                case Nodes.TaggedTemplateExpression:
+                    VisitTaggedTemplateExpression(node.As<TaggedTemplateExpression>());
+                    break;
+                case Nodes.YieldExpression:
+                    VisitYieldExpression(node.As<YieldExpression>());
+                    break;
+                case Nodes.ArrowFunctionExpression:
+                    VisitArrowFunctionExpression(node.As<ArrowFunctionExpression>());
+                    break;
+                case Nodes.ClassBody:
+                    VisitClassBody(node.As<ClassBody>());
+                    break;
+                case Nodes.ClassDeclaration:
+                    VisitClassDeclaration(node.As<ClassDeclaration>());
+                    break;
+                case Nodes.ForOfStatement:
+                    VisitForOfStatement(node.As<ForOfStatement>());
+                    break;
+                case Nodes.MethodDefinition:
+                    VisitMethodDefinition(node.As<MethodDefinition>());
+                    break;
+                case Nodes.ImportSpecifier:
+                    VisitImportSpecifier(node.As<ImportSpecifier>());
+                    break;
+                case Nodes.ImportDefaultSpecifier:
+                    VisitImportDefaultSpecifier(node.As<ImportDefaultSpecifier>());
+                    break;
+                case Nodes.ImportNamespaceSpecifier:
+                    VisitImportNamespaceSpecifier(node.As<ImportNamespaceSpecifier>());
+                    break;
+                case Nodes.ImportDeclaration:
+                    VisitImportDeclaration(node.As<ImportDeclaration>());
+                    break;
+                case Nodes.ExportSpecifier:
+                    VisitExportSpecifier(node.As<ExportSpecifier>());
+                    break;
+                case Nodes.ExportNamedDeclaration:
+                    VisitExportNamedDeclaration(node.As<ExportNamedDeclaration>());
+                    break;
+                case Nodes.ExportAllDeclaration:
+                    VisitExportAllDeclaration(node.As<ExportAllDeclaration>());
+                    break;
+                case Nodes.ExportDefaultDeclaration:
+                    VisitExportDefaultDeclaration(node.As<ExportDefaultDeclaration>());
+                    break;
+                case Nodes.ClassExpression:
+                    VisitClassExpression(node.As<ClassExpression>());
+                    break;
+                default:
+                    VisitUnknownNode(node);
+                    break;
             }
         }
 
@@ -90,6 +290,14 @@ namespace Esprima.Utils
                 default:
                     VisitUnknownNode(statement);
                     break;
+            }
+        }
+
+        protected virtual void VisitProgram(Program program)
+        {
+            foreach (var statement in program.Body)
+            {
+                VisitStatement((Statement)statement);
             }
         }
 
@@ -392,214 +600,6 @@ namespace Esprima.Utils
                 Visit(param);
             }
             VisitBlockStatement(function.Body);
-        }
-
-        public virtual void Visit(INode node)
-        {
-            switch (node.Type)
-            {
-                case Nodes.AssignmentExpression:
-                    VisitAssignmentExpression(node.As<AssignmentExpression>());
-                    break;
-                case Nodes.ArrayExpression:
-                    VisitArrayExpression(node.As<ArrayExpression>());
-                    break;
-                case Nodes.BlockStatement:
-                    VisitBlockStatement(node.As<BlockStatement>());
-                    break;
-                case Nodes.BinaryExpression:
-                    VisitBinaryExpression(node.As<BinaryExpression>());
-                    break;
-                case Nodes.BreakStatement:
-                    VisitBreakStatement(node.As<BreakStatement>());
-                    break;
-                case Nodes.CallExpression:
-                    VisitCallExpression(node.As<CallExpression>());
-                    break;
-                case Nodes.CatchClause:
-                    VisitCatchClause(node.As<CatchClause>());
-                    break;
-                case Nodes.ConditionalExpression:
-                    VisitConditionalExpression(node.As<ConditionalExpression>());
-                    break;
-                case Nodes.ContinueStatement:
-                    VisitContinueStatement(node.As<ContinueStatement>());
-                    break;
-                case Nodes.DoWhileStatement:
-                    VisitDoWhileStatement(node.As<DoWhileStatement>());
-                    break;
-                case Nodes.DebuggerStatement:
-                    VisitDebuggerStatement(node.As<DebuggerStatement>());
-                    break;
-                case Nodes.EmptyStatement:
-                    VisitEmptyStatement(node.As<EmptyStatement>());
-                    break;
-                case Nodes.ExpressionStatement:
-                    VisitExpressionStatement(node.As<ExpressionStatement>());
-                    break;
-                case Nodes.ForStatement:
-                    VisitForStatement(node.As<ForStatement>());
-                    break;
-                case Nodes.ForInStatement:
-                    VisitForInStatement(node.As<ForInStatement>());
-                    break;
-                case Nodes.FunctionDeclaration:
-                    VisitFunctionDeclaration(node.As<FunctionDeclaration>());
-                    break;
-                case Nodes.FunctionExpression:
-                    VisitFunctionExpression(node.As<FunctionExpression>());
-                    break;
-                case Nodes.Identifier:
-                    VisitIdentifier(node.As<Identifier>());
-                    break;
-                case Nodes.IfStatement:
-                    VisitIfStatement(node.As<IfStatement>());
-                    break;
-                case Nodes.Literal:
-                    VisitLiteral(node.As<Literal>());
-                    break;
-                case Nodes.LabeledStatement:
-                    VisitLabeledStatement(node.As<LabeledStatement>());
-                    break;
-                case Nodes.LogicalExpression:
-                    VisitLogicalExpression(node.As<BinaryExpression>());
-                    break;
-                case Nodes.MemberExpression:
-                    VisitMemberExpression(node.As<MemberExpression>());
-                    break;
-                case Nodes.NewExpression:
-                    VisitNewExpression(node.As<NewExpression>());
-                    break;
-                case Nodes.ObjectExpression:
-                    VisitObjectExpression(node.As<ObjectExpression>());
-                    break;
-                case Nodes.Program:
-                    VisitProgram(node.As<Esprima.Ast.Program>());
-                    break;
-                case Nodes.Property:
-                    VisitProperty(node.As<Property>());
-                    break;
-                case Nodes.RestElement:
-                    VisitRestElement(node.As<RestElement>());
-                    break;
-                case Nodes.ReturnStatement:
-                    VisitReturnStatement(node.As<ReturnStatement>());
-                    break;
-                case Nodes.SequenceExpression:
-                    VisitSequenceExpression(node.As<SequenceExpression>());
-                    break;
-                case Nodes.SwitchStatement:
-                    VisitSwitchStatement(node.As<SwitchStatement>());
-                    break;
-                case Nodes.SwitchCase:
-                    VisitSwitchCase(node.As<SwitchCase>());
-                    break;
-                case Nodes.TemplateElement:
-                    VisitTemplateElement(node.As<TemplateElement>());
-                    break;
-                case Nodes.TemplateLiteral:
-                    VisitTemplateLiteral(node.As<TemplateLiteral>());
-                    break;
-                case Nodes.ThisExpression:
-                    VisitThisExpression(node.As<ThisExpression>());
-                    break;
-                case Nodes.ThrowStatement:
-                    VisitThrowStatement(node.As<ThrowStatement>());
-                    break;
-                case Nodes.TryStatement:
-                    VisitTryStatement(node.As<TryStatement>());
-                    break;
-                case Nodes.UnaryExpression:
-                    VisitUnaryExpression(node.As<UnaryExpression>());
-                    break;
-                case Nodes.UpdateExpression:
-                    VisitUpdateExpression(node.As<UpdateExpression>());
-                    break;
-                case Nodes.VariableDeclaration:
-                    VisitVariableDeclaration(node.As<VariableDeclaration>());
-                    break;
-                case Nodes.VariableDeclarator:
-                    VisitVariableDeclarator(node.As<VariableDeclarator>());
-                    break;
-                case Nodes.WhileStatement:
-                    VisitWhileStatement(node.As<WhileStatement>());
-                    break;
-                case Nodes.WithStatement:
-                    VisitWithStatement(node.As<WithStatement>());
-                    break;
-                case Nodes.ArrayPattern:
-                    VisitArrayPattern(node.As<ArrayPattern>());
-                    break;
-                case Nodes.AssignmentPattern:
-                    VisitAssignmentPattern(node.As<AssignmentPattern>());
-                    break;
-                case Nodes.SpreadElement:
-                    VisitSpreadElement(node.As<SpreadElement>());
-                    break;
-                case Nodes.ObjectPattern:
-                    VisitObjectPattern(node.As<ObjectPattern>());
-                    break;
-                case Nodes.ArrowParameterPlaceHolder:
-                    VisitArrowParameterPlaceHolder(node.As<ArrowParameterPlaceHolder>());
-                    break;
-                case Nodes.MetaProperty:
-                    VisitMetaProperty(node.As<MetaProperty>());
-                    break;
-                case Nodes.Super:
-                    VisitSuper(node.As<Super>());
-                    break;
-                case Nodes.TaggedTemplateExpression:
-                    VisitTaggedTemplateExpression(node.As<TaggedTemplateExpression>());
-                    break;
-                case Nodes.YieldExpression:
-                    VisitYieldExpression(node.As<YieldExpression>());
-                    break;
-                case Nodes.ArrowFunctionExpression:
-                    VisitArrowFunctionExpression(node.As<ArrowFunctionExpression>());
-                    break;
-                case Nodes.ClassBody:
-                    VisitClassBody(node.As<ClassBody>());
-                    break;
-                case Nodes.ClassDeclaration:
-                    VisitClassDeclaration(node.As<ClassDeclaration>());
-                    break;
-                case Nodes.ForOfStatement:
-                    VisitForOfStatement(node.As<ForOfStatement>());
-                    break;
-                case Nodes.MethodDefinition:
-                    VisitMethodDefinition(node.As<MethodDefinition>());
-                    break;
-                case Nodes.ImportSpecifier:
-                    VisitImportSpecifier(node.As<ImportSpecifier>());
-                    break;
-                case Nodes.ImportDefaultSpecifier:
-                    VisitImportDefaultSpecifier(node.As<ImportDefaultSpecifier>());
-                    break;
-                case Nodes.ImportNamespaceSpecifier:
-                    VisitImportNamespaceSpecifier(node.As<ImportNamespaceSpecifier>());
-                    break;
-                case Nodes.ImportDeclaration:
-                    VisitImportDeclaration(node.As<ImportDeclaration>());
-                    break;
-                case Nodes.ExportSpecifier:
-                    VisitExportSpecifier(node.As<ExportSpecifier>());
-                    break;
-                case Nodes.ExportNamedDeclaration:
-                    VisitExportNamedDeclaration(node.As<ExportNamedDeclaration>());
-                    break;
-                case Nodes.ExportAllDeclaration:
-                    VisitExportAllDeclaration(node.As<ExportAllDeclaration>());
-                    break;
-                case Nodes.ExportDefaultDeclaration:
-                    VisitExportDefaultDeclaration(node.As<ExportDefaultDeclaration>());
-                    break;
-                case Nodes.ClassExpression:
-                    VisitClassExpression(node.As<ClassExpression>());
-                    break;
-                default:
-                    VisitUnknownNode(node);
-                    break;
-            }
         }
 
         protected virtual void VisitClassExpression(ClassExpression classExpression)

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -156,476 +156,476 @@ namespace Esprima.Utils
             VisitedNode?.Invoke(this, node);
         }
 
-        public override void VisitProgram(Program program)
+        protected override void VisitProgram(Program program)
         {
             VisitingProgram?.Invoke(this, program);
             base.VisitProgram(program);
             VisitedProgram?.Invoke(this, program);
         }
 
-        public override void VisitStatement(Statement statement)
+        protected override void VisitStatement(Statement statement)
         {
             VisitingStatement?.Invoke(this, statement);
             base.VisitStatement(statement);
             VisitedStatement?.Invoke(this, statement);
         }
 
-        public override void VisitUnknownNode(INode node)
+        protected override void VisitUnknownNode(INode node)
         {
             VisitingUnknownNode?.Invoke(this, node);
             base.VisitUnknownNode(node);
             VisitedUnknownNode?.Invoke(this, node);
         }
 
-        public override void VisitCatchClause(CatchClause catchClause)
+        protected override void VisitCatchClause(CatchClause catchClause)
         {
             VisitingCatchClause?.Invoke(this, catchClause);
             base.VisitCatchClause(catchClause);
             VisitedCatchClause?.Invoke(this, catchClause);
         }
 
-        public override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        protected override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
         {
             VisitingFunctionDeclaration?.Invoke(this, functionDeclaration);
             base.VisitFunctionDeclaration(functionDeclaration);
             VisitedFunctionDeclaration?.Invoke(this, functionDeclaration);
         }
 
-        public override void VisitWithStatement(WithStatement withStatement)
+        protected override void VisitWithStatement(WithStatement withStatement)
         {
             VisitingWithStatement?.Invoke(this, withStatement);
             base.VisitWithStatement(withStatement);
             VisitedWithStatement?.Invoke(this, withStatement);
         }
 
-        public override void VisitWhileStatement(WhileStatement whileStatement)
+        protected override void VisitWhileStatement(WhileStatement whileStatement)
         {
             VisitingWhileStatement?.Invoke(this, whileStatement);
             base.VisitWhileStatement(whileStatement);
             VisitedWhileStatement?.Invoke(this, whileStatement);
         }
 
-        public override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        protected override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
         {
             VisitingVariableDeclaration?.Invoke(this, variableDeclaration);
             base.VisitVariableDeclaration(variableDeclaration);
             VisitedVariableDeclaration?.Invoke(this, variableDeclaration);
         }
 
-        public override void VisitTryStatement(TryStatement tryStatement)
+        protected override void VisitTryStatement(TryStatement tryStatement)
         {
             VisitingTryStatement?.Invoke(this, tryStatement);
             base.VisitTryStatement(tryStatement);
             VisitedTryStatement?.Invoke(this, tryStatement);
         }
 
-        public override void VisitThrowStatement(ThrowStatement throwStatement)
+        protected override void VisitThrowStatement(ThrowStatement throwStatement)
         {
             VisitingThrowStatement?.Invoke(this, throwStatement);
             base.VisitThrowStatement(throwStatement);
             VisitedThrowStatement?.Invoke(this, throwStatement);
         }
 
-        public override void VisitSwitchStatement(SwitchStatement switchStatement)
+        protected override void VisitSwitchStatement(SwitchStatement switchStatement)
         {
             VisitingSwitchStatement?.Invoke(this, switchStatement);
             base.VisitSwitchStatement(switchStatement);
             VisitedSwitchStatement?.Invoke(this, switchStatement);
         }
 
-        public override void VisitSwitchCase(SwitchCase switchCase)
+        protected override void VisitSwitchCase(SwitchCase switchCase)
         {
             VisitingSwitchCase?.Invoke(this, switchCase);
             base.VisitSwitchCase(switchCase);
             VisitedSwitchCase?.Invoke(this, switchCase);
         }
 
-        public override void VisitReturnStatement(ReturnStatement returnStatement)
+        protected override void VisitReturnStatement(ReturnStatement returnStatement)
         {
             VisitingReturnStatement?.Invoke(this, returnStatement);
             base.VisitReturnStatement(returnStatement);
             VisitedReturnStatement?.Invoke(this, returnStatement);
         }
 
-        public override void VisitLabeledStatement(LabeledStatement labeledStatement)
+        protected override void VisitLabeledStatement(LabeledStatement labeledStatement)
         {
             VisitingLabeledStatement?.Invoke(this, labeledStatement);
             base.VisitLabeledStatement(labeledStatement);
             VisitedLabeledStatement?.Invoke(this, labeledStatement);
         }
 
-        public override void VisitIfStatement(IfStatement ifStatement)
+        protected override void VisitIfStatement(IfStatement ifStatement)
         {
             VisitingIfStatement?.Invoke(this, ifStatement);
             base.VisitIfStatement(ifStatement);
             VisitedIfStatement?.Invoke(this, ifStatement);
         }
 
-        public override void VisitEmptyStatement(EmptyStatement emptyStatement)
+        protected override void VisitEmptyStatement(EmptyStatement emptyStatement)
         {
             VisitingEmptyStatement?.Invoke(this, emptyStatement);
             base.VisitEmptyStatement(emptyStatement);
             VisitedEmptyStatement?.Invoke(this, emptyStatement);
         }
 
-        public override void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        protected override void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
         {
             VisitingDebuggerStatement?.Invoke(this, debuggerStatement);
             base.VisitDebuggerStatement(debuggerStatement);
             VisitedDebuggerStatement?.Invoke(this, debuggerStatement);
         }
 
-        public override void VisitExpressionStatement(ExpressionStatement expressionStatement)
+        protected override void VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
             VisitingExpressionStatement?.Invoke(this, expressionStatement);
             base.VisitExpressionStatement(expressionStatement);
             VisitedExpressionStatement?.Invoke(this, expressionStatement);
         }
 
-        public override void VisitForStatement(ForStatement forStatement)
+        protected override void VisitForStatement(ForStatement forStatement)
         {
             VisitingForStatement?.Invoke(this, forStatement);
             base.VisitForStatement(forStatement);
             VisitedForStatement?.Invoke(this, forStatement);
         }
 
-        public override void VisitForInStatement(ForInStatement forInStatement)
+        protected override void VisitForInStatement(ForInStatement forInStatement)
         {
             VisitingForInStatement?.Invoke(this, forInStatement);
             base.VisitForInStatement(forInStatement);
             VisitedForInStatement?.Invoke(this, forInStatement);
         }
 
-        public override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        protected override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
         {
             VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
             base.VisitDoWhileStatement(doWhileStatement);
             VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
         }
 
-        public override void VisitExpression(Expression expression)
+        protected override void VisitExpression(Expression expression)
         {
             VisitingExpression?.Invoke(this, expression);
             base.VisitExpression(expression);
             VisitedExpression?.Invoke(this, expression);
         }
 
-        public override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+        protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
             VisitingArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
             base.VisitArrowFunctionExpression(arrowFunctionExpression);
             VisitedArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
         }
 
-        public override void VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected override void VisitUnaryExpression(UnaryExpression unaryExpression)
         {
             VisitingUnaryExpression?.Invoke(this, unaryExpression);
             base.VisitUnaryExpression(unaryExpression);
             VisitedUnaryExpression?.Invoke(this, unaryExpression);
         }
 
-        public override void VisitUpdateExpression(UpdateExpression updateExpression)
+        protected override void VisitUpdateExpression(UpdateExpression updateExpression)
         {
             VisitingUpdateExpression?.Invoke(this, updateExpression);
             base.VisitUpdateExpression(updateExpression);
             VisitedUpdateExpression?.Invoke(this, updateExpression);
         }
 
-        public override void VisitThisExpression(ThisExpression thisExpression)
+        protected override void VisitThisExpression(ThisExpression thisExpression)
         {
             VisitingThisExpression?.Invoke(this, thisExpression);
             base.VisitThisExpression(thisExpression);
             VisitedThisExpression?.Invoke(this, thisExpression);
         }
 
-        public override void VisitSequenceExpression(SequenceExpression sequenceExpression)
+        protected override void VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
             VisitingSequenceExpression?.Invoke(this, sequenceExpression);
             base.VisitSequenceExpression(sequenceExpression);
             VisitedSequenceExpression?.Invoke(this, sequenceExpression);
         }
 
-        public override void VisitObjectExpression(ObjectExpression objectExpression)
+        protected override void VisitObjectExpression(ObjectExpression objectExpression)
         {
             VisitingObjectExpression?.Invoke(this, objectExpression);
             base.VisitObjectExpression(objectExpression);
             VisitedObjectExpression?.Invoke(this, objectExpression);
         }
 
-        public override void VisitNewExpression(NewExpression newExpression)
+        protected override void VisitNewExpression(NewExpression newExpression)
         {
             VisitingNewExpression?.Invoke(this, newExpression);
             base.VisitNewExpression(newExpression);
             VisitedNewExpression?.Invoke(this, newExpression);
         }
 
-        public override void VisitMemberExpression(MemberExpression memberExpression)
+        protected override void VisitMemberExpression(MemberExpression memberExpression)
         {
             VisitingMemberExpression?.Invoke(this, memberExpression);
             base.VisitMemberExpression(memberExpression);
             VisitedMemberExpression?.Invoke(this, memberExpression);
         }
 
-        public override void VisitLogicalExpression(BinaryExpression binaryExpression)
+        protected override void VisitLogicalExpression(BinaryExpression binaryExpression)
         {
             VisitingLogicalExpression?.Invoke(this, binaryExpression);
             base.VisitLogicalExpression(binaryExpression);
             VisitedLogicalExpression?.Invoke(this, binaryExpression);
         }
 
-        public override void VisitLiteral(Literal literal)
+        protected override void VisitLiteral(Literal literal)
         {
             VisitingLiteral?.Invoke(this, literal);
             base.VisitLiteral(literal);
             VisitedLiteral?.Invoke(this, literal);
         }
 
-        public override void VisitIdentifier(Identifier identifier)
+        protected override void VisitIdentifier(Identifier identifier)
         {
             VisitingIdentifier?.Invoke(this, identifier);
             base.VisitIdentifier(identifier);
             VisitedIdentifier?.Invoke(this, identifier);
         }
 
-        public override void VisitFunctionExpression(IFunction function)
+        protected override void VisitFunctionExpression(IFunction function)
         {
             VisitingFunctionExpression?.Invoke(this, function);
             base.VisitFunctionExpression(function);
             VisitedFunctionExpression?.Invoke(this, function);
         }
 
-        public override void VisitClassExpression(ClassExpression classExpression)
+        protected override void VisitClassExpression(ClassExpression classExpression)
         {
             VisitingClassExpression?.Invoke(this, classExpression);
             base.VisitClassExpression(classExpression);
             VisitedClassExpression?.Invoke(this, classExpression);
         }
 
-        public override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
         {
             VisitingExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
             base.VisitExportDefaultDeclaration(exportDefaultDeclaration);
             VisitedExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
         }
 
-        public override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+        protected override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
             VisitingExportAllDeclaration?.Invoke(this, exportAllDeclaration);
             base.VisitExportAllDeclaration(exportAllDeclaration);
             VisitedExportAllDeclaration?.Invoke(this, exportAllDeclaration);
         }
 
-        public override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+        protected override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
         {
             VisitingExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
             base.VisitExportNamedDeclaration(exportNamedDeclaration);
             VisitedExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
         }
 
-        public override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+        protected override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
         {
             VisitingExportSpecifier?.Invoke(this, exportSpecifier);
             base.VisitExportSpecifier(exportSpecifier);
             VisitedExportSpecifier?.Invoke(this, exportSpecifier);
         }
 
-        public override void VisitImportDeclaration(ImportDeclaration importDeclaration)
+        protected override void VisitImportDeclaration(ImportDeclaration importDeclaration)
         {
             VisitingImportDeclaration?.Invoke(this, importDeclaration);
             base.VisitImportDeclaration(importDeclaration);
             VisitedImportDeclaration?.Invoke(this, importDeclaration);
         }
 
-        public override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        protected override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
         {
             VisitingImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
             base.VisitImportNamespaceSpecifier(importNamespaceSpecifier);
             VisitedImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
         }
 
-        public override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+        protected override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
             VisitingImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
             base.VisitImportDefaultSpecifier(importDefaultSpecifier);
             VisitedImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
         }
 
-        public override void VisitImportSpecifier(ImportSpecifier importSpecifier)
+        protected override void VisitImportSpecifier(ImportSpecifier importSpecifier)
         {
             VisitingImportSpecifier?.Invoke(this, importSpecifier);
             base.VisitImportSpecifier(importSpecifier);
             VisitedImportSpecifier?.Invoke(this, importSpecifier);
         }
 
-        public override void VisitMethodDefinition(MethodDefinition methodDefinitions)
+        protected override void VisitMethodDefinition(MethodDefinition methodDefinitions)
         {
             VisitingMethodDefinition?.Invoke(this, methodDefinitions);
             base.VisitMethodDefinition(methodDefinitions);
             VisitedMethodDefinition?.Invoke(this, methodDefinitions);
         }
 
-        public override void VisitForOfStatement(ForOfStatement forOfStatement)
+        protected override void VisitForOfStatement(ForOfStatement forOfStatement)
         {
             VisitingForOfStatement?.Invoke(this, forOfStatement);
             base.VisitForOfStatement(forOfStatement);
             VisitedForOfStatement?.Invoke(this, forOfStatement);
         }
 
-        public override void VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected override void VisitClassDeclaration(ClassDeclaration classDeclaration)
         {
             VisitingClassDeclaration?.Invoke(this, classDeclaration);
             base.VisitClassDeclaration(classDeclaration);
             VisitedClassDeclaration?.Invoke(this, classDeclaration);
         }
 
-        public override void VisitClassBody(ClassBody classBody)
+        protected override void VisitClassBody(ClassBody classBody)
         {
             VisitingClassBody?.Invoke(this, classBody);
             base.VisitClassBody(classBody);
             VisitedClassBody?.Invoke(this, classBody);
         }
 
-        public override void VisitYieldExpression(YieldExpression yieldExpression)
+        protected override void VisitYieldExpression(YieldExpression yieldExpression)
         {
             VisitingYieldExpression?.Invoke(this, yieldExpression);
             base.VisitYieldExpression(yieldExpression);
             VisitedYieldExpression?.Invoke(this, yieldExpression);
         }
 
-        public override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        protected override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
             VisitingTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
             base.VisitTaggedTemplateExpression(taggedTemplateExpression);
             VisitedTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
         }
 
-        public override void VisitSuper(Super super)
+        protected override void VisitSuper(Super super)
         {
             VisitingSuper?.Invoke(this, super);
             base.VisitSuper(super);
             VisitedSuper?.Invoke(this, super);
         }
 
-        public override void VisitMetaProperty(MetaProperty metaProperty)
+        protected override void VisitMetaProperty(MetaProperty metaProperty)
         {
             VisitingMetaProperty?.Invoke(this, metaProperty);
             base.VisitMetaProperty(metaProperty);
             VisitedMetaProperty?.Invoke(this, metaProperty);
         }
 
-        public override void VisitObjectPattern(ObjectPattern objectPattern)
+        protected override void VisitObjectPattern(ObjectPattern objectPattern)
         {
             VisitingObjectPattern?.Invoke(this, objectPattern);
             base.VisitObjectPattern(objectPattern);
             VisitedObjectPattern?.Invoke(this, objectPattern);
         }
 
-        public override void VisitSpreadElement(SpreadElement spreadElement)
+        protected override void VisitSpreadElement(SpreadElement spreadElement)
         {
             VisitingSpreadElement?.Invoke(this, spreadElement);
             base.VisitSpreadElement(spreadElement);
             VisitedSpreadElement?.Invoke(this, spreadElement);
         }
 
-        public override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
             VisitingAssignmentPattern?.Invoke(this, assignmentPattern);
             base.VisitAssignmentPattern(assignmentPattern);
             VisitedAssignmentPattern?.Invoke(this, assignmentPattern);
         }
 
-        public override void VisitArrayPattern(ArrayPattern arrayPattern)
+        protected override void VisitArrayPattern(ArrayPattern arrayPattern)
         {
             VisitingArrayPattern?.Invoke(this, arrayPattern);
             base.VisitArrayPattern(arrayPattern);
             VisitedArrayPattern?.Invoke(this, arrayPattern);
         }
 
-        public override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        protected override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
         {
             VisitingVariableDeclarator?.Invoke(this, variableDeclarator);
             base.VisitVariableDeclarator(variableDeclarator);
             VisitedVariableDeclarator?.Invoke(this, variableDeclarator);
         }
 
-        public override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        protected override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
             VisitingTemplateLiteral?.Invoke(this, templateLiteral);
             base.VisitTemplateLiteral(templateLiteral);
             VisitedTemplateLiteral?.Invoke(this, templateLiteral);
         }
 
-        public override void VisitTemplateElement(TemplateElement templateElement)
+        protected override void VisitTemplateElement(TemplateElement templateElement)
         {
             VisitingTemplateElement?.Invoke(this, templateElement);
             base.VisitTemplateElement(templateElement);
             VisitedTemplateElement?.Invoke(this, templateElement);
         }
 
-        public override void VisitRestElement(RestElement restElement)
+        protected override void VisitRestElement(RestElement restElement)
         {
             VisitingRestElement?.Invoke(this, restElement);
             base.VisitRestElement(restElement);
             VisitedRestElement?.Invoke(this, restElement);
         }
 
-        public override void VisitProperty(Property property)
+        protected override void VisitProperty(Property property)
         {
             VisitingProperty?.Invoke(this, property);
             base.VisitProperty(property);
             VisitedProperty?.Invoke(this, property);
         }
 
-        public override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
             VisitingConditionalExpression?.Invoke(this, conditionalExpression);
             base.VisitConditionalExpression(conditionalExpression);
             VisitedConditionalExpression?.Invoke(this, conditionalExpression);
         }
 
-        public override void VisitCallExpression(CallExpression callExpression)
+        protected override void VisitCallExpression(CallExpression callExpression)
         {
             VisitingCallExpression?.Invoke(this, callExpression);
             base.VisitCallExpression(callExpression);
             VisitedCallExpression?.Invoke(this, callExpression);
         }
 
-        public override void VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected override void VisitBinaryExpression(BinaryExpression binaryExpression)
         {
             VisitingBinaryExpression?.Invoke(this, binaryExpression);
             base.VisitBinaryExpression(binaryExpression);
             VisitedBinaryExpression?.Invoke(this, binaryExpression);
         }
 
-        public override void VisitArrayExpression(ArrayExpression arrayExpression)
+        protected override void VisitArrayExpression(ArrayExpression arrayExpression)
         {
             VisitingArrayExpression?.Invoke(this, arrayExpression);
             base.VisitArrayExpression(arrayExpression);
             VisitedArrayExpression?.Invoke(this, arrayExpression);
         }
 
-        public override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
             VisitingAssignmentExpression?.Invoke(this, assignmentExpression);
             base.VisitAssignmentExpression(assignmentExpression);
             VisitedAssignmentExpression?.Invoke(this, assignmentExpression);
         }
 
-        public override void VisitContinueStatement(ContinueStatement continueStatement)
+        protected override void VisitContinueStatement(ContinueStatement continueStatement)
         {
             VisitingContinueStatement?.Invoke(this, continueStatement);
             base.VisitContinueStatement(continueStatement);
             VisitedContinueStatement?.Invoke(this, continueStatement);
         }
 
-        public override void VisitBreakStatement(BreakStatement breakStatement)
+        protected override void VisitBreakStatement(BreakStatement breakStatement)
         {
             VisitingBreakStatement?.Invoke(this, breakStatement);
             base.VisitBreakStatement(breakStatement);
             VisitedBreakStatement?.Invoke(this, breakStatement);
         }
 
-        public override void VisitBlockStatement(BlockStatement blockStatement)
+        protected override void VisitBlockStatement(BlockStatement blockStatement)
         {
             VisitingBlockStatement?.Invoke(this, blockStatement);
             base.VisitBlockStatement(blockStatement);

--- a/test/Esprima.Tests/VisitorTests.cs
+++ b/test/Esprima.Tests/VisitorTests.cs
@@ -12,9 +12,9 @@ namespace Esprima.Tests
             var program = parser.ParseProgram();
 
             AstVisitor visitor = new AstVisitor();
-            visitor.VisitProgram(program);
+            visitor.Visit(program);
         }
-        
+
         [Fact]
         public void CanVisitSwitchCase()
         {
@@ -26,9 +26,9 @@ namespace Esprima.Tests
             var program = parser.ParseProgram();
 
             AstVisitor visitor = new AstVisitor();
-            visitor.VisitProgram(program);
+            visitor.Visit(program);
         }
-        
+
         [Fact]
         public void CanVisitDefaultSwitchCase()
         {
@@ -40,9 +40,9 @@ namespace Esprima.Tests
             var program = parser.ParseProgram();
 
             AstVisitor visitor = new AstVisitor();
-            visitor.VisitProgram(program);
+            visitor.Visit(program);
         }
-        
+
         [Fact]
         public void CanVisitForWithNoTest()
         {
@@ -50,9 +50,9 @@ namespace Esprima.Tests
             var program = parser.ParseProgram();
 
             AstVisitor visitor = new AstVisitor();
-            visitor.VisitProgram(program);
+            visitor.Visit(program);
         }
-        
+
         [Fact]
         public void CanVisitForOfStatement()
         {
@@ -60,7 +60,7 @@ namespace Esprima.Tests
             var program = parser.ParseProgram();
 
             AstVisitor visitor = new AstVisitor();
-            visitor.VisitProgram(program);
+            visitor.Visit(program);
         }
     }
 }


### PR DESCRIPTION
This PR proposes to render all members of `AstVisitor` except `Visit(INode)`, the entry-point, to be secured for protected access by subclasses only. There doesn't seem to be any good reason to have  them public.