### PR TITLE
Fix AstVisitor bugs that miss a few nodes

### DIFF
--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -579,6 +579,7 @@ namespace Esprima.Utils
         protected virtual void VisitMemberExpression(MemberExpression memberExpression)
         {
             VisitExpression(memberExpression.Object);
+            VisitExpression(memberExpression.Property);
         }
 
         protected virtual void VisitLogicalExpression(BinaryExpression binaryExpression)

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -544,6 +544,7 @@ namespace Esprima.Utils
 
         protected virtual void VisitUpdateExpression(UpdateExpression updateExpression)
         {
+            VisitExpression(updateExpression.Argument);
         }
 
         protected virtual void VisitThisExpression(ThisExpression thisExpression)

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -718,6 +718,8 @@ namespace Esprima.Utils
 
         protected virtual void VisitProperty(Property property)
         {
+            VisitExpression(property.Key);
+
             switch (property.Kind)
             {
                 case PropertyKind.Init:

--- a/test/Esprima.Tests/AstVisitorEventSourceTests.cs
+++ b/test/Esprima.Tests/AstVisitorEventSourceTests.cs
@@ -1,0 +1,68 @@
+using System.Collections.Generic;
+using System.Linq;
+using Esprima.Ast;
+using Esprima.Utils;
+using Xunit;
+
+namespace Esprima.Tests
+{
+    public class AstVisitorEventSourceTests
+    {
+        static T ParseExpression<T>(string code) where T : class, Expression =>
+            new JavaScriptParser(code).ParseExpression().As<T>();
+
+        [Fact]
+        public void MemberExpression()
+        {
+            var expression = ParseExpression<MemberExpression>("foo.bar");
+
+            var visitor = new AstVisitorEventSource();
+            MemberExpression memberExpression = null;
+            var identifiers = new List<Identifier>();
+            visitor.VisitingMemberExpression += (_, arg) => memberExpression = arg;
+            visitor.VisitedIdentifier += (_, arg) => identifiers.Add(arg);
+            visitor.Visit(expression);
+
+            Assert.Same(expression, memberExpression);
+            Assert.Equal(2, identifiers.Count);
+            Assert.Same(expression.Object, identifiers[0]);
+            Assert.Same(expression.Property, identifiers[1]);
+        }
+
+        [Fact]
+        public void Property()
+        {
+            var expression = ParseExpression<ObjectExpression>("{ x: 42 }");
+
+            var visitor = new AstVisitorEventSource();
+            Property property = null;
+            Identifier key = null;
+            Literal value = null;
+            visitor.VisitingProperty += (_, arg) => property = arg;
+            visitor.VisitedIdentifier += (_, arg) => key = arg;
+            visitor.VisitedLiteral += (_, arg) => value = arg;
+            visitor.Visit(expression);
+
+            var expectedProperty = expression.Properties.Single();
+            Assert.Same(expectedProperty, property);
+            Assert.Same(expectedProperty.Key, key);
+            Assert.Same(expectedProperty.Value, value);
+        }
+
+        [Fact]
+        public void UpdateExpression()
+        {
+            var expression = ParseExpression<UpdateExpression>("x++");
+
+            var visitor = new AstVisitorEventSource();
+            UpdateExpression updateExpression = null;
+            Identifier argument = null;
+            visitor.VisitingUpdateExpression += (_, arg) => updateExpression = arg;
+            visitor.VisitedIdentifier += (_, arg) => argument = arg;
+            visitor.Visit(expression);
+
+            Assert.Same(expression, updateExpression);
+            Assert.Same(expression.Argument, argument);
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes a few bugs in `AstVisitor`. These surfaced after using the feature proposed in PR #77 and comparing the nodes returned by `DescendantNodesAndSelf` versus nodes visited by `AstVisitorEventSource` via its base implementation `AstVisitor`. Below is the test code that reports mismatches in count of `Identifier` nodes reported in the parsed AST for `underscore-1.5.2.js`:

```c#
var code = File.ReadAllText("test\Esprima.Tests\Fixtures\3rdparty\underscore-1.5.2.js");
var parser = new JavaScriptParser(code);
var program = parser.ParseProgram();

var ves = new AstVisitorEventSource();
var ids = new List<Identifier>();
ves.VisitingIdentifier += (_, id) => ids.Add(id);
ves.Visit(program);

var mismatches =
    from d in program.DescendantNodesAndSelf()
                     .OfType<Identifier>()
                     .Select(e => e.Name)
                     .CountBy(e => e)
    join v in ids.CountBy(e => e.Name) on d.Key equals v.Key into vs
    from v in vs.DefaultIfEmpty()
    select new
    {
        Identifier = d.Key,
        DescendantCount = d.Value,
        VisitedCount = v.Value
    }
    into e
    where e.DescendantCount != e.VisitedCount
    select e;
    
mismatches.Dump();

foreach (var mm in mismatches)
    Console.WriteLine(mm);
```

Note that the above uses [`CountBy`](https://morelinq.github.io/3.0/ref/api/html/M_MoreLinq_MoreEnumerable_CountBy__2.htm) from [MoreLINQ](https://morelinq.github.io/) for convenience and brevity.

The table below shows the results, all of which disappear after applying the fixes in this PR.

| Identifier         | DescendantCount | VisitedCount |
|--------------------|----------------:|-------------:|
| `_`                |             220 |          215 |
| `prototype`        |              10 |            0 |
| `push`             |              15 |            4 |
| `slice`            |              27 |           23 |
| `concat`           |              11 |            5 |
| `toString`         |               7 |            6 |
| `hasOwnProperty`   |               3 |            2 |
| `forEach`          |               4 |            0 |
| `map`              |               9 |            0 |
| `reduce`           |               5 |            0 |
| `reduceRight`      |               5 |            0 |
| `filter`           |               8 |            0 |
| `every`            |               6 |            0 |
| `some`             |               4 |            0 |
| `indexOf`          |               7 |            0 |
| `lastIndexOf`      |               5 |            0 |
| `isArray`          |               9 |            0 |
| `keys`             |              36 |           22 |
| `bind`             |               6 |            0 |
| `obj`              |             213 |          211 |
| `_wrapped`         |               7 |            0 |
| `exports`          |               5 |            3 |
| `VERSION`          |               1 |            0 |
| `each`             |              23 |           21 |
| `length`           |              71 |           28 |
| `i`                |              60 |           29 |
| `call`             |              51 |            0 |
| `collect`          |               1 |            0 |
| `value`            |              84 |           75 |
| `index`            |              40 |           32 |
| `list`             |              28 |           26 |
| `foldl`            |               1 |            0 |
| `inject`           |               1 |            0 |
| `initial`          |              13 |           12 |
| `foldr`            |               1 |            0 |
| `find`             |               1 |            0 |
| `detect`           |               1 |            0 |
| `result`           |              66 |           64 |
| `any`              |               4 |            3 |
| `select`           |               1 |            0 |
| `reject`           |               1 |            0 |
| `all`              |               1 |            0 |
| `identity`         |               8 |            0 |
| `contains`         |               4 |            0 |
| `include`          |               1 |            0 |
| `invoke`           |               1 |            0 |
| `method`           |              12 |            8 |
| `isFunction`       |               9 |            0 |
| `apply`            |              29 |            0 |
| `pluck`            |               4 |            0 |
| `key`              |              46 |           29 |
| `where`            |               2 |            0 |
| `first`            |               4 |            2 |
| `isEmpty`          |               4 |            0 |
| `findWhere`        |               1 |            0 |
| `max`              |              12 |            4 |
| `computed`         |              12 |            6 |
| `min`              |               7 |            5 |
| `shuffle`          |               2 |            0 |
| `rand`             |               4 |            2 |
| `random`           |               4 |            0 |
| `sample`           |               1 |            0 |
| `sortBy`           |               1 |            0 |
| `criteria`         |               3 |            0 |
| `sort`             |               2 |            0 |
| `groupBy`          |               1 |            0 |
| `has`              |              10 |            0 |
| `indexBy`          |               1 |            0 |
| `countBy`          |               1 |            0 |
| `sortedIndex`      |               2 |            0 |
| `array`            |              47 |           46 |
| `mid`              |               4 |            3 |
| `toArray`          |               1 |            0 |
| `values`           |               8 |            6 |
| `size`             |              10 |            4 |
| `head`             |               1 |            0 |
| `take`             |               1 |            0 |
| `last`             |               4 |            3 |
| `rest`             |               5 |            4 |
| `tail`             |               1 |            0 |
| `drop`             |               1 |            0 |
| `compact`          |               1 |            0 |
| `flatten`          |               5 |            3 |
| `isArguments`      |               3 |            0 |
| `without`          |               1 |            0 |
| `difference`       |               2 |            0 |
| `uniq`             |               3 |            0 |
| `unique`           |               1 |            0 |
| `seen`             |               5 |            4 |
| `union`            |               1 |            0 |
| `intersection`     |               1 |            0 |
| `zip`              |               1 |            0 |
| `object`           |               5 |            4 |
| `range`            |               4 |            3 |
| `ceil`             |               1 |            0 |
| `idx`              |               3 |            2 |
| `partial`          |               1 |            0 |
| `bindAll`          |               1 |            0 |
| `f`                |               3 |            1 |
| `memoize`          |               1 |            0 |
| `delay`            |               2 |            0 |
| `defer`            |               1 |            0 |
| `throttle`         |               1 |            0 |
| `leading`          |               2 |            0 |
| `trailing`         |               1 |            0 |
| `debounce`         |               1 |            0 |
| `once`             |               1 |            0 |
| `wrap`             |               1 |            0 |
| `compose`          |               1 |            0 |
| `after`            |               1 |            0 |
| `times`            |               3 |            1 |
| `pairs`            |               4 |            3 |
| `invert`           |               2 |            0 |
| `functions`        |               2 |            0 |
| `methods`          |               1 |            0 |
| `extend`           |               3 |            0 |
| `source`           |              28 |           21 |
| `prop`             |               7 |            2 |
| `pick`             |               1 |            0 |
| `omit`             |               1 |            0 |
| `defaults`         |               2 |            0 |
| `clone`            |               1 |            0 |
| `isObject`         |               2 |            0 |
| `tap`              |               1 |            0 |
| `global`           |               2 |            0 |
| `multiline`        |               2 |            0 |
| `ignoreCase`       |               2 |            0 |
| `constructor`      |               2 |            0 |
| `pop`              |               2 |            0 |
| `isEqual`          |               1 |            0 |
| `isString`         |               1 |            0 |
| `isElement`        |               1 |            0 |
| `nodeType`         |               1 |            0 |
| `name`             |              15 |            7 |
| `isFinite`         |               2 |            1 |
| `isNaN`            |               2 |            1 |
| `isNumber`         |               1 |            0 |
| `isBoolean`        |               1 |            0 |
| `isNull`           |               1 |            0 |
| `isUndefined`      |               1 |            0 |
| `noConflict`       |               1 |            0 |
| `floor`            |               1 |            0 |
| `escape`           |               9 |            3 |
| `unescape`         |               3 |            0 |
| `join`             |               3 |            0 |
| `replace`          |               3 |            0 |
| `match`            |               7 |            5 |
| `property`         |               2 |            1 |
| `mixin`            |               2 |            0 |
| `idCounter`        |               2 |            1 |
| `uniqueId`         |               1 |            0 |
| `templateSettings` |               2 |            0 |
| `evaluate`         |               5 |            3 |
| `interpolate`      |               5 |            3 |
| `template`         |               4 |            3 |
| `variable`         |               3 |            0 |
| `chain`            |               4 |            0 |
| `_chain`           |               2 |            0 |