### PR TITLE
Fix CS0649 warnings about unused fields

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -16,7 +16,6 @@ namespace Esprima
 
         private sealed class Context
         {
-            public int LastCommentStart;
             public bool AllowIn;
             public bool AllowYield;
             public Token FirstCoverInitializedNameError;
@@ -27,7 +26,6 @@ namespace Esprima
             public bool InSwitch;
             public bool Strict;
             public HashSet<string> LabelSet;
-            public Stack<int> MarkerStack;
         }
 
         private readonly Stack<HoistingScope> _hoistingScopes = new Stack<HoistingScope>();


### PR DESCRIPTION
Fixes following warnings:

    JavascriptParser.cs(30,31): warning CS0649: Field 'JavaScriptParser.Context.MarkerStack' is never assigned to, and will always have its default value null
    JavascriptParser.cs(19,24): warning CS0649: Field 'JavaScriptParser.Context.LastCommentStart' is never assigned to, and will always have its default value 0

[These can be found in the last CI build](https://ci.appveyor.com/project/SebastienRos/esprima-dotnet/builds/21672606#L57).