### PR TITLE
Disable packing of sample & benchmark projects

### DIFF
--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <AssemblyName>Esprima.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>Esprima.Benchmark</PackageId>
+    <IsPackable>false</IsPackable>
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>

--- a/samples/Esprima.Sample/Esprima.Sample.csproj
+++ b/samples/Esprima.Sample/Esprima.Sample.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <AssemblyName>Esprima.Sample</AssemblyName>
     <OutputType>Exe</OutputType>
-    <PackageId>Esprima.Sample</PackageId>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR disables packaging of the sample and benchmark projects during `dotnet pack`. It's not expected that these will ever be published or consumed as NuGet packages.

This also suppresses NU5104 warnings:

```
/usr/local/share/dotnet/sdk/2.1.500/Sdks/NuGet.Build.Tasks.Pack/buildCrossTargeting/NuGet.Build.Tasks.Pack.targets(202,5): warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Esprima [1.0.0-beta-0, )" or update the version field in the nuspec. [esprima-dotnet/samples/Esprima.Sample/Esprima.Sample.csproj]
/usr/local/share/dotnet/sdk/2.1.500/Sdks/NuGet.Build.Tasks.Pack/build/NuGet.Build.Tasks.Pack.targets(202,5): warning NU5104: A stable release of a package should not have a prerelease dependency. Either modify the version spec of dependency "Esprima [1.0.0-beta-0, )" or update the version field in the nuspec. [esprima-dotnet/samples/Esprima.Benchmark/Esprima.Benchmark.csproj]
```