### PR TITLE
Removed unused system collections imports

### DIFF
--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class ArrayExpression : Node, Expression

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ArrayPattern : Node, BindingPattern
     {

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ArrowFunctionExpression : Node, Expression
     {

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ArrowParameterPlaceHolder : Node, Expression
     {

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class BlockStatement : Statement

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class CallExpression : Node,

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ClassBody : Node
     {

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ExportNamedDeclaration : Node, ExportDeclaration
     {

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class FunctionDeclaration : Statement, Declaration, IFunction

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class FunctionExpression : Node,

--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     /// <summary>
     /// Represents either a <see cref="FunctionDeclaration"/> or a <see cref="FunctionExpression"/>

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ImportDeclaration : Node, Declaration
     {

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class NewExpression : Node,

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class ObjectExpression : Node, Expression

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class ObjectPattern : Node, BindingPattern
     {

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class Program : Statement

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class SequenceExpression : Node, Expression

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class SwitchCase : Node

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class SwitchStatement : Statement

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public class TemplateLiteral : Node,
         Expression

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-
 namespace Esprima.Ast
 {
     public class VariableDeclaration : Statement,

--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-
-namespace Esprima
+﻿namespace Esprima
 {
     using Ast;
 

--- a/src/Esprima/HoistingScope.cs
+++ b/src/Esprima/HoistingScope.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Esprima.Ast;
 
 namespace Esprima
@@ -8,7 +7,7 @@ namespace Esprima
     /// </summary>
     public class HoistingScope
     {
-        public Ast.List<FunctionDeclaration> FunctionDeclarations = new Ast.List<FunctionDeclaration>();
-        public Ast.List<VariableDeclaration> VariableDeclarations = new Ast.List<VariableDeclaration>();
+        public List<FunctionDeclaration> FunctionDeclarations = new List<FunctionDeclaration>();
+        public List<VariableDeclaration> VariableDeclarations = new List<VariableDeclaration>();
     }
 }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
 

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
 using Esprima.Ast;
 
@@ -526,7 +525,7 @@ namespace Esprima.Utils
             //Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
             var statement =
                 arrowFunctionExpression.Expression
-                    ? new BlockStatement(new Ast.List<StatementListItem> {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())})
+                    ? new BlockStatement(new List<StatementListItem> {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())})
                     : arrowFunctionExpression.Body.As<BlockStatement>();
             var func = new FunctionExpression(new Identifier(null),
                 arrowFunctionExpression.Params,


### PR DESCRIPTION
This PR is post PR #68 clean-up to reduce to confusion & potential conflicts between BCL's `List<>` and our `List<>`.

Once I've had a chance to review the AST interface model, we might be able to constrain the type parameter of our `List<>` to `INode` and eventually rename it to `AstList<>` (as @lahma suggested). 🤞 