### PR TITLE
Add list creation methods

### DIFF
--- a/test/Esprima.Tests/Breaking.cs
+++ b/test/Esprima.Tests/Breaking.cs
@@ -1,0 +1,75 @@
+﻿#region MoreLINQ - Extensions to LINQ to Objects
+//
+// (C) 2008 Jonathan Skeet. Portions
+// Portions (C) 2009 Atif Aziz, Chris Ammerman, Konrad Rudolph.
+// Portions (C) 2010 Johannes Rudolph, Leopold Bushkin.
+// Portions (C) 2015 Felipe Sateler, "sholland".
+// Portions (C) 2016 Andreas Gullberg Larsen, Leandro F. Vieira (leandromoh).
+// Portions (C) 2017 Jonas Nyrup (jnyrup).
+// Portions (C) Microsoft. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Esprima.Tests
+{
+    internal class BreakingSequence<T> : IEnumerable<T>
+    {
+        public IEnumerator<T> GetEnumerator() => throw new InvalidOperationException();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal class BreakingCollection<T> : BreakingSequence<T>, ICollection<T>
+    {
+        protected readonly IList<T> List;
+
+        public BreakingCollection(params T[] values) : this ((IList<T>) values) {}
+        public BreakingCollection(IList<T> list) => List = list;
+        public BreakingCollection(int count) :
+            this(Enumerable.Repeat(default(T), count).ToList()) {}
+
+        public int Count => List.Count;
+
+        public void Add(T item) => throw new NotImplementedException();
+        public void Clear() => throw new NotImplementedException();
+        public bool Contains(T item) => List.Contains(item);
+        public void CopyTo(T[] array, int arrayIndex) => List.CopyTo(array, arrayIndex);
+        public bool Remove(T item) => throw new NotImplementedException();
+        public bool IsReadOnly => true;
+    }
+
+    internal class BreakingReadOnlyCollection<T> : BreakingSequence<T>, IReadOnlyCollection<T>
+    {
+        readonly IReadOnlyCollection<T> _collection;
+
+        public BreakingReadOnlyCollection(params T[] values) : this ((IReadOnlyCollection<T>) values) {}
+        public BreakingReadOnlyCollection(IReadOnlyCollection<T> collection) => _collection = collection;
+        public int Count => _collection.Count;
+    }
+
+    internal sealed class BreakingReadOnlyList<T> : BreakingReadOnlyCollection<T>, IReadOnlyList<T>
+    {
+        readonly IReadOnlyList<T> _list;
+
+        public BreakingReadOnlyList(params T[] values) : this ((IReadOnlyList<T>) values) {}
+        public BreakingReadOnlyList(IReadOnlyList<T> list) : base (list)
+            => _list = list;
+
+        public T this[int index] => _list[index];
+    }
+}

--- a/test/Esprima.Tests/Lazy.cs
+++ b/test/Esprima.Tests/Lazy.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Esprima.Tests
+{
+    internal static class Lazy
+    {
+        public static Lazy<T, TMetadata>
+            Create<T, TMetadata>(TMetadata metadata, Func<T> factory) =>
+            new Lazy<T, TMetadata>(factory, metadata);
+    }
+
+    public sealed class Lazy<T, TMetadata> : Lazy<T>
+    {
+        public TMetadata Metadata { get; }
+
+        public Lazy(Func<T> valueFactory, TMetadata metadata) :
+            base(valueFactory)
+        {
+            Metadata = metadata;
+        }
+
+        public override string ToString() => $"{Metadata}";
+    }
+}

--- a/test/Esprima.Tests/ListTests.cs
+++ b/test/Esprima.Tests/ListTests.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Linq;
+using Esprima.Ast;
+using Xunit;
+
+namespace Esprima.Tests
+{
+    public class ListTests
+    {
+        public static TheoryData<int, int, Lazy<List<int>>>
+            CreateTestData(int start, int count)
+        {
+            var sequence = Enumerable.Range(start, count);
+            var array = sequence.ToArray();
+
+            return new TheoryData<int, int, Lazy<List<int>>>
+            {
+                { start, count, Lazy.Create("Sequence"    , () => List.Create(sequence.AsEnumerable())) },
+                { start, count, Lazy.Create("Collection"  , () => List.Create(new BreakingCollection<int>(array))) },
+                { start, count, Lazy.Create("ReadOnlyList", () => List.Create(new BreakingReadOnlyList<int>(array))) },
+            };
+        }
+
+        [Theory]
+        [MemberData(nameof(CreateTestData), 1, 0)]
+        [MemberData(nameof(CreateTestData), 1, 3)]
+        [MemberData(nameof(CreateTestData), 1, 4)]
+        [MemberData(nameof(CreateTestData), 1, 7)]
+        [MemberData(nameof(CreateTestData), 1, 10)]
+        [MemberData(nameof(CreateTestData), 1, 22)]
+        public void Create(int start, int count, Lazy<List<int>> xs)
+        {
+            var list = xs.Value;
+
+            Assert.Equal(count, list.Count);
+
+            for (var i = 0; i < count; i++)
+            {
+                Assert.Equal(start + i, list[i]);
+            }
+
+            using (var e = list.GetEnumerator())
+            {
+                for (var i = 0; i < count; i++)
+                {
+                    Assert.True(e.MoveNext());
+                    Assert.Equal(start + i, e.Current);
+                }
+
+                Assert.False(e.MoveNext());
+            }
+        }
+    }
+}


### PR DESCRIPTION
In PR #68, BCL's `List<>` was replaced with our own that was _publicly_ read-only. This PR adds creation methods (`List.Create`) for the public to create our `List<>` for a non-parsed population of an AST. Once initialized, however, it cannot be changed to keep in the spirit of a persistent AST.

The `List.Create` is optimized for different sources of collection types.