### PR TITLE
Consolidate duplicate ArrayPatternElement interface definition

### DIFF
--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -2,9 +2,9 @@
 {
     public class ArrayPattern : Node, BindingPattern
     {
-        public readonly List<ArrayPatternElement> Elements;
+        public readonly List<IArrayPatternElement> Elements;
 
-        public ArrayPattern(List<ArrayPatternElement> elements) :
+        public ArrayPattern(List<IArrayPatternElement> elements) :
             base(Nodes.ArrayPattern)
         {
             Elements = elements;

--- a/src/Esprima/Ast/ArrayPatternElement.cs
+++ b/src/Esprima/Ast/ArrayPatternElement.cs
@@ -1,6 +1,0 @@
-﻿namespace Esprima.Ast
-{
-    public interface ArrayPatternElement : INode
-    {
-    }
-}

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -3,7 +3,7 @@
     public class AssignmentPattern :
         Node,
         Expression,
-        ArrayPatternElement,
+        IArrayPatternElement,
         FunctionParameter,
         PropertyValue
     {

--- a/src/Esprima/Ast/BindingIdentifier.cs
+++ b/src/Esprima/Ast/BindingIdentifier.cs
@@ -1,7 +1,7 @@
 ﻿namespace Esprima.Ast
 {
     public interface BindingIdentifier :
-        ArrayPatternElement,
+        IArrayPatternElement,
         FunctionParameter,
         PropertyValue
     {

--- a/src/Esprima/Ast/BindingPattern.cs
+++ b/src/Esprima/Ast/BindingPattern.cs
@@ -1,7 +1,7 @@
 ﻿namespace Esprima.Ast
 {
     public interface BindingPattern :
-        ArrayPatternElement,
+        IArrayPatternElement,
         FunctionParameter,
         PropertyValue
     {

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -2,10 +2,10 @@ namespace Esprima.Ast
 {
     public class CatchClause : Statement
     {
-        public readonly ArrayPatternElement Param; // BindingIdentifier | BindingPattern;
+        public readonly IArrayPatternElement Param; // BindingIdentifier | BindingPattern;
         public readonly BlockStatement Body;
 
-        public CatchClause(ArrayPatternElement param, BlockStatement body) :
+        public CatchClause(IArrayPatternElement param, BlockStatement body) :
             base(Nodes.CatchClause)
         {
             Param = param;

--- a/src/Esprima/Ast/IArrayPatternElement.cs
+++ b/src/Esprima/Ast/IArrayPatternElement.cs
@@ -1,6 +1,6 @@
 ﻿namespace Esprima.Ast
 {
-    public interface IArrayPatternElement
+    public interface IArrayPatternElement : INode
     {
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -2,7 +2,7 @@ namespace Esprima.Ast
 {
     public abstract class MemberExpression : Node,
         Expression,
-        ArrayPatternElement
+        IArrayPatternElement
     {
         public readonly Expression Object;
         public readonly Expression Property;

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -1,7 +1,7 @@
 ﻿namespace Esprima.Ast
 {
     public class RestElement : Node,
-        ArrayPatternElement, Expression
+        IArrayPatternElement, Expression
     {
         // Identifier in esprima but not forced and
         // for instance ...i[0] is a SpreadElement

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -2,10 +2,10 @@ namespace Esprima.Ast
 {
     public class VariableDeclarator : Node
     {
-        public readonly ArrayPatternElement Id; // BindingIdentifier | BindingPattern;
+        public readonly IArrayPatternElement Id; // BindingIdentifier | BindingPattern;
         public readonly Expression Init;
 
-        public VariableDeclarator(ArrayPatternElement id, Expression init) :
+        public VariableDeclarator(IArrayPatternElement id, Expression init) :
             base(Nodes.VariableDeclarator)
         {
             Id = id;

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1051,13 +1051,13 @@ namespace Esprima
 
                     break;
                 case Nodes.ArrayExpression:
-                    var elements = new Ast.List<ArrayPatternElement>();
+                    var elements = new Ast.List<IArrayPatternElement>();
 
                     foreach (var element in expr.As<ArrayExpression>().Elements)
                     {
                         if (element != null)
                         {
-                            elements.Add(ReinterpretExpressionAsPattern(element).As<ArrayPatternElement>());
+                            elements.Add(ReinterpretExpressionAsPattern(element).As<IArrayPatternElement>());
                         }
                         else
                         {
@@ -2152,7 +2152,7 @@ namespace Esprima
             var node = CreateNode();
 
             Expect("[");
-            var elements = new Ast.List<ArrayPatternElement>();
+            var elements = new Ast.List<IArrayPatternElement>();
             while (!Match("]"))
             {
                 if (Match(","))
@@ -2249,9 +2249,9 @@ namespace Esprima
             return Finalize(node, new ObjectPattern(properties));
         }
 
-        private ArrayPatternElement ParsePattern(ref Ast.List<Token> parameters, VariableDeclarationKind? kind = null)
+        private IArrayPatternElement ParsePattern(ref Ast.List<Token> parameters, VariableDeclarationKind? kind = null)
         {
-            ArrayPatternElement pattern;
+            IArrayPatternElement pattern;
 
             if (Match("["))
             {
@@ -2274,7 +2274,7 @@ namespace Esprima
             return pattern;
         }
 
-        private ArrayPatternElement ParsePatternWithDefault(ref Ast.List<Token> parameters, VariableDeclarationKind? kind = null)
+        private IArrayPatternElement ParsePatternWithDefault(ref Ast.List<Token> parameters, VariableDeclarationKind? kind = null)
         {
             var startToken = _lookahead;
 
@@ -2937,7 +2937,7 @@ namespace Esprima
             Expect(")");
             var body = ParseBlock();
 
-            return Finalize(node, new CatchClause(param.As<ArrayPatternElement>(), body));
+            return Finalize(node, new CatchClause(param.As<IArrayPatternElement>(), body));
         }
 
         private BlockStatement ParseFinallyClause()


### PR DESCRIPTION
The `ArrayPatternElement`  and `IArrayPatternElement` interface definitions were duplicates of each other and the latter was not used anywhere. This `PR` folds `ArrayPatternElement` into `IArrayPatternElement` since it's more conventional to have interface identifiers starting with “I”.