### PR TITLE
ParserException API clean up

### DIFF
--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -34,16 +34,7 @@ namespace Esprima
 
         public ParserException CreateError(int index, int line, int col, string description)
         {
-            var msg = $"Line {line}: {description}";
-            var error = new ParserException(msg)
-            {
-                Index = index,
-                Column = col,
-                LineNumber = line,
-                Description = description,
-                SourceText = Source
-            };
-            return error;
+            return new ParserException(description, Source, index, line, col);
         }
 
         public void TolerateError(int index, int line, int col, string description)

--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -34,7 +34,7 @@ namespace Esprima
 
         public ParserException CreateError(int index, int line, int col, string description)
         {
-            return new ParserException(description, Source, index, line, col);
+            return new ParserException(new ParseError(description, Source, index, new Position(line, col)));
         }
 
         public void TolerateError(int index, int line, int col, string description)

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Esprima
+{
+    public class ParseError
+    {
+        public string Description     { get; }
+        public string Source          { get; }
+
+        public bool IsIndexDefined    => Index >= 0;
+        public int Index              { get; }
+
+        public bool IsPositionDefined => Position.Line > 0;
+        public Position Position      { get; }
+        public int LineNumber         => Position.Line;
+        public int Column             => Position.Column;
+
+        public ParseError(string description) :
+            this(description, null, -1, default) {}
+
+        public ParseError(string description,
+            string source, int index, Position position)
+        {
+            Description = description ?? throw new ArgumentNullException(nameof(description));
+            Source      = source;
+            Index       = index;
+            Position    = position;
+        }
+
+        public override string ToString() =>
+            LineNumber > 0 ? $"Line {LineNumber}: {Description}" : Description;
+    }
+}

--- a/src/Esprima/ParserException.cs
+++ b/src/Esprima/ParserException.cs
@@ -4,41 +4,33 @@ namespace Esprima
 {
     public class ParserException : Exception
     {
-        public string Description { get; }
-        public string SourceText  { get; }
-        public int Index          { get; }
-        public int LineNumber     { get; }
-        public int Column         { get; }
+        public ParseError Error  { get; }
+
+        public string Description => Error?.Description;
+        public string SourceText  => Error?.Source;
+        public int Index          => Error?.Index ?? -1;
+        public int LineNumber     => Error?.LineNumber ?? 0;
+        public int Column         => Error?.Column ?? 0;
 
         public ParserException() :
-            this(null) {}
+            this(null, null, null) {}
 
         public ParserException(string message) :
-            this(message, null) {}
+            this(message, null, null) {}
 
-        public ParserException(string description,
-            string sourceText, int index, int lineNumber, int column) :
-            this(null, description, sourceText, index, lineNumber, column) {}
+        public ParserException(string message, Exception innerException) :
+            this(message, null, innerException) {}
 
-        public ParserException(string message, string description) :
-            this(message, description, null, 0, 0, 0) {}
+        public ParserException(ParseError error) :
+            this(null, error) {}
 
-        public ParserException(string message, string description,
-            string sourceText, int index, int lineNumber, int column) :
-            base(message ?? FormatDefaultMessage(description, lineNumber))
+        public ParserException(string message, ParseError error) :
+            this(message, error, null) {}
+
+        public ParserException(string message, ParseError error, Exception innerException) :
+            base(message ?? error?.ToString(), innerException)
         {
-            Description = description;
-            SourceText  = sourceText;
-            Index       = index;
-            LineNumber  = lineNumber;
-            Column      = column;
+            Error = error;
         }
-
-        static string FormatDefaultMessage(string description, int lineNumber)
-            => description is string desc
-             ? lineNumber > 0
-             ? $"Line {lineNumber}: {desc}"
-             : desc
-             : null;
     }
 }

--- a/src/Esprima/ParserException.cs
+++ b/src/Esprima/ParserException.cs
@@ -4,14 +4,41 @@ namespace Esprima
 {
     public class ParserException : Exception
     {
-        public int Column;
-        public string Description;
-        public int Index;
-        public int LineNumber;
-        public string SourceText;
+        public string Description { get; }
+        public string SourceText  { get; }
+        public int Index          { get; }
+        public int LineNumber     { get; }
+        public int Column         { get; }
 
-        public ParserException(string message) : base(message)
+        public ParserException() :
+            this(null) {}
+
+        public ParserException(string message) :
+            this(message, null) {}
+
+        public ParserException(string description,
+            string sourceText, int index, int lineNumber, int column) :
+            this(null, description, sourceText, index, lineNumber, column) {}
+
+        public ParserException(string message, string description) :
+            this(message, description, null, 0, 0, 0) {}
+
+        public ParserException(string message, string description,
+            string sourceText, int index, int lineNumber, int column) :
+            base(message ?? FormatDefaultMessage(description, lineNumber))
         {
+            Description = description;
+            SourceText  = sourceText;
+            Index       = index;
+            LineNumber  = lineNumber;
+            Column      = column;
         }
+
+        static string FormatDefaultMessage(string description, int lineNumber)
+            => description is string desc
+             ? lineNumber > 0
+             ? $"Line {lineNumber}: {desc}"
+             : desc
+             : null;
     }
 }


### PR DESCRIPTION
This PR is clean-up of `ParserException` to make it conform more with what's expected of the .NET exceptions like there should be chaining constructors to initialize _any one_ of the following:

1. message
2. additional information
3. inner exception

In support of point 2, I have introduced a `ParseError` class that cleanly separates the API holding parsing error data and an exception type that is more of designed to be thrown for program control flow. It also brings the following benefits:

- Simpler set of `ParserException` constructors; that is instead of having many overloads of all combinations, which would be vastly more than the 6 there are already there!
- `ParserException` constructors are stronger-typed since the parsing error information is its own type and so you get a nice product of `String * ParseError * Exception`.
- `ParserException` and `ParseError` can evolve separately.
- `ParseError` is fully immutable so the instance can be shared among `ParserException` instances if needed.
- `ParseError` reuses `Position` and benefits from all built-in validation.

I have added a number of helper properties to `ParserException` that _lift_ the `ParseError` counterparts.
