### PR TITLE
Redundant BinaryExpression alloc in parser

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1675,7 +1675,6 @@ namespace Esprima
                         right = (Expression)stack.Pop();
                         var op = ((Token)stack.Pop()).Value;
                         left = (Expression)stack.Pop();
-                        expr = new BinaryExpression((string)op, left, right);
 
                         markers.Pop();
                         var node = StartNode(markers.Peek());


### PR DESCRIPTION
The `expr` variable and allocation is not used anywhere and possibly redundant with line 1685 later:

https://github.com/sebastienros/esprima-dotnet/blob/e92de0250c9cfb626541cb49fbd1e2f47b68bcb9/src/Esprima/Parser/JavascriptParser.cs#L1685

Removing it, which this PR suggests, doesn't break tests. Meanwhile, represents wasteful allocation and work.
