### PR TITLE
Tidy up arrow functions

### DIFF
--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -2,15 +2,21 @@
 
 namespace Esprima.Ast
 {
-    public class ArrowFunctionExpression : Node, Expression
+    public class ArrowFunctionExpression : Node, Expression, IFunction
     {
-        public readonly Identifier Id;
-        public readonly List<INode> Params;
-        public readonly INode Body; // : BlockStatement | Expression;
-        public readonly bool Generator;
-        public readonly bool Expression;
+        public bool Strict { get; }
 
-        public HoistingScope HoistingScope;
+        public Identifier Id { get; }
+
+        public List<INode> Params { get; }
+
+        public INode Body { get; } // : BlockStatement | Expression;
+
+        public bool Generator { get; }
+
+        public bool Expression { get; }
+
+        public HoistingScope HoistingScope { get; }
 
         public ArrowFunctionExpression(List<INode> parameters, INode body, bool expression, HoistingScope hoistingScope) :
             base(Nodes.ArrowFunctionExpression)

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -6,7 +6,7 @@ namespace Esprima.Ast
     {
         public Identifier Id { get; }
         public List<INode> Params { get; }
-        public BlockStatement Body { get; }
+        public INode Body { get; }
         public bool Generator { get; }
         public bool Expression { get; }
 

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -9,7 +9,7 @@ namespace Esprima.Ast
     {
         public Identifier Id { get; }
         public List<INode> Params { get; }
-        public BlockStatement Body { get; }
+        public INode Body { get; }
         public bool Generator { get; }
         public bool Expression { get; }
 

--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -7,7 +7,7 @@
     {
         Identifier Id { get; }
         List<INode> Params { get; }
-        BlockStatement Body { get; }
+        INode Body { get; }
         bool Generator { get; }
         bool Expression { get; }
         HoistingScope HoistingScope { get; }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -318,7 +318,7 @@ namespace Esprima.Utils
                 Visit(p);
             }
 
-            VisitBlockStatement(functionDeclaration.Body);
+            Visit(functionDeclaration.Body);
         }
 
         protected virtual void VisitWithStatement(WithStatement withStatement)
@@ -600,7 +600,7 @@ namespace Esprima.Utils
             {
                 Visit(param);
             }
-            VisitBlockStatement(function.Body);
+            Visit(function.Body);
         }
 
         protected virtual void VisitClassExpression(ClassExpression classExpression)

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -70,7 +70,7 @@ namespace Esprima.Tests
             var parser = new JavaScriptParser("function p() {'use strict'; function q() { return; } return; }");
             var program = parser.ParseProgram();
             var p = program.Body.First().As<FunctionDeclaration>();
-            var q = p.Body.Body.Skip(1).First().As<FunctionDeclaration>();
+            var q = p.Body.As<BlockStatement>().Body.Skip(1).First().As<FunctionDeclaration>();
 
             Assert.Equal("p", p.Id.Name);
             Assert.Equal("q", q.Id.Name);


### PR DESCRIPTION
ArrowFunctionExpression needs to be an IFunction to share an interface with other function types.

IFunction has been changed to use INode for the function body, so that it can be either a BlockStatement or an Expression.

Tests have been kept essentially the same.

Also added a small bugfix that EndColumn can be equal to StartColumn on a file which has multiple lines which are all comments.