### PR TITLE
#92 Fix Location and add test

### DIFF
--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -18,7 +18,7 @@
             End    = start == default && end != default
                      || end == default && start != default
                      || end.Line < start.Line
-                     || start.Line > 0 && start.Line == end.Line && end.Column <= start.Column
+                     || start.Line > 0 && start.Line == end.Line && end.Column < start.Column
                    ? throw new ArgumentOutOfRangeException(nameof(end), end,
                          Exception<ArgumentOutOfRangeException>.DefaultMessage)
                    : end;

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -9,6 +9,7 @@ namespace Esprima.Tests
     {
         [Theory]
         [InlineData(0, 0, 0, 0)]
+        [InlineData(1, 0, 1, 0)]
         [InlineData(1, 0, 2, 0)]
         [InlineData(1, 4, 2, 0)]
         [InlineData(1, 4, 2, 5)]
@@ -22,7 +23,8 @@ namespace Esprima.Tests
         }
 
         [Theory]
-        [InlineData(1, 0, 1, 0)]
+        [InlineData(0, 0, 1, 0)]
+        [InlineData(1, 0, 0, 0)]
         [InlineData(2, 0, 1, 0)]
         [InlineData(1, 1, 1, 0)]
         public void InvalidStartAndEnd(int startLine, int startColumn, int endLine, int endColumn)

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -118,5 +118,17 @@ namespace Esprima.Tests
             var parser = new JavaScriptParser("var a = { [Symbol.iterator]: undefined }");
             var program = parser.ParseProgram();
         }
+
+        [Fact]
+        public void ShouldParseLocation()
+        {
+            var options = new ParserOptions
+            {
+                Loc = true
+            };
+            var parser = new JavaScriptParser("// End on second line\r\n", options);
+
+            var program = parser.ParseProgram();
+        }
     }
 }


### PR DESCRIPTION
Attempt to fix #92.

End can be in same position as start, even on lines other than 0.
Specifically, by having no statements, just comments, and multiple lines.

As an added benefit, will allow Jint to work with the latest version of Esprima.