### PR TITLE
Fix hoisting scope state transfer and array pattern parsing

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -27,7 +27,7 @@ namespace Esprima
             public HashSet<string> LabelSet;
         }
 
-        private struct HoistingScopeLists
+        private class HoistingScopeLists
         {
             public ArrayList<FunctionDeclaration> FunctionDeclarations;
             public ArrayList<VariableDeclaration> VariableDeclarations;
@@ -1051,7 +1051,7 @@ namespace Esprima
                     break;
                 case Nodes.SpreadElement:
                     var newArgument = ReinterpretExpressionAsPattern(expr.As<SpreadElement>().Argument);
-                    node = new RestElement(newArgument.As<Expression>());
+                    node = new RestElement(newArgument.As<IArrayPatternElement>());
                     node.Range = expr.Range;
                     node.Location = _config.Loc ? expr.Location : default;
 
@@ -3333,7 +3333,9 @@ namespace Esprima
             _context.AllowYield = previousAllowYield;
 
             var functionDeclaration = Finalize(node, new FunctionDeclaration(id, parameters, body, isGenerator, LeaveHoistingScope(), hasStrictDirective));
-            _hoistingScopes.Peek().FunctionDeclarations.Add(functionDeclaration);
+            var lists = _hoistingScopes.Peek();
+            ref var functionDeclarations = ref lists.FunctionDeclarations;
+            functionDeclarations.Add(functionDeclaration);
 
             return functionDeclaration;
         }
@@ -4263,7 +4265,9 @@ namespace Esprima
         {
             if (variableDeclaration.Kind == VariableDeclarationKind.Var)
             {
-                _hoistingScopes.Peek().VariableDeclarations.Add(variableDeclaration);
+                var scopeLists = _hoistingScopes.Peek();
+                ref var variableDeclarations = ref scopeLists.VariableDeclarations;
+                variableDeclarations.Add(variableDeclaration);
             }
 
             return variableDeclaration;

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -130,5 +130,25 @@ namespace Esprima.Tests
 
             var program = parser.ParseProgram();
         }
+
+
+        [Fact]
+        public void ShouldParseArrayPattern()
+        {
+            var parser = new JavaScriptParser(@"
+var values = [1, 2, 3];
+
+var callCount = 0;
+var f;
+f = ([...[...x]]) => {
+    callCount = callCount + 1;
+};
+
+f(values);
+
+");
+
+            var program = parser.ParseProgram();
+        }
     }
 }


### PR DESCRIPTION
Fixed couple issues found while integrating latest dev package to Jint.

* spread tried to cast to Expression instead of IArrayPatternElement
* hoisting scope came with empty lists as stack Peek and Pop returned copies, replaced struct with class