### PR TITLE
Revert HoistingScopeLists to be struct

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -27,7 +27,7 @@ namespace Esprima
             public HashSet<string> LabelSet;
         }
 
-        private class HoistingScopeLists
+        private struct HoistingScopeLists
         {
             public ArrayList<FunctionDeclaration> FunctionDeclarations;
             public ArrayList<VariableDeclaration> VariableDeclarations;
@@ -3333,9 +3333,10 @@ namespace Esprima
             _context.AllowYield = previousAllowYield;
 
             var functionDeclaration = Finalize(node, new FunctionDeclaration(id, parameters, body, isGenerator, LeaveHoistingScope(), hasStrictDirective));
-            var lists = _hoistingScopes.Peek();
+            var lists = _hoistingScopes.Pop();
             ref var functionDeclarations = ref lists.FunctionDeclarations;
             functionDeclarations.Add(functionDeclaration);
+            _hoistingScopes.Push(lists);
 
             return functionDeclaration;
         }
@@ -4265,9 +4266,10 @@ namespace Esprima
         {
             if (variableDeclaration.Kind == VariableDeclarationKind.Var)
             {
-                var scopeLists = _hoistingScopes.Peek();
+                var scopeLists = _hoistingScopes.Pop();
                 ref var variableDeclarations = ref scopeLists.VariableDeclarations;
                 variableDeclarations.Add(variableDeclaration);
+                _hoistingScopes.Push(scopeLists);
             }
 
             return variableDeclaration;

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -12,6 +12,17 @@ namespace Esprima.Test
 {
     public class Fixtures
     {
+        [Fact]
+        public void HoistingScopeShouldWork()
+        {
+            var parser = new JavaScriptParser(@"
+                function p() {}
+                var x;");
+            var program = parser.ParseProgram();
+            Assert.NotEmpty(program.HoistingScope.FunctionDeclarations);
+            Assert.NotEmpty(program.HoistingScope.VariableDeclarations);
+        }
+
         public string ParseAndFormat(string source, ParserOptions options)
         {
             var parser = new JavaScriptParser(source, options);


### PR DESCRIPTION
PR #97 changed `HoistingScopeLists` to be a `class` when it could have been kept as a `struct` by slightly changing how it is used. This PR reverts `HoistingScopeLists` to be `struct` again.

---
PS In the commit message, I have [given credit](https://help.github.com/en/articles/creating-a-commit-with-multiple-authors) to @lahma for the test.
