### PR TITLE
Report invalid RegEx flags eagerly

### DIFF
--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1474,17 +1474,8 @@ namespace Esprima
                 tmp = Regex.Replace(tmp, "[\uD800-\uDBFF][\uDC00-\uDFFF]", astralSubstitute);
             }
 
-            RegexOptions options = RegexOptions.ECMAScript;
-
             // First, detect invalid regular expressions.
-            try
-            {
-                options = ParseRegexOptions(flags);
-            }
-            catch
-            {
-                return null;
-            }
+            var options = ParseRegexOptions(flags);
 
             try
             {

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -173,5 +173,12 @@ f(values);
             var parser = new JavaScriptParser(script);
             Assert.Throws<ParserException>(() => parser.ParseProgram());
         }
+
+        [Fact]
+        public void ThrowsErrorForInvalidRegExFlags()
+        {
+            var parser = new JavaScriptParser("/'/o//'///C//ÿ");
+            Assert.Throws<ParserException>(() => parser.ParseProgram());
+        }
     }
 }


### PR DESCRIPTION
Relates to https://github.com/sebastienros/jint/issues/571 . Invalid flags will produce null regex which Jint cannot handle, would seem more reasonable for JS parsing to prohibit such definition as Jint has no idea what could be the causes for RegEx instance's Value (string) to be null.