### PR TITLE
Don't cache state in AST

### DIFF
--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -8,9 +8,6 @@ namespace Esprima.Ast
         private readonly NodeList<ArgumentListElement> _arguments;
 
         public readonly Expression Callee;
-        public bool Cached;
-        public bool CanBeCached = true;
-        public object CachedArguments;
 
         public CallExpression(Expression callee, in NodeList<ArgumentListElement> args) :
             base(Nodes.CallExpression)

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -16,7 +16,6 @@ namespace Esprima.Ast
         public readonly object Value;
         public readonly string Raw;
         public readonly TokenType TokenType;
-        public object CachedValue;
 
         private Literal(TokenType tokenType, object value, string raw) :
             base(Nodes.Literal)

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -812,11 +812,7 @@ namespace Esprima.Utils
                 using (StartNodeObject(callExpression))
                 {
                     Member("callee", callExpression.Callee);
-
-                    if (!callExpression.Cached)
-                    {
-                        Member("arguments", callExpression.Arguments, e => (Expression) e);
-                    }
+                    Member("arguments", callExpression.Arguments, e => (Expression) e);
                 }
             }
 

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -750,12 +750,9 @@ namespace Esprima.Utils
         protected virtual void VisitCallExpression(CallExpression callExpression)
         {
             VisitExpression(callExpression.Callee);
-            if (callExpression.Cached == false)
+            foreach (var arg in callExpression.Arguments)
             {
-                foreach (var arg in callExpression.Arguments)
-                {
-                    VisitExpression(arg.As<Expression>());
-                }
+                VisitExpression(arg.As<Expression>());
             }
         }
 


### PR DESCRIPTION
Jint doesn't need it anymore and it's always been a bit of hack. Users should do like Jint and wrap the usage when needed and provide their own caching based on needs, if any.