### PR TITLE
Don't concatenate dollar prefix for param/label set names

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1778,11 +1778,11 @@ namespace Esprima
 
         private ParsedParameters ReinterpretAsCoverFormalsList(INode expr)
         {
-            var parameters = new ArrayList<INode>(1) { expr };
-
+            ArrayList<INode> parameters;
             switch (expr.Type)
             {
                 case Nodes.Identifier:
+                    parameters = new ArrayList<INode>(1) { expr };
                     break;
                 case Nodes.ArrowParameterPlaceHolder:
                     // TODO clean-up
@@ -2711,7 +2711,7 @@ namespace Esprima
             {
                 label = ParseVariableIdentifier();
 
-                var key = '$' + label.Name;
+                var key = label.Name;
                 if (!_context.LabelSet.Contains(key))
                 {
                     ThrowError(Messages.UnknownLabel, label.Name);
@@ -2739,7 +2739,7 @@ namespace Esprima
             {
                 label = ParseVariableIdentifier();
 
-                var key = '$' + label.Name;
+                var key = label.Name;
                 if (!_context.LabelSet.Contains(key))
                 {
                     ThrowError(Messages.UnknownLabel, label.Name);
@@ -2878,7 +2878,7 @@ namespace Esprima
                 NextToken();
 
                 var id = expr.As<Identifier>();
-                var key = '$' + id.Name;
+                var key = id.Name;
                 if (_context.LabelSet.Contains(key))
                 {
                     ThrowError(Messages.Redeclaration, "Label", id.Name);
@@ -2936,7 +2936,7 @@ namespace Esprima
             var paramMap = new Dictionary<string, bool>();
             for (var i = 0; i < parameters.Count; i++)
             {
-                var key = '$' + (string)parameters[i].Value;
+                var key = (string)parameters[i].Value;
                 if (paramMap.ContainsKey(key))
                 {
                     TolerateError(Messages.DuplicateBinding, parameters[i].Value);
@@ -3130,7 +3130,7 @@ namespace Esprima
 
         private void ValidateParam(ParsedParameters options, INode param, string name)
         {
-            var key = '$' + name;
+            var key = name;
             if (_context.Strict)
             {
                 if (Scanner.IsRestrictedWord(name))
@@ -3168,7 +3168,7 @@ namespace Esprima
 
         private void ValidateParam2(ParsedParameters options, Token param, string name)
         {
-            var key = '$' + name;
+            var key = name;
             if (_context.Strict)
             {
                 if (Scanner.IsRestrictedWord(name))


### PR DESCRIPTION
Had a small revelation while reading the original code base. The '$' prefix is used only not to override object properties in javascript object that is used for lookup. .NET version uses HashSet which does not have such problems. We can safely ditch the prefixing which always allocates new strings.