### PR TITLE
Add dotAll support

### DIFF
--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -1,0 +1,25 @@
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Esprima.Tests
+{
+    public class RegExpTests
+    {
+        [Fact]
+        public void DotAll()
+        {
+            Assert.Matches(CreateRegex("/^.$/s"), "\n");
+            Assert.DoesNotMatch(CreateRegex("/^.$/"), "\n");
+        }
+
+        private static Regex CreateRegex(string code)
+        {
+            var options = new ParserOptions
+            {
+                AdaptRegexp = true
+            };
+            var token = new Scanner(code, options).ScanRegExp();
+            return (Regex) token.Value;
+        }
+    }
+}


### PR DESCRIPTION
The new dotAll options isn't yet supported in generating the Regex. Unfortunately we need to turn of ECMA mode when the /s which is present, but that takes us at least a bit closer to desired behavior (and not throwing when parsing such JS files).