### PR TITLE
Expose NodeCollection Children from IFunction

### DIFF
--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -12,5 +12,6 @@
         bool Expression { get; }
         bool Strict { get; }
         bool Async { get; }
+        NodeCollection ChildNodes { get; }
     }
 }


### PR DESCRIPTION
I was cross-checking Jint against RavenDB and saw that they would like to access child nodes from IFunction (was earlier exposed via INode that IFunction inherited).