### PR TITLE
Declare Microsoft.SourceLink.GitHub as a dev dependency

### DIFF
--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -24,7 +24,7 @@
 
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>


### PR DESCRIPTION
[Microsoft.SourceLink.GitHub] shows up as a dependency that is unnecessary and confusing:

  [Microsoft.SourceLink.GitHub]: https://www.nuget.org/packages/Microsoft.SourceLink.GitHub

![image](https://user-images.githubusercontent.com/20511/84993705-e9b67800-b149-11ea-9408-03efad5d73ae.png)

This PR declares it as a dev dependency so it doesn't show up as a dependency of the [Esprima package](https://www.nuget.org/packages/esprima).

Before this PR, run `dotnet pack src\Esprima` on the `dev` branch (3ce3a6fa5300ad4304ccbb8d50bc0ca8140fd021):

```
Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  All projects are up-to-date for restore.
  Esprima -> A:\esprima-dotnet\src\Esprima\bin\Debug\netstandard2.0\Esprima.dll
  Esprima -> A:\esprima-dotnet\src\Esprima\bin\Debug\net461\Esprima.dll
```

Dump the NuSpec file in the output package using:

    unzip -p src\Esprima\bin\Debug\Esprima.2.0.0-beta-0.nupkg Esprima.nuspec

which will output:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
  <metadata>
    <id>Esprima</id>
    <version>2.0.0-beta-0</version>
    <authors>Sebastien Ros</authors>
    <owners>Sebastien Ros</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://raw.githubusercontent.com/sebastienros/esprima-dotnet/master/LICENSE.txt</licenseUrl>
    <projectUrl>https://github.com/sebastienros/esprima-dotnet</projectUrl>
    <description>Standard-compliant ECMAScript 2016 parser (also popularly known as JavaScript or ES6).</description>
    <copyright>Sebastien Ros</copyright>
    <tags>javascript, parser</tags>
    <repository type="git" url="https://github.com/atifaziz/esprima-dotnet.git" commit="3ce3a6fa5300ad4304ccbb8d50bc0ca8140fd021" />
    <dependencies>
      <group targetFramework=".NETFramework4.6.1">
        <dependency id="Microsoft.SourceLink.GitHub" version="1.0.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Microsoft.SourceLink.GitHub" version="1.0.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
  </metadata>
</package>
```

Take note of Microsoft.SourceLink.GitHub in the `<dependencies>` section:

```xml
    <dependencies>
      <group targetFramework=".NETFramework4.6.1">
        <dependency id="Microsoft.SourceLink.GitHub" version="1.0.0" exclude="Build,Analyzers" />
      </group>
      <group targetFramework=".NETStandard2.0">
        <dependency id="Microsoft.SourceLink.GitHub" version="1.0.0" exclude="Build,Analyzers" />
      </group>
    </dependencies>
```

After this PR, run `dotnet pack src\Esprima`:

```
Microsoft (R) Build Engine version 16.6.0+5ff7b0c9e for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  Determining projects to restore...
  Restored A:\esprima-dotnet\src\Esprima\Esprima.csproj (in 523 ms).
  Esprima -> A:\esprima-dotnet\src\Esprima\bin\Debug\netstandard2.0\Esprima.dll
  Esprima -> A:\esprima-dotnet\src\Esprima\bin\Debug\net461\Esprima.dll
  Successfully created package 'A:\esprima-dotnet\src\Esprima\bin\Debug\Esprima.2.0.0-beta-0.nupkg'.
C:\Program Files\dotnet\sdk\3.1.300\Sdks\NuGet.Build.Tasks.Pack\buildCrossTargeting\NuGet.Build.Tasks.Pack.targets(198,5): warning NU5125: The 'licenseUrl' element will be deprecated. Consider using the 'license' element instead. [A:\esprima-dotnet\src\Esprima\Esprima.csproj]
```

Again, dump the NuSpec file in the output package using:

    unzip -p src\Esprima\bin\Debug\Esprima.2.0.0-beta-0.nupkg Esprima.nuspec

which will output:

```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
  <metadata>
    <id>Esprima</id>
    <version>2.0.0-beta-0</version>
    <authors>Sebastien Ros</authors>
    <owners>Sebastien Ros</owners>
    <requireLicenseAcceptance>false</requireLicenseAcceptance>
    <licenseUrl>https://raw.githubusercontent.com/sebastienros/esprima-dotnet/master/LICENSE.txt</licenseUrl>
    <projectUrl>https://github.com/sebastienros/esprima-dotnet</projectUrl>
    <description>Standard-compliant ECMAScript 2016 parser (also popularly known as JavaScript or ES6).</description>
    <copyright>Sebastien Ros</copyright>
    <tags>javascript, parser</tags>
    <repository type="git" url="https://github.com/atifaziz/esprima-dotnet.git" commit="a097d2819aa6796fa464907e6063fc957bd6889b" />
    <dependencies>
      <group targetFramework=".NETFramework4.6.1" />
      <group targetFramework=".NETStandard2.0" />
    </dependencies>
  </metadata>
</package>
```

Note that the `<dependencies>` are gone:

```xml
    <dependencies>
      <group targetFramework=".NETFramework4.6.1" />
      <group targetFramework=".NETStandard2.0" />
    </dependencies>
```
