### PR TITLE
Publish symbol package

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ test_script:
   - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Debug
   - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Release
 artifacts:
-  - path: 'src\**\*.nupkg'
+  - path: 'src\**\*.*nupkg'
 deploy:  
   - provider: NuGet
     on:
@@ -29,5 +29,4 @@ deploy:
     server: https://www.nuget.org/api/v2/package
     api_key:
       secure: qZ6R8U4mtBXFVRhhNLJyRz3bktF/jL5BvzrCQsXcn6ATRQ4YavFP3By8Sg4hYMH5
-    skip_symbols: true
-    artifact: /.*\.nupkg/  
+    artifact: /.*\.*nupkg/  

--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -13,15 +13,16 @@
     <PackageId>Esprima</PackageId>
     <PackageTags>javascript, parser</PackageTags>
     <PackageProjectUrl>https://github.com/sebastienros/esprima-dotnet</PackageProjectUrl>
-    <PackageLicenseUrl>https://raw.githubusercontent.com/sebastienros/esprima-dotnet/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
     <Version>2.0.0-beta-$(BuildNumber)</Version>
-    <LangVersion>latest</LangVersion>
 
-    <!-- SourceLink support -->
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    <Nullable>enable</Nullable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
 
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Less size for published package, debug support for debuggers. Also set the license expression instead of the obsolete URL.