### PR TITLE
Fix multi-line comment scanning

### DIFF
--- a/src/Esprima/Comment.cs
+++ b/src/Esprima/Comment.cs
@@ -17,6 +17,6 @@ namespace Esprima
         public int[] Slice = Array.Empty<int>();
         public int Start;
         public int End;
-        public Loc? Loc;
+        public SourceLocation? Loc;
     }
 }

--- a/src/Esprima/Marker.cs
+++ b/src/Esprima/Marker.cs
@@ -1,6 +1,6 @@
 namespace Esprima
 {
-    public class Marker
+    internal class Marker
     {
         public int Index;
         public int Line;

--- a/src/Esprima/Marker.cs
+++ b/src/Esprima/Marker.cs
@@ -1,0 +1,20 @@
+namespace Esprima
+{
+    public class Marker
+    {
+        public int Index;
+        public int Line;
+        public int Column;
+
+        public Marker()
+        {
+        }
+
+        public Marker(int index, int line, int column)
+        {
+            Index = index;
+            Line = line;
+            Column = column;
+        }
+    }
+}

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -8,28 +8,10 @@ using Esprima.Ast;
 
 namespace Esprima
 {
-    public class Loc
+    public class SourceLocation
     {
-        public Marker? Start;
-        public Marker? End;
-    }
-
-    public class Marker
-    {
-        public int Index;
-        public int Line;
-        public int Column;
-
-        public Marker()
-        {
-        }
-
-        public Marker(int index, int line, int column)
-        {
-            Index = index;
-            Line = line;
-            Column = column;
-        }
+        public Position? Start;
+        public Position? End;
     }
 
     internal readonly struct ScannerState
@@ -252,13 +234,13 @@ namespace Esprima
         {
             var comments = new ArrayList<Comment>();
             int start = 0;
-            Loc loc = new Loc();
+            var loc = new SourceLocation();
 
             if (_trackComment)
             {
                 start = Index - offset;
-                loc.Start = new Marker(0, LineNumber, Index - LineStart - offset);
-                loc.End = new Marker();
+                loc.Start = new Position(LineNumber, Index - LineStart - offset);
+                loc.End = new Position();
             }
 
             while (!Eof())
@@ -269,7 +251,7 @@ namespace Esprima
                 {
                     if (_trackComment)
                     {
-                        loc.End = new Marker(loc.End!.Index, LineNumber, Index - LineStart - 1);
+                        loc.End = new Position(LineNumber, Index - LineStart - 1);
 
                         Comment entry = new Comment
                         {
@@ -294,7 +276,7 @@ namespace Esprima
 
             if (_trackComment)
             {
-                loc.End = new Marker(loc.End!.Index, LineNumber, Index - LineStart);
+                loc.End = new Position(LineNumber, Index - LineStart);
                 var entry = new Comment
                 {
                     MultiLine = false,
@@ -314,12 +296,12 @@ namespace Esprima
         {
             var comments = new ArrayList<Comment>();
             int start = 0;
-            Loc loc = new Loc();
+            var loc = new SourceLocation();
 
             if (_trackComment)
             {
                 start = Index - 2;
-                loc.Start = new Marker(loc.Start!.Index, LineNumber, Index - LineStart - 2);
+                loc.Start = new Position(LineNumber, Index - LineStart - 2);
             }
 
             while (!Eof())
@@ -343,7 +325,7 @@ namespace Esprima
                         Index += 2;
                         if (_trackComment)
                         {
-                            loc.End = new Marker(loc.End!.Index, LineNumber, Index - LineStart);
+                            loc.End = new Position(LineNumber, Index - LineStart);
                             var entry = new Comment
                             {
                                 MultiLine = true,
@@ -367,7 +349,7 @@ namespace Esprima
             // Ran off the end of the file - the whole thing is a comment
             if (_trackComment)
             {
-                loc.End = new Marker(loc.End!.Index, LineNumber, Index - LineStart);
+                loc.End = new Position(LineNumber, Index - LineStart);
                 var entry = new Comment
                 {
                     MultiLine = true,
@@ -379,7 +361,7 @@ namespace Esprima
                 comments.Add(entry);
             }
 
-            this.TolerateUnexpectedToken();
+            TolerateUnexpectedToken();
             return comments;
         }
 

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -168,30 +168,30 @@ namespace Esprima.Utils
                 {
                     if (includeRange)
                     {
-                        writer.Member("range");
-                        writer.StartArray();
-                        writer.Number(node.Range.Start);
-                        writer.Number(node.Range.End);
-                        writer.EndArray();
+                        _writer.Member("range");
+                        _writer.StartArray();
+                        _writer.Number(node.Range.Start);
+                        _writer.Number(node.Range.End);
+                        _writer.EndArray();
                     }
 
                     if (includeLineColumn)
                     {
-                        writer.Member("loc");
-                        writer.StartObject();
-                        writer.Member("start");
+                        _writer.Member("loc");
+                        _writer.StartObject();
+                        _writer.Member("start");
                         Write(node.Location.Start);
-                        writer.Member("end");
+                        _writer.Member("end");
                         Write(node.Location.End);
-                        writer.EndObject();
+                        _writer.EndObject();
                     }
 
                     void Write(Position position)
                     {
-                        writer.StartObject();
+                        _writer.StartObject();
                         Member("line", position.Line);
                         Member("column", position.Column);
-                        writer.EndObject();
+                        _writer.EndObject();
                     }
                 }
             }

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace Esprima.Tests
+{
+    public class ScannerTests
+    {
+        [Fact]
+        public void CanScanMultiLineComment()
+        {
+            var scanner = new Scanner("var foo=1; /* \"330413500\" */", new ParserOptions {Comment = true, Loc = true});
+            
+            var results = new List<string>();
+            Token token;
+            do
+            {
+                foreach (var comment in scanner.ScanComments())
+                {
+                    results.Add($"{comment.Start}-{comment.End}");
+                }
+                token = scanner.Lex();
+            } while (token.Type != TokenType.EOF);
+
+            Assert.Equal(new[] {"11-28"}, results);
+        }
+    }
+}


### PR DESCRIPTION
Nullable annotations were yelling that this is a bad idea, and it was. 

Original code used to just set line and column but the real problem was that different data structures were used than in original Esprima. Changed to follow the same format for scanner structures as in JS version:

https://github.com/jquery/esprima/blob/45c9ab14d96f7f7fa88333fdd897487a8c20082f/src/scanner.ts#L15-L31

fixes #137