### PR TITLE
Always include Location and Range information

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ build_script:
   - dotnet --version
   - dotnet pack -c Release
 test_script:
-  - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Release
+  - dotnet test .\test\Esprima.Tests\Esprima.Tests.csproj -c Release /p:Checked=true
 artifacts:
   - path: 'src\**\*.*nupkg'
 deploy:  

--- a/samples/Esprima.Benchmark/FileParsingBenchmark.cs
+++ b/samples/Esprima.Benchmark/FileParsingBenchmark.cs
@@ -19,6 +19,12 @@ namespace Esprima.Benchmark
             {"angular-1.2.5", null}
         };
 
+        private static readonly ParserOptions parserOptions = new ParserOptions()
+        {
+            Comment = true,
+            Tokens = true 
+        };
+
         [GlobalSetup]
         public void Setup()
         {
@@ -42,7 +48,7 @@ namespace Esprima.Benchmark
         [Benchmark]
         public void ParseProgram()
         {
-            var parser = new JavaScriptParser(files[FileName]);
+            var parser = new JavaScriptParser(files[FileName], parserOptions);
             parser.ParseScript();
         }
     }

--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -27,6 +27,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     
+    <DefineConstants Condition="'$(Checked)' == true or $(Configuration) == 'Debug'">$(DefineConstants);LOCATION_ASSERTS</DefineConstants>
+    
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />

--- a/src/Esprima/EsprimaExceptionHelper.cs
+++ b/src/Esprima/EsprimaExceptionHelper.cs
@@ -19,11 +19,6 @@ namespace Esprima
             throw new ArgumentOutOfRangeException(paramName, actualValue, message);
         }
 
-        public static void ThrowObjectDisposedException(string objectName)
-        {
-            throw new ObjectDisposedException(objectName);
-        }
-
         public static T ThrowInvalidOperationException<T>(string? message = null)
         {
             throw new InvalidOperationException(message);

--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -1,35 +1,37 @@
-﻿using System.Diagnostics;
-using static Esprima.EsprimaExceptionHelper;
+﻿using System;
+using System.Diagnostics;
 
 namespace Esprima
 {
-    using System;
-
     [DebuggerDisplay("{ToString()}")]
     public readonly struct Location : IEquatable<Location>
     {
         public Position Start  { get; }
         public Position End    { get; }
-        public string?   Source { get; }
+        public string?  Source { get; }
 
         public Location(Position start, Position end) : this(start, end, null)
         {
         }
 
-        public Location(Position start, Position end, string? source)
+        public Location(in Position start, in Position end, string? source)
         {
+#if LOCATION_ASSERTS
+            if (start == default && end != default
+                || end == default && start != default
+                || end.Line < start.Line
+                || start.Line > 0 && start.Line == end.Line && end.Column < start.Column)
+            {
+                EsprimaExceptionHelper.ThrowArgumentOutOfRangeException(nameof(end), end, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+            }
+#endif
+            
             Start  = start;
-
-            End    = start == default && end != default
-                     || end == default && start != default
-                     || end.Line < start.Line
-                     || start.Line > 0 && start.Line == end.Line && end.Column < start.Column
-                   ? ThrowArgumentOutOfRangeException<Position>(nameof(end), end, Exception<ArgumentOutOfRangeException>.DefaultMessage)
-                   : end;
+            End = end;
             Source = source;
         }
 
-        public Location WithPosition(Position start, Position end) =>
+        public Location WithPosition(in Position start, in Position end) =>
             new Location(start, end, Source);
 
         public override bool Equals(object obj) =>
@@ -48,8 +50,8 @@ namespace Esprima
         public override string ToString() =>
             $"{Start}...{End}{(Source is string s ? ": " + s : null)}";
 
-        public static bool operator ==(Location left, Location right) => left.Equals(right);
-        public static bool operator !=(Location left, Location right) => !left.Equals(right);
+        public static bool operator ==(in Location left, in Location right) => left.Equals(right);
+        public static bool operator !=(in Location left, in Location right) => !left.Equals(right);
 
         public void Deconstruct(out Position start, out Position end)
         {

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -31,17 +31,6 @@
         }
 
         /// <summary>
-        /// Gets or sets whether each node should have their range included.
-        /// </summary>
-        /// <value></value>
-        public bool Range { get; set; } = false;
-
-        /// <summary>
-        /// Gets or sets whether the parsed elements have their location included.
-        /// </summary>
-        public bool Loc { get; set; } = false;
-
-        /// <summary>
         /// Gets or sets whether the tokens are included in the parsed tree.
         /// </summary>
         public bool Tokens { get; set; } = false;

--- a/src/Esprima/Position.cs
+++ b/src/Esprima/Position.cs
@@ -1,10 +1,8 @@
-﻿using static Esprima.EsprimaExceptionHelper;
+﻿using System;
+using System.Globalization;
 
 namespace Esprima
 {
-    using System;
-    using System.Globalization;
-
     /// <summary>
     /// Represents a source position as line number and column offset, where
     /// the first line is 1 and first column is 0.
@@ -22,13 +20,18 @@ namespace Esprima
 
         public Position(int line, int column)
         {
-            Line = line >= 0 ? line
-                 : ThrowArgumentOutOfRangeException<int>(nameof(line), line, Exception<ArgumentOutOfRangeException>.DefaultMessage);
-
-            Column = line > 0 && column >= 0
-                     || line == 0 && column == 0 // if line is 0 then column MUST BE 0!
-                   ? column
-                   : ThrowArgumentOutOfRangeException<int>(nameof(column), column, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+#if LOCATION_ASSERTS
+            if (line < 0)
+            {
+                EsprimaExceptionHelper.ThrowArgumentOutOfRangeException(nameof(line), line, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+            }
+            if ((line <= 0 || column < 0) && (line != 0 || column != 0))
+            {
+                EsprimaExceptionHelper.ThrowArgumentOutOfRangeException(nameof(column), column, Exception<ArgumentOutOfRangeException>.DefaultMessage);
+            }
+#endif
+            Line = line;
+            Column = column;
         }
 
         public override bool Equals(object obj) =>

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -28,8 +28,6 @@ namespace Esprima
 
         public Location Location;
 
-        public int Precedence;
-
         // For NumericLiteral
         public bool Octal;
 
@@ -52,7 +50,6 @@ namespace Esprima
             LineNumber = 0;
             LineStart = 0;
             Location = default;
-            Precedence = 0;
             Octal = false;
             Head = false;
             Tail = false;

--- a/test/Esprima.Tests/Esprima.Tests.csproj
+++ b/test/Esprima.Tests/Esprima.Tests.csproj
@@ -3,6 +3,7 @@
     <TargetFrameworks>net461;netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Esprima.Tests</AssemblyName>
     <PackageId>Esprima.Tests</PackageId>
+    <DefineConstants Condition="'$(Checked)' == true or $(Configuration) == 'Debug'">$(DefineConstants);LOCATION_ASSERTS</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -53,8 +53,6 @@ namespace Esprima.Test
         {
             var options = new ParserOptions
             {
-                Range = true,
-                Loc = true,
                 Tokens = true
             };
 

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -21,6 +21,7 @@ namespace Esprima.Tests
             Assert.Equal(end, actualEnd);
         }
 
+#if LOCATION_ASSERTS
         [Theory]
         [InlineData(0, 0, 1, 0)]
         [InlineData(1, 0, 0, 0)]
@@ -35,5 +36,6 @@ namespace Esprima.Tests
             Assert.Equal("end", e.ParamName);
             Assert.Equal(end, e.ActualValue);
         }
+#endif        
     }
 }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -122,15 +122,9 @@ namespace Esprima.Tests
         [Fact]
         public void ShouldParseLocation()
         {
-            var options = new ParserOptions
-            {
-                Loc = true
-            };
-            var parser = new JavaScriptParser("// End on second line\r\n", options);
-
+            var parser = new JavaScriptParser("// End on second line\r\n");
             var program = parser.ParseScript();
         }
-
 
         [Fact]
         public void ShouldParseArrayPattern()

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -8,7 +8,7 @@ namespace Esprima.Tests
         [Fact]
         public void CanScanMultiLineComment()
         {
-            var scanner = new Scanner("var foo=1; /* \"330413500\" */", new ParserOptions {Comment = true, Loc = true});
+            var scanner = new Scanner("var foo=1; /* \"330413500\" */", new ParserOptions {Comment = true});
             
             var results = new List<string>();
             Token token;


### PR DESCRIPTION
As these are struct to begin with, it's not a big penalty to include them always (and now it's actually faster). I tweaked the code a bit so only when testing we check the location line and column, JS version doesn't check them either. Also tweaked location passing to be using `in` to reduce some allocations. Removed the options from configuration as unneeded.

## Esprima.Benchmark.FileParsingBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |ParseProgram|angular-1.2.5|54.383 ms|1.0115 ms|3888.8889|1444.4444|555.5556|21.26 MB|
| **New** |	|	| **51.332 ms (-6%)** | **1.0094 ms** | **3600.0000 (-7%)** | **1400.0000 (-3%)** | **600.0000 (+8%)** | **20.45 MB (-4%)** |
| Old |ParseProgram|backbone-1.1.0|7.047 ms|0.0449 ms|617.1875|257.8125|109.3750|3.45 MB|
| **New** |	|	| **6.450 ms (-8%)** | **0.0221 ms** | **601.5625 (-3%)** | **242.1875 (-6%)** | **109.3750 (0%)** | **3.32 MB (-4%)** |
| Old |ParseProgram|jquery-1.9.1|46.479 ms|0.9223 ms|3363.6364|1272.7273|454.5455|18.13 MB|
| **New** |	|	| **44.180 ms (-5%)** | **0.8818 ms** | **3307.6923 (-2%)** | **1307.6923 (+3%)** | **538.4615 (+18%)** | **17.42 MB (-4%)** |
| Old |ParseProgram|jquery.mobile-1.4.2|77.086 ms|1.5404 ms|5142.8571|2000.0000|857.1429|29.02 MB|
| **New** |	|	| **64.977 ms (-16%)** | **1.2618 ms** | **4857.1429 (-6%)** | **2142.8571 (+7%)** | **857.1429 (0%)** | **27.9 MB (-4%)** |
| Old |ParseProgram|mootools-1.4.5|39.090 ms|0.7786 ms|2642.8571|1071.4286|357.1429|14.81 MB|
| **New** |	|	| **34.171 ms (-13%)** | **0.0935 ms** | **2533.3333 (-4%)** | **1000.0000 (-7%)** | **466.6667 (+31%)** | **14.21 MB (-4%)** |
| Old |ParseProgram|underscore-1.5.2|3.931 ms|0.0035 ms|500.0000|210.9375|0.0000|2.85 MB|
| **New** |	|	| **3.569 ms (-9%)** | **0.0023 ms** | **496.0938 (-1%)** | **238.2813 (+13%)** | **0.0000** | **2.73 MB (-4%)** |
| Old |ParseProgram|yui-3.12.0|34.505 ms|0.6384 ms|2500.0000|1071.4286|357.1429|14.04 MB|
| **New** |	|	| **34.118 ms (-1%)** | **0.5066 ms** | **2357.1429 (-6%)** | **1000.0000 (-7%)** | **357.1429 (0%)** | **13.51 MB (-4%)** |


