### PR TITLE
Separate collecting logic for error handler

### DIFF
--- a/src/Esprima/CollectingErrorHandler.cs
+++ b/src/Esprima/CollectingErrorHandler.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace Esprima
+{
+    /// <summary>
+    /// Error handler that collects errors that have been seen during the parsing.
+    /// </summary>
+    /// <remarks>
+    /// If you reuse this instance memory usage can grow during process lifetime when errors
+    /// are gathered.
+    /// </remarks>
+    public sealed class CollectingErrorHandler : ErrorHandler
+    {
+        private readonly List<ParserException> _errors = new List<ParserException>();
+
+        public IReadOnlyCollection<ParserException> Errors => _errors;
+
+        public override void RecordError(ParserException error)
+        {
+            _errors.Add(error);
+        }
+    }
+}

--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -1,23 +1,15 @@
-﻿using System.Collections.Generic;
-
 namespace Esprima
 {
+    /// <summary>
+    /// Default error handling logic for Esprima.
+    /// </summary>
     public class ErrorHandler : IErrorHandler
     {
-        public IList<ParserException> Errors { get; }
+        public string? Source { get; set; }
         public bool Tolerant { get; set; }
 
-        public string? Source { get; set; }
-
-        public ErrorHandler()
+        public virtual void RecordError(ParserException error)
         {
-            Errors = new List<ParserException>();
-            Tolerant = false;
-        }
-
-        public void RecordError(ParserException error)
-        {
-            Errors.Add(error);
         }
 
         public void Tolerate(ParserException error)
@@ -34,12 +26,12 @@ namespace Esprima
 
         public ParserException CreateError(int index, int line, int col, string description)
         {
-            return new ParserException(new ParseError(description, Source, index, new Position(line, col)));
+            return new(new ParseError(description, Source, index, new Position(line, col)));
         }
 
         public void TolerateError(int index, int line, int col, string description)
         {
-            var error = this.CreateError(index, line, col, description);
+            var error = CreateError(index, line, col, description);
             if (Tolerant)
             {
                 RecordError(error);

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -16,7 +16,6 @@
         /// Create a new <see cref="ParserOptions" /> instance.
         /// </summary>
         /// <param name="source">A string representing where the code is coming from, if an error occurs.</param>
-        /// <returns></returns>
         public ParserOptions(string source) : this(new ErrorHandler {Source = source})
         {
         }


### PR DESCRIPTION
As shown in https://github.com/sebastienros/jint/issues/829 the default error handler is bad for reuse. ParserOptions feels like something that could be reused, even between Jint engine instances but the default behavior of collecting errors can cause a memory leak. The `IErrorHandler`doesn't even expose such list for use.

Created separate `CollectingErrorHandler` if someone would like this out of the box, but now opt-in. Now by default the errors are not collected into memory in tolerant mode.