### PR TITLE
AstVisitor refactoring

### DIFF
--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -529,9 +529,6 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitLogicalExpression(BinaryExpression binaryExpression) =>
-                VisitBinaryExpression(binaryExpression);
-
             protected override void VisitLiteral(Literal literal)
             {
                 using (StartNodeObject(literal))

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -7,28 +7,8 @@ namespace Esprima.Utils
 {
     public class AstVisitor
     {
-        private readonly List<Node> _parentStack = new List<Node>();
-        protected IReadOnlyList<Node> ParentStack => _parentStack;
-
-        /// <summary>
-        /// Returns parent node at specified position.
-        /// </summary>
-        /// <param name="offset">Zero index value returns current node; one corresponds to direct
-        /// parent of current node.</param>
-        protected Node? TryGetParentAt(int offset)
-        {
-            if (_parentStack.Count < offset + 1)
-            {
-                return null;
-            }
-
-            return _parentStack[_parentStack.Count - 1 - offset];
-        }
-
         public virtual void Visit(Node node)
         {
-            _parentStack.Add(node);
-
             switch (node.Type)
             {
                 case Nodes.AssignmentExpression:
@@ -239,8 +219,6 @@ namespace Esprima.Utils
                     VisitUnknownNode(node);
                     break;
             }
-
-            _parentStack.RemoveAt(_parentStack.Count - 1);
         }
 
         protected virtual void VisitProgram(Program program)

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -14,8 +14,6 @@ namespace Esprima.Utils
         public event EventHandler<Node>? VisitedNode;
         public event EventHandler<Program>? VisitingProgram;
         public event EventHandler<Program>? VisitedProgram;
-        public event EventHandler<Statement>? VisitingStatement;
-        public event EventHandler<Statement>? VisitedStatement;
         public event EventHandler<Node>? VisitingUnknownNode;
         public event EventHandler<Node>? VisitedUnknownNode;
         public event EventHandler<CatchClause>? VisitingCatchClause;
@@ -54,8 +52,6 @@ namespace Esprima.Utils
         public event EventHandler<ForInStatement>? VisitedForInStatement;
         public event EventHandler<DoWhileStatement>? VisitingDoWhileStatement;
         public event EventHandler<DoWhileStatement>? VisitedDoWhileStatement;
-        public event EventHandler<Expression>? VisitingExpression;
-        public event EventHandler<Expression>? VisitedExpression;
         public event EventHandler<ArrowFunctionExpression>? VisitingArrowFunctionExpression;
         public event EventHandler<ArrowFunctionExpression>? VisitedArrowFunctionExpression;
         public event EventHandler<UnaryExpression>? VisitingUnaryExpression;
@@ -72,8 +68,6 @@ namespace Esprima.Utils
         public event EventHandler<NewExpression>? VisitedNewExpression;
         public event EventHandler<MemberExpression>? VisitingMemberExpression;
         public event EventHandler<MemberExpression>? VisitedMemberExpression;
-        public event EventHandler<BinaryExpression>? VisitingLogicalExpression;
-        public event EventHandler<BinaryExpression>? VisitedLogicalExpression;
         public event EventHandler<Literal>? VisitingLiteral;
         public event EventHandler<Literal>? VisitedLiteral;
         public event EventHandler<Identifier>? VisitingIdentifier;
@@ -163,13 +157,6 @@ namespace Esprima.Utils
             VisitingProgram?.Invoke(this, program);
             base.VisitProgram(program);
             VisitedProgram?.Invoke(this, program);
-        }
-
-        protected override void VisitStatement(Statement statement)
-        {
-            VisitingStatement?.Invoke(this, statement);
-            base.VisitStatement(statement);
-            VisitedStatement?.Invoke(this, statement);
         }
 
         protected override void VisitUnknownNode(Node node)
@@ -305,13 +292,6 @@ namespace Esprima.Utils
             VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
         }
 
-        protected override void VisitExpression(Expression expression)
-        {
-            VisitingExpression?.Invoke(this, expression);
-            base.VisitExpression(expression);
-            VisitedExpression?.Invoke(this, expression);
-        }
-
         protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
             VisitingArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
@@ -366,13 +346,6 @@ namespace Esprima.Utils
             VisitingMemberExpression?.Invoke(this, memberExpression);
             base.VisitMemberExpression(memberExpression);
             VisitedMemberExpression?.Invoke(this, memberExpression);
-        }
-
-        protected override void VisitLogicalExpression(BinaryExpression binaryExpression)
-        {
-            VisitingLogicalExpression?.Invoke(this, binaryExpression);
-            base.VisitLogicalExpression(binaryExpression);
-            VisitedLogicalExpression?.Invoke(this, binaryExpression);
         }
 
         protected override void VisitLiteral(Literal literal)


### PR DESCRIPTION
This PR contains refactored `AstVisitor` class that:
- pass all nodes through `Visit(Node)` dispatcher. Previous implementation were cutting corners a lot making it hard to use without a lot of overloads
- update all `Visit<Node>` methods to enumerate all child nodes. Previous implementation skipped a lot of nodes
- tracks stack of parent nodes. Replaces `NodeExtensions.AncestorNodes` helpers which traverse whole AST on each call

It's kinda breaking one (no issues with existing tests, but public API surface and behavior changed), but I think it is acceptable for v2 release. Other option is to have two visitors: legacy one and new.