### PR TITLE
Fix ParseCatchClause duplicate binding check

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -3350,6 +3350,7 @@ namespace Esprima
                 for (var i = 0; i < parameters.Count; i++)
                 {
                     var key = (string?) parameters[i].Value;
+                    if (paramMap.ContainsKey(key))
                     {
                         TolerateError(Messages.DuplicateBinding, parameters[i].Value);
                     }


### PR DESCRIPTION
Was unfortunately broken while merging optional catch clause changes.