### PR TITLE
Fix adapting Regex for C#

### DIFF
--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1574,20 +1574,29 @@ namespace Esprima
             try
             {
                 // Do we need to convert the expression to its .NET equivalent?
-                if (_adaptRegexp && options.HasFlag(RegexOptions.Multiline))
+                if (_adaptRegexp)
                 {
-                    // Replace all non-escaped $ occurences by \r?$
-                    // c.f. http://programmaticallyspeaking.com/regular-expression-multiline-mode-whats-a-newline.html
-
-                    int index = 0;
                     var newPattern = pattern;
-                    while ((index = newPattern.IndexOf("$", index, StringComparison.Ordinal)) != -1)
+
+                    if (options.HasFlag(RegexOptions.Multiline))
                     {
-                        if (index > 0 && newPattern[index - 1] != '\\')
+                        // Replace all non-escaped $ occurences by \r?$
+                        // c.f. http://programmaticallyspeaking.com/regular-expression-multiline-mode-whats-a-newline.html
+
+                        int index = 0;
+                        while ((index = newPattern.IndexOf("$", index, StringComparison.Ordinal)) != -1)
                         {
-                            newPattern = newPattern.Substring(0, index) + @"\r?" + newPattern.Substring(index);
-                            index += 4;
+                            if (index > 0 && newPattern[index - 1] != '\\')
+                            {
+                                newPattern = newPattern.Substring(0, index) + @"\r?" + newPattern.Substring(index);
+                                index += 4;
+                            }
                         }
+                    }
+
+                    if (newPattern.Contains("[^]"))
+                    {
+                        newPattern = newPattern.Replace("[^]", "[^.]");
                     }
 
                     pattern = newPattern;

--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -33,5 +33,17 @@ namespace Esprima.Tests
 
             Assert.NotNull(program);
         }
+
+        [Theory]
+        [InlineData(@"/[^]*? (:[rp] [el] a[\w -]+)[^]*/")]
+        [InlineData(@"/[^]/")]
+        [InlineData(@"/[^ ]/")]
+        public void ShouldGetNonNullRegexFromScanner(string regexp)
+        {
+            var scanner = new Scanner("", new ParserOptions { AdaptRegexp = true });
+            var regex = scanner.TestRegExp(regexp, "");
+
+            Assert.NotNull(regex);
+        }
     }
 }


### PR DESCRIPTION
Jint was still suffering from the `[^]` bug. The recent fix by @sebastienros  was preventing Parser to fail but it was not returning the adapted Regex.

This code seems confusing to me. Why do we parse the Regex twice? It is the same in original `esprima`.

Can't we just parse the Regex in one pass?