### PR TITLE
Allow reusing same JavaScriptParser instance for parsing

### DIFF
--- a/samples/Esprima.Benchmark/AstTreeWalkBenchmark.cs
+++ b/samples/Esprima.Benchmark/AstTreeWalkBenchmark.cs
@@ -14,8 +14,8 @@ namespace Esprima.Benchmark
         public void Setup()
         {
             var code = File.ReadAllText("3rdparty/angular-1.7.9.js");
-            var parser = new JavaScriptParser(code);
-            _script = parser.ParseScript();
+            var parser = new JavaScriptParser();
+            _script = parser.ParseScript(code);
         }
 
         [Benchmark]
@@ -70,8 +70,8 @@ namespace Esprima.Benchmark
                     {
                         var type = childNode.Type;
                         if (type == Nodes.FunctionDeclaration
-                            || type == Nodes.FunctionExpression  
-                            || type == Nodes.ArrowFunctionExpression 
+                            || type == Nodes.FunctionExpression
+                            || type == Nodes.ArrowFunctionExpression
                             || type == Nodes.ArrowParameterPlaceHolder)
                         {
                             _functionCount++;

--- a/samples/Esprima.Benchmark/EvaluationBenchmark.cs
+++ b/samples/Esprima.Benchmark/EvaluationBenchmark.cs
@@ -27,6 +27,8 @@ namespace Jint.Benchmark
             var done = true;
         ";
 
+        private readonly JavaScriptParser _parser = new JavaScriptParser();
+
         [Params(200)]
         public int N { get; set; }
 
@@ -35,8 +37,7 @@ namespace Jint.Benchmark
         {
             for (int i = 0; i < N; ++i)
             {
-                var parser = new JavaScriptParser(Script);
-                parser.ParseScript();
+                _parser.ParseScript(Script);
             }
         }
     }

--- a/samples/Esprima.Benchmark/FileParsingBenchmark.cs
+++ b/samples/Esprima.Benchmark/FileParsingBenchmark.cs
@@ -22,8 +22,10 @@ namespace Esprima.Benchmark
         private static readonly ParserOptions parserOptions = new ParserOptions()
         {
             Comment = true,
-            Tokens = true 
+            Tokens = true
         };
+
+        private JavaScriptParser _parser;
 
         [GlobalSetup]
         public void Setup()
@@ -32,6 +34,8 @@ namespace Esprima.Benchmark
             {
                 files[fileName] = File.ReadAllText($"3rdparty/{fileName}.js");
             }
+
+            _parser = new JavaScriptParser(parserOptions);
         }
 
         [ParamsSource(nameof(FileNames))]
@@ -48,8 +52,7 @@ namespace Esprima.Benchmark
         [Benchmark]
         public void ParseProgram()
         {
-            var parser = new JavaScriptParser(files[FileName], parserOptions);
-            parser.ParseScript();
+            _parser.ParseScript(files[FileName]);
         }
     }
 }

--- a/samples/Esprima.Sample/Program.cs
+++ b/samples/Esprima.Sample/Program.cs
@@ -10,11 +10,12 @@ namespace Esprima.Sample
     {
         public static void Main(string[] args)
         {
-            var scanner = new Scanner(@"
+            const string code = @"
 ""use strict"";
 try { } catch (evil) { }
 
-");
+";
+            var scanner = new Scanner(code);
             Tokenize(scanner);
             //Parse(scanner);
         }
@@ -36,8 +37,8 @@ try { } catch (evil) { }
 
         private static void Parse(string source, TextWriter output)
         {
-            var parser = new JavaScriptParser(source);
-            var program = parser.ParseScript();
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(source);
 
             program.WriteJson(output);
             Console.WriteLine();

--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -5,7 +5,6 @@ namespace Esprima
     /// </summary>
     public class ErrorHandler : IErrorHandler
     {
-        public string? Source { get; set; }
         public bool Tolerant { get; set; }
 
         public virtual void RecordError(ParserException error)
@@ -24,14 +23,14 @@ namespace Esprima
             }
         }
 
-        public ParserException CreateError(int index, int line, int col, string description)
+        public ParserException CreateError(string? source, int index, int line, int col, string description)
         {
-            return new(new ParseError(description, Source, index, new Position(line, col)));
+            return new(new ParseError(description, source, index, new Position(line, col)));
         }
 
-        public void TolerateError(int index, int line, int col, string description)
+        public void TolerateError(string? source, int index, int line, int col, string description)
         {
-            var error = CreateError(index, line, col, description);
+            var error = CreateError(source, index, line, col, description);
             if (Tolerant)
             {
                 RecordError(error);

--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -14,7 +14,7 @@
     <PackageTags>javascript, parser, ecmascript</PackageTags>
     <PackageProjectUrl>https://github.com/sebastienros/esprima-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <Version>2.0.0-beta-$(BuildNumber)</Version>
+    <Version>3.0.0-beta-$(BuildNumber)</Version>
 
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
@@ -26,12 +26,12 @@
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
-    
+
     <DefineConstants Condition="'$(Checked)' == true or $(Configuration) == 'Debug'">$(DefineConstants);LOCATION_ASSERTS</DefineConstants>
-    
+
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Esprima/IErrorHandler.cs
+++ b/src/Esprima/IErrorHandler.cs
@@ -2,11 +2,10 @@
 {
     public interface IErrorHandler
     {
-        string? Source { get; set; }
         bool Tolerant { get; set; }
         void RecordError(ParserException error);
         void Tolerate(ParserException error);
-        ParserException CreateError(int index, int line, int column, string message);
-        void TolerateError(int index, int line, int column, string message);
+        ParserException CreateError(string? source, int index, int line, int column, string message);
+        void TolerateError(string? source, int index, int line, int column, string message);
     }
 }

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -4,30 +4,28 @@ namespace Esprima
 {
     public class ParseError
     {
-        public string Description     { get; }
-        public string? Source          { get; }
+        public string Description { get; }
+        public string? Source { get; }
 
-        public bool IsIndexDefined    => Index >= 0;
-        public int Index              { get; }
+        public bool IsIndexDefined => Index >= 0;
+        public int Index { get; }
 
         public bool IsPositionDefined => Position.Line > 0;
-        public Position Position      { get; }
-        public int LineNumber         => Position.Line;
-        public int Column             => Position.Column;
+        public Position Position { get; }
+        public int LineNumber => Position.Line;
+        public int Column => Position.Column;
 
-        public ParseError(string description) :
-            this(description, null, -1, default) {}
-
-        public ParseError(string description,
-            string? source, int index, Position position)
+        public ParseError(string description, string? source = null, int index = -1, Position position = default)
         {
             Description = description ?? ThrowArgumentNullException<string>(nameof(description));
-            Source      = source;
-            Index       = index;
-            Position    = position;
+            Source = source;
+            Index = index;
+            Position = position;
         }
 
-        public override string ToString() =>
-            LineNumber > 0 ? $"Line {LineNumber}: {Description}" : Description;
+        public override string ToString()
+        {
+            return LineNumber > 0 ? $"Line {LineNumber}: {Description}" : Description;
+        }
     }
 }

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -15,14 +15,6 @@
         /// <summary>
         /// Create a new <see cref="ParserOptions" /> instance.
         /// </summary>
-        /// <param name="source">A string representing where the code is coming from, if an error occurs.</param>
-        public ParserOptions(string source) : this(new ErrorHandler {Source = source})
-        {
-        }
-
-        /// <summary>
-        /// Create a new <see cref="ParserOptions" /> instance.
-        /// </summary>
         /// <param name="errorHandler">The <see cref="IErrorHandler" /> to use to handle errors.</param>
         public ParserOptions(IErrorHandler errorHandler)
         {

--- a/test/Esprima.Tests/AstVisitorEventSourceTests.cs
+++ b/test/Esprima.Tests/AstVisitorEventSourceTests.cs
@@ -7,7 +7,11 @@ namespace Esprima.Tests
 {
     public class AstVisitorEventSourceTests
     {
-        static T ParseExpression<T>(string code) where T : Expression => new JavaScriptParser(code).ParseExpression().As<T>();
+        private static T ParseExpression<T>(string code) where T : Expression
+        {
+            var final = $"var f = {code}";
+            return new JavaScriptParser().ParseScript(final).Body[0].As<VariableDeclaration>().Declarations[0].Init.As<T>();
+        }
 
         [Fact]
         public void MemberExpression()

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -9,8 +9,9 @@ namespace Esprima.Tests
         [Fact]
         public void ProgramShouldBeStrict()
         {
-            var parser = new JavaScriptParser("'use strict'; function p() {}");
-            var program = parser.ParseScript();
+            const string code = "'use strict'; function p() {}";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
 
             Assert.True(program.Strict);
         }
@@ -18,8 +19,9 @@ namespace Esprima.Tests
         [Fact]
         public void ProgramShouldNotBeStrict()
         {
-            var parser = new JavaScriptParser("function p() {}");
-            var program = parser.ParseScript();
+            const string code = "function p() {}";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
 
             Assert.False(program.Strict);
         }
@@ -27,8 +29,9 @@ namespace Esprima.Tests
         [Fact]
         public void FunctionShouldNotBeStrict()
         {
-            var parser = new JavaScriptParser("function p() {}");
-            var program = parser.ParseScript();
+            const string code = "function p() {}";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var function = program.Body.First().As<FunctionDeclaration>();
 
             Assert.False(function.Strict);
@@ -37,8 +40,9 @@ namespace Esprima.Tests
         [Fact]
         public void FunctionWithUseStrictShouldBeStrict()
         {
-            var parser = new JavaScriptParser("function p() { 'use strict'; }");
-            var program = parser.ParseScript();
+            const string code = "function p() { 'use strict'; }";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var function = program.Body.First().As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
@@ -47,8 +51,9 @@ namespace Esprima.Tests
         [Fact]
         public void FunctionShouldBeStrictInProgramStrict()
         {
-            var parser = new JavaScriptParser("'use strict'; function p() {}");
-            var program = parser.ParseScript();
+            const string code = "'use strict'; function p() {}";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var function = program.Body.Skip(1).First().As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
@@ -57,8 +62,9 @@ namespace Esprima.Tests
         [Fact]
         public void FunctionShouldBeStrict()
         {
-            var parser = new JavaScriptParser("function p() {'use strict'; return false;}");
-            var program = parser.ParseScript();
+            const string code = "function p() {'use strict'; return false;}";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var function = program.Body.First().As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
@@ -67,8 +73,9 @@ namespace Esprima.Tests
         [Fact]
         public void FunctionShouldBeStrictInStrictFunction()
         {
-            var parser = new JavaScriptParser("function p() {'use strict'; function q() { return; } return; }");
-            var program = parser.ParseScript();
+            const string code = "function p() {'use strict'; function q() { return; } return; }";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var p = program.Body.First().As<FunctionDeclaration>();
             var q = p.Body.As<BlockStatement>().Body.Skip(1).First().As<FunctionDeclaration>();
 
@@ -82,8 +89,9 @@ namespace Esprima.Tests
         [Fact]
         public void LabelSetShouldPointToStatement()
         {
-            var parser = new JavaScriptParser("here: Hello();");
-            var program = parser.ParseScript();
+            const string code = "here: Hello();";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
             var labeledStatement = program.Body.First().As<LabeledStatement>();
             var body = labeledStatement.Body;
 
@@ -95,41 +103,44 @@ namespace Esprima.Tests
         [InlineData(18446744073709552000d, "0xffffffffffffffff")]
         public void ShouldParseNumericLiterals(object expected, string source)
         {
-            var parser = new JavaScriptParser(source);
-            var expression = parser.ParseExpression();
+            var parser = new JavaScriptParser();
+            var script = parser.ParseScript($"var f = {source};");
+            var expression = script.Body[0].As<VariableDeclaration>().Declarations[0].Init;
 
             var literal = expression as Literal;
 
             Assert.NotNull(literal);
             Assert.Equal(expected, literal.NumericValue);
-
         }
 
         [Fact]
         public void ShouldParseClassInheritance()
         {
-            var parser = new JavaScriptParser("class Rectangle extends aggregation(Shape, Colored, ZCoord) { }");
-            var program = parser.ParseScript();
+            const string code = "class Rectangle extends aggregation(Shape, Colored, ZCoord) { }";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
         }
 
         [Fact]
         public void ShouldSymbolPropertyKey()
         {
-            var parser = new JavaScriptParser("var a = { [Symbol.iterator]: undefined }");
-            var program = parser.ParseScript();
+            var code = "var a = { [Symbol.iterator]: undefined }";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
         }
 
         [Fact]
         public void ShouldParseLocation()
         {
-            var parser = new JavaScriptParser("// End on second line\r\n");
-            var program = parser.ParseScript();
+            const string code = "// End on second line\r\n";
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
         }
 
         [Fact]
         public void ShouldParseArrayPattern()
         {
-            var parser = new JavaScriptParser(@"
+            const string code = @"
 var values = [1, 2, 3];
 
 var callCount = 0;
@@ -139,23 +150,24 @@ f = ([...[...x]]) => {
 };
 
 f(values);
+";
+            var parser = new JavaScriptParser();
 
-");
-
-            var program = parser.ParseScript();
+            var program = parser.ParseScript(code);
         }
 
         [Fact]
         public void CanParseInvalidCurly()
         {
-            var parser = new JavaScriptParser("if (1}=1) eval('1');");
-            Assert.Throws<ParserException>(() => parser.ParseScript());
+            const string code = "if (1}=1) eval('1');";
+            var parser = new JavaScriptParser();
+            Assert.Throws<ParserException>(() => parser.ParseScript(code));
         }
 
         [Fact]
         public void CanReportProblemWithLargeNumber()
         {
-            Assert.Throws<ParserException>(() => new JavaScriptParser("066666666666666666666666666666"));
+            Assert.Throws<ParserException>(() => new JavaScriptParser().ParseScript("066666666666666666666666666666"));
         }
 
         [Theory]
@@ -164,29 +176,32 @@ f(values);
         [InlineData("...")]
         public void CanParseDot(string script)
         {
-            var parser = new JavaScriptParser(script);
-            Assert.Throws<ParserException>(() => parser.ParseScript());
+            var parser = new JavaScriptParser();
+            Assert.Throws<ParserException>(() => parser.ParseScript(script));
         }
 
         [Fact]
         public void ThrowsErrorForInvalidRegExFlags()
         {
-            var parser = new JavaScriptParser("/'/o//'///C//ÿ");
-            Assert.Throws<ParserException>(() => parser.ParseScript());
+            const string code = "/'/o//'///C//ÿ";
+            var parser = new JavaScriptParser();
+            Assert.Throws<ParserException>(() => parser.ParseScript(code));
         }
 
         [Fact]
         public void ThrowsErrorForDeepRecursionParsing()
         {
-            var parser = new JavaScriptParser("if ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((true)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) { } ");
-            Assert.Throws<ParserException>(() => parser.ParseScript());
+            const string code = "if ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((true)))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))) { } ";
+            var parser = new JavaScriptParser();
+            Assert.Throws<ParserException>(() => parser.ParseScript(code));
         }
 
         [Fact]
         public void ShouldParseStaticMemberExpressionPropertyInitializer()
         {
-            var parser = new JavaScriptParser("class Edge { [util.inspect.custom] () { return this.toJSON() } }");
-            parser.ParseScript();
+            const string code = "class Edge { [util.inspect.custom] () { return this.toJSON() } }";
+            var parser = new JavaScriptParser();
+            parser.ParseScript(code);
         }
     }
 }

--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -31,8 +31,9 @@ namespace Esprima.Tests
         [InlineData(@"/[]a/")]
         public void ShouldParseRegularExpression(string regexp)
         {
-            var parser = new JavaScriptParser(@"var O = " + regexp);
-            var program = parser.ParseScript();
+            var code = @"var O = " + regexp;
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(code);
 
             Assert.NotNull(program);
         }

--- a/test/Esprima.Tests/VisitorTests.cs
+++ b/test/Esprima.Tests/VisitorTests.cs
@@ -5,11 +5,17 @@ namespace Esprima.Tests
 {
     public class VisitorTests
     {
+        private readonly JavaScriptParser _parser;
+
+        public VisitorTests()
+        {
+            _parser = new JavaScriptParser();
+        }
+
         [Fact]
         public void CanVisitIfWithNoElse()
         {
-            var parser = new JavaScriptParser("if (true) { p(); }");
-            var program = parser.ParseScript();
+            var program = _parser.ParseScript("if (true) { p(); }");
 
             AstVisitor visitor = new AstVisitor();
             visitor.Visit(program);
@@ -18,12 +24,12 @@ namespace Esprima.Tests
         [Fact]
         public void CanVisitSwitchCase()
         {
-            var parser = new JavaScriptParser(@"switch(foo) {
+            var parser = new JavaScriptParser();
+            var program = _parser.ParseScript(@"switch(foo) {
     case 'A':
         p();
         break;
 }");
-            var program = parser.ParseScript();
 
             AstVisitor visitor = new AstVisitor();
             visitor.Visit(program);
@@ -32,12 +38,12 @@ namespace Esprima.Tests
         [Fact]
         public void CanVisitDefaultSwitchCase()
         {
-            var parser = new JavaScriptParser(@"switch(foo) {
+            var parser = new JavaScriptParser();
+            var program = _parser.ParseScript(@"switch(foo) {
     default:
         p();
         break;
 }");
-            var program = parser.ParseScript();
 
             AstVisitor visitor = new AstVisitor();
             visitor.Visit(program);
@@ -46,8 +52,7 @@ namespace Esprima.Tests
         [Fact]
         public void CanVisitForWithNoTest()
         {
-            var parser = new JavaScriptParser(@"for (var a = []; ; ) { }");
-            var program = parser.ParseScript();
+            var program = _parser.ParseScript(@"for (var a = []; ; ) { }");
 
             AstVisitor visitor = new AstVisitor();
             visitor.Visit(program);
@@ -56,8 +61,8 @@ namespace Esprima.Tests
         [Fact]
         public void CanVisitForOfStatement()
         {
-            var parser = new JavaScriptParser(@"for (var elem of list) { }");
-            var program = parser.ParseScript();
+            var parser = new JavaScriptParser();
+            var program = parser.ParseScript(@"for (var elem of list) { }");
 
             AstVisitor visitor = new AstVisitor();
             visitor.Visit(program);


### PR DESCRIPTION
It's always been a bit odd that you need to instantiate a new instance of `JavaScriptParser` every time you want to parse something. Changing parsing to be stateless and based on `ParseScript`/`ParseModule` input, resetting internal state between calls. Tested on Jint side and all tests green when reusing same parser instance inside engine instance.

API breaking change so probably requires setting version to 3.x.

Before (new'ing parser 200 times for parsing same script):

|       Method |   N |     Mean |     Error |    StdDev |    Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------- |---- |---------:|----------:|----------:|---------:|-------:|------:|----------:|
| ParseProgram | 200 | 2.639 ms | 0.0051 ms | 0.0043 ms | 312.5000 | 3.9063 |     - |   5.03 MB |


After (having parser as member and reusing same instance):

|       Method |   N |     Mean |     Error |    StdDev |    Gen 0 |  Gen 1 | Gen 2 | Allocated |
|------------- |---- |---------:|----------:|----------:|---------:|-------:|------:|----------:|
| ParseProgram | 200 | 2.420 ms | 0.0051 ms | 0.0048 ms | 292.9688 | 3.9063 |     - |   4.68 MB |

