### PR TITLE
Add missing branching to AstVisitor

### DIFF
--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -2,15 +2,17 @@
 {
     public sealed class ArrayPattern : BindingPattern
     {
-        private readonly NodeList<Expression> _elements;
+        private readonly NodeList<Expression?> _elements;
 
-        public ArrayPattern(in NodeList<Expression> elements) : base(Nodes.ArrayPattern)
+        public ArrayPattern(in NodeList<Expression?> elements) : base(Nodes.ArrayPattern)
         {
             _elements = elements;
         }
 
-        public ref readonly NodeList<Expression> Elements => ref _elements;
+        public ref readonly NodeList<Expression?> Elements => ref _elements;
 
+#pragma warning disable 8631
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
+#pragma warning restore 8631
     }
 }

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -585,7 +585,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitFunctionExpression(FunctionExpression function)
+            protected override void VisitFunctionExpression(IFunction function)
             {
                 using (StartNodeObject((Node) function))
                 {

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -249,10 +249,10 @@ namespace Esprima.Utils
                 Member(name, map[value]);
             }
 
-            private void Member<T>(string name, in NodeList<T> nodes) where T : Node =>
+            private void Member<T>(string name, in NodeList<T> nodes) where T : Node? =>
                 Member(name, nodes, node => node);
 
-            private void Member<T>(string name, in NodeList<T> list, Func<T, Node> nodeSelector) where T : Node
+            private void Member<T>(string name, in NodeList<T> list, Func<T, Node?> nodeSelector) where T : Node?
             {
                 Member(name);
                 _writer.StartArray();
@@ -610,7 +610,7 @@ namespace Esprima.Utils
 
             protected override void VisitChainExpression(ChainExpression chainExpression)
             {
-                using (StartNodeObject(chainExpression)) 
+                using (StartNodeObject(chainExpression))
                     Member("expression", chainExpression.Expression);
             }
 

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -585,7 +585,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitFunctionExpression(IFunction function)
+            protected override void VisitFunctionExpression(FunctionExpression function)
             {
                 using (StartNodeObject((Node) function))
                 {

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -225,87 +225,12 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitStatement(Statement statement)
-        {
-            switch (statement.Type)
-            {
-                case Nodes.BlockStatement:
-                    VisitBlockStatement(statement.As<BlockStatement>());
-                    break;
-                case Nodes.BreakStatement:
-                    VisitBreakStatement(statement.As<BreakStatement>());
-                    break;
-                case Nodes.ContinueStatement:
-                    VisitContinueStatement(statement.As<ContinueStatement>());
-                    break;
-                case Nodes.DoWhileStatement:
-                    VisitDoWhileStatement(statement.As<DoWhileStatement>());
-                    break;
-                case Nodes.DebuggerStatement:
-                    VisitDebuggerStatement(statement.As<DebuggerStatement>());
-                    break;
-                case Nodes.EmptyStatement:
-                    VisitEmptyStatement(statement.As<EmptyStatement>());
-                    break;
-                case Nodes.ExpressionStatement:
-                    VisitExpressionStatement(statement.As<ExpressionStatement>());
-                    break;
-                case Nodes.ForStatement:
-                    VisitForStatement(statement.As<ForStatement>());
-                    break;
-                case Nodes.ForInStatement:
-                    VisitForInStatement(statement.As<ForInStatement>());
-                    break;
-                case Nodes.ForOfStatement:
-                    VisitForOfStatement(statement.As<ForOfStatement>());
-                    break;
-                case Nodes.FunctionDeclaration:
-                    VisitFunctionDeclaration(statement.As<FunctionDeclaration>());
-                    break;
-                case Nodes.IfStatement:
-                    VisitIfStatement(statement.As<IfStatement>());
-                    break;
-                case Nodes.LabeledStatement:
-                    VisitLabeledStatement(statement.As<LabeledStatement>());
-                    break;
-                case Nodes.ReturnStatement:
-                    VisitReturnStatement(statement.As<ReturnStatement>());
-                    break;
-                case Nodes.SwitchStatement:
-                    VisitSwitchStatement(statement.As<SwitchStatement>());
-                    break;
-                case Nodes.ThrowStatement:
-                    VisitThrowStatement(statement.As<ThrowStatement>());
-                    break;
-                case Nodes.TryStatement:
-                    VisitTryStatement(statement.As<TryStatement>());
-                    break;
-                case Nodes.VariableDeclaration:
-                    VisitVariableDeclaration(statement.As<VariableDeclaration>());
-                    break;
-                case Nodes.WhileStatement:
-                    VisitWhileStatement(statement.As<WhileStatement>());
-                    break;
-                case Nodes.WithStatement:
-                    VisitWithStatement(statement.As<WithStatement>());
-                    break;
-                case Nodes.Program:
-                    VisitProgram(statement.As<Program>());
-                    break;
-                case Nodes.CatchClause:
-                    VisitCatchClause(statement.As<CatchClause>());
-                    break;
-                default:
-                    VisitUnknownNode(statement);
-                    break;
-            }
-        }
-
         protected virtual void VisitProgram(Program program)
         {
-            foreach (var statement in program.Body)
+            ref readonly var statements = ref program.Body;
+            for (var i = 0; i < statements.Count; i++)
             {
-                VisitStatement((Statement)statement);
+                Visit(statements[i]);
             }
         }
 
@@ -316,18 +241,27 @@ namespace Esprima.Utils
 
         protected virtual void VisitCatchClause(CatchClause catchClause)
         {
-            if (catchClause.Param is not null)
+            if (catchClause.Param is Identifier identifier)
             {
-                VisitIdentifier(catchClause.Param.As<Identifier>());
+                VisitIdentifier(identifier);
             }
-            VisitStatement(catchClause.Body);
+            else if (catchClause.Param is ArrayPattern arrayPattern)
+            {
+                VisitArrayPattern(arrayPattern);
+            }
+            else if (catchClause.Param is ObjectPattern objectPattern)
+            {
+                VisitObjectPattern(objectPattern);
+            }
+            Visit(catchClause.Body);
         }
 
         protected virtual void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
         {
-            foreach (var p in functionDeclaration.Params)
+            ref readonly var parameters = ref functionDeclaration.Params;
+            for (var i = 0; i < parameters.Count; i++)
             {
-                Visit(p);
+                Visit(parameters[i]);
             }
 
             Visit(functionDeclaration.Body);
@@ -335,27 +269,28 @@ namespace Esprima.Utils
 
         protected virtual void VisitWithStatement(WithStatement withStatement)
         {
-            VisitExpression(withStatement.Object);
-            VisitStatement(withStatement.Body);
+            Visit(withStatement.Object);
+            Visit(withStatement.Body);
         }
 
         protected virtual void VisitWhileStatement(WhileStatement whileStatement)
         {
-            VisitExpression(whileStatement.Test);
-            VisitStatement(whileStatement.Body);
+            Visit(whileStatement.Test);
+            Visit(whileStatement.Body);
         }
 
         protected virtual void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
         {
-            foreach (var declaration in variableDeclaration.Declarations)
+            ref readonly var declarations = ref variableDeclaration.Declarations;
+            for (var i = 0; i < declarations.Count; i++)
             {
-                Visit(declaration);
+                Visit(declarations[i]);
             }
         }
 
         protected virtual void VisitTryStatement(TryStatement tryStatement)
         {
-            VisitStatement(tryStatement.Block);
+            Visit(tryStatement.Block);
             if (tryStatement.Handler != null)
             {
                 VisitCatchClause(tryStatement.Handler);
@@ -363,21 +298,22 @@ namespace Esprima.Utils
 
             if (tryStatement.Finalizer != null)
             {
-                VisitStatement(tryStatement.Finalizer);
+                Visit(tryStatement.Finalizer);
             }
         }
 
         protected virtual void VisitThrowStatement(ThrowStatement throwStatement)
         {
-            VisitExpression(throwStatement.Argument);
+            Visit(throwStatement.Argument);
         }
 
         protected virtual void VisitSwitchStatement(SwitchStatement switchStatement)
         {
-            VisitExpression(switchStatement.Discriminant);
-            foreach (var c in switchStatement.Cases)
+            Visit(switchStatement.Discriminant);
+            ref readonly var cases = ref switchStatement.Cases;
+            for (var i = 0; i < cases.Count; i++)
             {
-                VisitSwitchCase(c);
+                VisitSwitchCase(cases[i]);
             }
         }
 
@@ -385,12 +321,14 @@ namespace Esprima.Utils
         {
             if (switchCase.Test != null)
             {
-                VisitExpression(switchCase.Test);
+                Visit(switchCase.Test);
             }
 
-            foreach (var s in switchCase.Consequent)
+            ref readonly var consequent = ref switchCase.Consequent;
+            for (var i = 0; i < consequent.Count; i++)
             {
-                VisitStatement(s);
+                var s = consequent[i];
+                Visit(s);
             }
         }
 
@@ -398,21 +336,21 @@ namespace Esprima.Utils
         {
             if (returnStatement.Argument == null)
                 return;
-            VisitExpression(returnStatement.Argument);
+            Visit(returnStatement.Argument);
         }
 
         protected virtual void VisitLabeledStatement(LabeledStatement labeledStatement)
         {
-            VisitStatement(labeledStatement.Body);
+            Visit(labeledStatement.Body);
         }
 
         protected virtual void VisitIfStatement(IfStatement ifStatement)
         {
-            VisitExpression(ifStatement.Test);
-            VisitStatement(ifStatement.Consequent);
+            Visit(ifStatement.Test);
+            Visit(ifStatement.Consequent);
             if (ifStatement.Alternate != null)
             {
-                VisitStatement(ifStatement.Alternate);
+                Visit(ifStatement.Alternate);
             }
         }
 
@@ -426,7 +364,7 @@ namespace Esprima.Utils
 
         protected virtual void VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
-            VisitExpression(expressionStatement.Expression);
+            Visit(expressionStatement.Expression);
         }
 
         protected virtual void VisitForStatement(ForStatement forStatement)
@@ -435,104 +373,40 @@ namespace Esprima.Utils
             {
                 if (forStatement.Init.Type == Nodes.VariableDeclaration)
                 {
-                    VisitStatement(forStatement.Init.As<Statement>());
+                    Visit(forStatement.Init.As<Statement>());
                 }
                 else
                 {
-                    VisitExpression(forStatement.Init.As<Expression>());
+                    Visit(forStatement.Init.As<Expression>());
                 }
             }
             if (forStatement.Test != null)
             {
-                VisitExpression(forStatement.Test);
+                Visit(forStatement.Test);
             }
-            VisitStatement(forStatement.Body);
+            Visit(forStatement.Body);
             if (forStatement.Update != null)
             {
-                VisitExpression(forStatement.Update);
+                Visit(forStatement.Update);
             }
         }
 
         protected virtual void VisitForInStatement(ForInStatement forInStatement)
         {
-            Identifier identifier = forInStatement.Left.Type == Nodes.VariableDeclaration
-                ? forInStatement.Left.As<VariableDeclaration>().Declarations[0].Id.As<Identifier>()
-                : forInStatement.Left.As<Identifier>();
-            VisitExpression(identifier);
-            VisitExpression(forInStatement.Right);
-            VisitStatement(forInStatement.Body);
+            Visit(forInStatement.Left);
+            Visit(forInStatement.Right);
+            Visit(forInStatement.Body);
         }
 
         protected virtual void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
         {
-            VisitStatement(doWhileStatement.Body);
-            VisitExpression(doWhileStatement.Test);
-        }
-
-        protected virtual void VisitExpression(Expression expression)
-        {
-            switch (expression.Type)
-            {
-                case Nodes.AssignmentExpression:
-                    VisitAssignmentExpression(expression.As<AssignmentExpression>());
-                    break;
-                case Nodes.ArrayExpression:
-                    VisitArrayExpression(expression.As<ArrayExpression>());
-                    break;
-                case Nodes.BinaryExpression:
-                    VisitBinaryExpression(expression.As<BinaryExpression>());
-                    break;
-                case Nodes.CallExpression:
-                    VisitCallExpression(expression.As<CallExpression>());
-                    break;
-                case Nodes.ConditionalExpression:
-                    VisitConditionalExpression(expression.As<ConditionalExpression>());
-                    break;
-                case Nodes.FunctionExpression:
-                    VisitFunctionExpression(expression.As<FunctionExpression>());
-                    break;
-                case Nodes.Identifier:
-                    VisitIdentifier(expression.As<Identifier>());
-                    break;
-                case Nodes.Literal:
-                    VisitLiteral(expression.As<Literal>());
-                    break;
-                case Nodes.LogicalExpression:
-                    VisitLogicalExpression(expression.As<BinaryExpression>());
-                    break;
-                case Nodes.MemberExpression:
-                    VisitMemberExpression(expression.As<MemberExpression>());
-                    break;
-                case Nodes.NewExpression:
-                    VisitNewExpression(expression.As<NewExpression>());
-                    break;
-                case Nodes.ObjectExpression:
-                    VisitObjectExpression(expression.As<ObjectExpression>());
-                    break;
-                case Nodes.SequenceExpression:
-                    VisitSequenceExpression(expression.As<SequenceExpression>());
-                    break;
-                case Nodes.ThisExpression:
-                    VisitThisExpression(expression.As<ThisExpression>());
-                    break;
-                case Nodes.UpdateExpression:
-                    VisitUpdateExpression(expression.As<UpdateExpression>());
-                    break;
-                case Nodes.UnaryExpression:
-                    VisitUnaryExpression(expression.As<UnaryExpression>());
-                    break;
-                case Nodes.ArrowFunctionExpression:
-                    VisitArrowFunctionExpression(expression.As<ArrowFunctionExpression>());
-                    break;
-                default:
-                    VisitUnknownNode(expression);
-                    break;
-            }
+            Visit(doWhileStatement.Body);
+            Visit(doWhileStatement.Test);
         }
 
         protected virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
-            //Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
+            // Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
             var statement = arrowFunctionExpression.Expression
                 ? new BlockStatement(new NodeList<Statement>(new Statement[] {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())}, 1))
                 : arrowFunctionExpression.Body.As<BlockStatement>();
@@ -549,12 +423,12 @@ namespace Esprima.Utils
 
         protected virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
         {
-            VisitExpression(unaryExpression.Argument);
+            Visit(unaryExpression.Argument);
         }
 
         protected virtual void VisitUpdateExpression(UpdateExpression updateExpression)
         {
-            VisitExpression(updateExpression.Argument);
+            Visit(updateExpression.Argument);
         }
 
         protected virtual void VisitThisExpression(ThisExpression thisExpression)
@@ -563,16 +437,19 @@ namespace Esprima.Utils
 
         protected virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
-            foreach (var e in sequenceExpression.Expressions)
+            ref readonly var expressions = ref sequenceExpression.Expressions;
+            for (var i = 0; i < expressions.Count; i++)
             {
-                VisitExpression(e);
+                Visit(expressions[i]);
             }
         }
 
         protected virtual void VisitObjectExpression(ObjectExpression objectExpression)
         {
-            foreach (var p in objectExpression.Properties)
+            ref readonly var properties = ref objectExpression.Properties;
+            for (var i = 0; i < properties.Count; i++)
             {
+                var p = properties[i];
                 if (p is SpreadElement spreadElement)
                 {
                     VisitSpreadElement(spreadElement);
@@ -586,17 +463,20 @@ namespace Esprima.Utils
 
         protected virtual void VisitNewExpression(NewExpression newExpression)
         {
-            foreach (var e in newExpression.Arguments)
+            ref readonly var arguments = ref newExpression.Arguments;
+            for (var i = 0; i < arguments.Count; i++)
             {
-                VisitExpression(e);
+                var e = arguments[i];
+                Visit(e);
             }
-            VisitExpression(newExpression.Callee);
+
+            Visit(newExpression.Callee);
         }
 
         protected virtual void VisitMemberExpression(MemberExpression memberExpression)
         {
-            VisitExpression(memberExpression.Object);
-            VisitExpression(memberExpression.Property);
+            Visit(memberExpression.Object);
+            Visit(memberExpression.Property);
         }
 
         protected virtual void VisitLogicalExpression(BinaryExpression binaryExpression)
@@ -614,35 +494,62 @@ namespace Esprima.Utils
 
         protected virtual void VisitFunctionExpression(IFunction function)
         {
-            foreach (var param in function.Params)
+            ref readonly var parameters = ref function.Params;
+            for (var i = 0; i < parameters.Count; i++)
             {
+                var param = parameters[i];
                 Visit(param!);
             }
+
             Visit(function.Body);
         }
 
         protected virtual void VisitChainExpression(ChainExpression chainExpression)
         {
+            Visit(chainExpression.Expression);
         }
 
         protected virtual void VisitClassExpression(ClassExpression classExpression)
         {
+            if (classExpression.Id is not null)
+            {
+                Visit(classExpression.Id);
+            }
         }
 
         protected virtual void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
         {
+            Visit(exportDefaultDeclaration.Declaration);
         }
 
         protected virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
+            VisitLiteral(exportAllDeclaration.Source);
         }
 
         protected virtual void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
         {
+            ref readonly var specifiers = ref exportNamedDeclaration.Specifiers;
+            for (var i = 0; i < specifiers.Count; i++)
+            {
+                VisitExportSpecifier(specifiers[i]);
+            }
+
+            if (exportNamedDeclaration.Declaration is not null)
+            {
+                Visit(exportNamedDeclaration.Declaration);
+            }
+
+            if (exportNamedDeclaration.Source is not null)
+            {
+                Visit(exportNamedDeclaration.Source);
+            }
         }
 
         protected virtual void VisitExportSpecifier(ExportSpecifier exportSpecifier)
         {
+            Visit(exportSpecifier.Exported);
+            Visit(exportSpecifier.Local);
         }
 
         protected virtual void VisitImport(Import import)
@@ -651,45 +558,79 @@ namespace Esprima.Utils
 
         protected virtual void VisitImportDeclaration(ImportDeclaration importDeclaration)
         {
+            ref readonly var specifiers = ref importDeclaration.Specifiers;
+            for (var i = 0; i < specifiers.Count; i++)
+            {
+                Visit(specifiers[i]);
+            }
+
+            Visit(importDeclaration.Source);
         }
 
         protected virtual void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
         {
+            Visit(importNamespaceSpecifier.Local);
         }
 
         protected virtual void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
+            Visit(importDefaultSpecifier.Local);
         }
 
         protected virtual void VisitImportSpecifier(ImportSpecifier importSpecifier)
         {
+            Visit(importSpecifier.Local);
+            Visit(importSpecifier.Imported);
         }
 
-        protected virtual void VisitMethodDefinition(MethodDefinition methodDefinitions)
+        protected virtual void VisitMethodDefinition(MethodDefinition methodDefinition)
         {
+            Visit(methodDefinition.Key);
+            Visit(methodDefinition.Value);
         }
 
         protected virtual void VisitForOfStatement(ForOfStatement forOfStatement)
         {
-            VisitExpression(forOfStatement.Right);
+            Visit(forOfStatement.Right);
             Visit(forOfStatement.Left);
-            VisitStatement(forOfStatement.Body);
+            Visit(forOfStatement.Body);
         }
 
         protected virtual void VisitClassDeclaration(ClassDeclaration classDeclaration)
         {
+            if (classDeclaration.Id is not null)
+            {
+                VisitIdentifier(classDeclaration.Id);
+            }
+            if (classDeclaration.SuperClass is not null)
+            {
+                Visit(classDeclaration.SuperClass);
+            }
+            VisitClassBody(classDeclaration.Body);
         }
 
         protected virtual void VisitClassBody(ClassBody classBody)
         {
+            ref readonly var body = ref classBody.Body;
+            for (var i = 0; i < body.Count; i++)
+            {
+                var classProperty = body[i];
+                Visit(classProperty);
+            }
         }
 
         protected virtual void VisitYieldExpression(YieldExpression yieldExpression)
         {
+            if (yieldExpression.Argument is not null)
+            {
+                Visit(yieldExpression.Argument);
+            }
         }
 
         protected virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
+            Visit(taggedTemplateExpression.Tag);
+            VisitTemplateLiteral(taggedTemplateExpression.Quasi);
         }
 
         protected virtual void VisitSuper(Super super)
@@ -698,39 +639,71 @@ namespace Esprima.Utils
 
         protected virtual void VisitMetaProperty(MetaProperty metaProperty)
         {
+            VisitIdentifier(metaProperty.Meta);
+            VisitIdentifier(metaProperty.Property);
         }
 
         protected virtual void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
         {
+            // ArrowParameterPlaceHolder nodes never appear in the final tree and only used during the construction of a tree.
         }
 
         protected virtual void VisitObjectPattern(ObjectPattern objectPattern)
         {
+            ref readonly var properties = ref objectPattern.Properties;
+            for (var i = 0; i < properties.Count; i++)
+            {
+                var property = properties[i];
+                Visit(property);
+            }
         }
 
         protected virtual void VisitSpreadElement(SpreadElement spreadElement)
         {
+            Visit(spreadElement.Argument);
         }
 
         protected virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
+            Visit(assignmentPattern.Left);
+            Visit(assignmentPattern.Right);
         }
 
         protected virtual void VisitArrayPattern(ArrayPattern arrayPattern)
         {
+            ref readonly var elements = ref arrayPattern.Elements;
+            for (var i = 0; i < elements.Count; i++)
+            {
+                var arg = elements[i];
+                if (arg is not null)
+                {
+                    Visit(arg);
+                }
+            }
         }
 
         protected virtual void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
         {
-            VisitIdentifier(variableDeclarator.Id.As<Identifier>());
+            Visit(variableDeclarator.Id);
             if (variableDeclarator.Init != null)
             {
-                VisitExpression(variableDeclarator.Init);
+                Visit(variableDeclarator.Init);
             }
         }
 
         protected virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
+            ref readonly var quasis = ref templateLiteral.Quasis;
+            for (var i = 0; i < quasis.Count; i++)
+            {
+                VisitTemplateElement(quasis[i]);
+            }
+
+            ref readonly var expressions = ref templateLiteral.Expressions;
+            for (var i = 0; i < expressions.Count; i++)
+            {
+                Visit(expressions[i]);
+            }
         }
 
         protected virtual void VisitTemplateElement(TemplateElement templateElement)
@@ -739,17 +712,18 @@ namespace Esprima.Utils
 
         protected virtual void VisitRestElement(RestElement restElement)
         {
+            Visit(restElement.Argument);
         }
 
         protected virtual void VisitProperty(Property property)
         {
-            VisitExpression(property.Key);
+            Visit(property.Key);
 
             switch (property.Kind)
             {
                 case PropertyKind.Init:
                 case PropertyKind.Data:
-                    VisitExpression(property.Value);
+                    Visit(property.Value);
                     break;
                 case PropertyKind.None:
                     break;
@@ -769,58 +743,75 @@ namespace Esprima.Utils
 
         protected virtual void VisitAwaitExpression(AwaitExpression awaitExpression)
         {
-            VisitExpression(awaitExpression.Argument);
+            Visit(awaitExpression.Argument);
         }
 
         protected virtual void VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
-            VisitExpression(conditionalExpression.Test);
-            VisitExpression(conditionalExpression.Consequent);
-            VisitExpression(conditionalExpression.Alternate);
+            Visit(conditionalExpression.Test);
+            Visit(conditionalExpression.Consequent);
+            Visit(conditionalExpression.Alternate);
         }
 
         protected virtual void VisitCallExpression(CallExpression callExpression)
         {
-            VisitExpression(callExpression.Callee);
-            foreach (var arg in callExpression.Arguments)
+            Visit(callExpression.Callee);
+            ref readonly var arguments = ref callExpression.Arguments;
+            for (var i = 0; i < arguments.Count; i++)
             {
-                VisitExpression(arg);
+                var arg = arguments[i];
+                Visit(arg);
             }
         }
 
         protected virtual void VisitBinaryExpression(BinaryExpression binaryExpression)
         {
-            VisitExpression(binaryExpression.Left);
-            VisitExpression(binaryExpression.Right);
+            Visit(binaryExpression.Left);
+            Visit(binaryExpression.Right);
         }
 
         protected virtual void VisitArrayExpression(ArrayExpression arrayExpression)
         {
-            foreach (var expr in arrayExpression.Elements)
+            ref readonly var elements = ref arrayExpression.Elements;
+            for (var i = 0; i < elements.Count; i++)
             {
-                VisitExpression(expr!);
+                var expr = elements[i];
+                if (expr is not null)
+                {
+                    Visit(expr);
+                }
             }
         }
 
         protected virtual void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
-            VisitExpression(assignmentExpression.Left);
-            VisitExpression(assignmentExpression.Right);
+            Visit(assignmentExpression.Left);
+            Visit(assignmentExpression.Right);
         }
 
         protected virtual void VisitContinueStatement(ContinueStatement continueStatement)
         {
+            if (continueStatement.Label is not null)
+            {
+                VisitIdentifier(continueStatement.Label);
+            }
         }
 
         protected virtual void VisitBreakStatement(BreakStatement breakStatement)
         {
+            if (breakStatement.Label is not null)
+            {
+                VisitIdentifier(breakStatement.Label);
+            }
         }
 
         protected virtual void VisitBlockStatement(BlockStatement blockStatement)
         {
-            foreach (var statement in blockStatement.Body)
+            ref readonly var body = ref blockStatement.Body;
+            for (var i = 0; i < body.Count; i++)
             {
-                VisitStatement(statement);
+                var statement = body[i];
+                Visit(statement);
             }
         }
     }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -404,19 +404,14 @@ namespace Esprima.Utils
 
         protected virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
-            // Here we construct the function so if we iterate only functions we will be able to iterate ArrowFunctions too
-            var statement = arrowFunctionExpression.Expression
-                ? new BlockStatement(new NodeList<Statement>(new Statement[] {new ReturnStatement(arrowFunctionExpression.Body.As<Expression>())}, 1))
-                : arrowFunctionExpression.Body.As<BlockStatement>();
+            ref readonly var parameters = ref arrowFunctionExpression.Params;
+            for (var i = 0; i < parameters.Count; i++)
+            {
+                var param = parameters[i];
+                Visit(param!);
+            }
 
-            var func = new FunctionExpression(new Identifier(null),
-                arrowFunctionExpression.Params,
-                statement,
-                generator: arrowFunctionExpression.Generator,
-                IsStrictMode,
-                async: arrowFunctionExpression.Async);
-
-            Visit(func);
+            Visit(arrowFunctionExpression.Body);
         }
 
         protected virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
@@ -486,7 +481,7 @@ namespace Esprima.Utils
         {
         }
 
-        protected virtual void VisitFunctionExpression(FunctionExpression function)
+        protected virtual void VisitFunctionExpression(IFunction function)
         {
             if (function.Id is not null)
             {

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -14,8 +14,6 @@ namespace Esprima.Utils
         public event EventHandler<Node>? VisitedNode;
         public event EventHandler<Program>? VisitingProgram;
         public event EventHandler<Program>? VisitedProgram;
-        public event EventHandler<Statement>? VisitingStatement;
-        public event EventHandler<Statement>? VisitedStatement;
         public event EventHandler<Node>? VisitingUnknownNode;
         public event EventHandler<Node>? VisitedUnknownNode;
         public event EventHandler<CatchClause>? VisitingCatchClause;
@@ -54,8 +52,6 @@ namespace Esprima.Utils
         public event EventHandler<ForInStatement>? VisitedForInStatement;
         public event EventHandler<DoWhileStatement>? VisitingDoWhileStatement;
         public event EventHandler<DoWhileStatement>? VisitedDoWhileStatement;
-        public event EventHandler<Expression>? VisitingExpression;
-        public event EventHandler<Expression>? VisitedExpression;
         public event EventHandler<ArrowFunctionExpression>? VisitingArrowFunctionExpression;
         public event EventHandler<ArrowFunctionExpression>? VisitedArrowFunctionExpression;
         public event EventHandler<UnaryExpression>? VisitingUnaryExpression;
@@ -165,13 +161,6 @@ namespace Esprima.Utils
             VisitingProgram?.Invoke(this, program);
             base.VisitProgram(program);
             VisitedProgram?.Invoke(this, program);
-        }
-
-        protected override void VisitStatement(Statement statement)
-        {
-            VisitingStatement?.Invoke(this, statement);
-            base.VisitStatement(statement);
-            VisitedStatement?.Invoke(this, statement);
         }
 
         protected override void VisitUnknownNode(Node node)
@@ -305,13 +294,6 @@ namespace Esprima.Utils
             VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
             base.VisitDoWhileStatement(doWhileStatement);
             VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
-        }
-
-        protected override void VisitExpression(Expression expression)
-        {
-            VisitingExpression?.Invoke(this, expression);
-            base.VisitExpression(expression);
-            VisitedExpression?.Invoke(this, expression);
         }
 
         protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
@@ -475,11 +457,11 @@ namespace Esprima.Utils
             VisitedImportSpecifier?.Invoke(this, importSpecifier);
         }
 
-        protected override void VisitMethodDefinition(MethodDefinition methodDefinitions)
+        protected override void VisitMethodDefinition(MethodDefinition methodDefinition)
         {
-            VisitingMethodDefinition?.Invoke(this, methodDefinitions);
-            base.VisitMethodDefinition(methodDefinitions);
-            VisitedMethodDefinition?.Invoke(this, methodDefinitions);
+            VisitingMethodDefinition?.Invoke(this, methodDefinition);
+            base.VisitMethodDefinition(methodDefinition);
+            VisitedMethodDefinition?.Invoke(this, methodDefinition);
         }
 
         protected override void VisitForOfStatement(ForOfStatement forOfStatement)

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -74,8 +74,8 @@ namespace Esprima.Utils
         public event EventHandler<Literal>? VisitedLiteral;
         public event EventHandler<Identifier>? VisitingIdentifier;
         public event EventHandler<Identifier>? VisitedIdentifier;
-        public event EventHandler<IFunction>? VisitingFunctionExpression;
-        public event EventHandler<IFunction>? VisitedFunctionExpression;
+        public event EventHandler<FunctionExpression>? VisitingFunctionExpression;
+        public event EventHandler<FunctionExpression>? VisitedFunctionExpression;
         public event EventHandler<ChainExpression>? VisitingChainExpression;
         public event EventHandler<ChainExpression>? VisitedChainExpression;
         public event EventHandler<ClassExpression>? VisitingClassExpression;
@@ -373,7 +373,7 @@ namespace Esprima.Utils
             VisitedIdentifier?.Invoke(this, identifier);
         }
 
-        protected override void VisitFunctionExpression(IFunction function)
+        protected override void VisitFunctionExpression(FunctionExpression function)
         {
             VisitingFunctionExpression?.Invoke(this, function);
             base.VisitFunctionExpression(function);

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -74,8 +74,8 @@ namespace Esprima.Utils
         public event EventHandler<Literal>? VisitedLiteral;
         public event EventHandler<Identifier>? VisitingIdentifier;
         public event EventHandler<Identifier>? VisitedIdentifier;
-        public event EventHandler<FunctionExpression>? VisitingFunctionExpression;
-        public event EventHandler<FunctionExpression>? VisitedFunctionExpression;
+        public event EventHandler<IFunction>? VisitingFunctionExpression;
+        public event EventHandler<IFunction>? VisitedFunctionExpression;
         public event EventHandler<ChainExpression>? VisitingChainExpression;
         public event EventHandler<ChainExpression>? VisitedChainExpression;
         public event EventHandler<ClassExpression>? VisitingClassExpression;
@@ -373,7 +373,7 @@ namespace Esprima.Utils
             VisitedIdentifier?.Invoke(this, identifier);
         }
 
-        protected override void VisitFunctionExpression(FunctionExpression function)
+        protected override void VisitFunctionExpression(IFunction function)
         {
             VisitingFunctionExpression?.Invoke(this, function);
             base.VisitFunctionExpression(function);

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -157,7 +157,7 @@ namespace Esprima.Test
                 .ToList();
         }
 
-        private static string GetFixturesPath()
+        internal static string GetFixturesPath()
         {
             var assemblyPath = new Uri(typeof(Fixtures).GetTypeInfo().Assembly.CodeBase).LocalPath;
             var assemblyDirectory = new FileInfo(assemblyPath).Directory;

--- a/test/Esprima.Tests/VisitorTests.cs
+++ b/test/Esprima.Tests/VisitorTests.cs
@@ -1,4 +1,9 @@
-﻿using Esprima.Utils;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Esprima.Ast;
+using Esprima.Test;
+using Esprima.Utils;
 using Xunit;
 
 namespace Esprima.Tests
@@ -11,7 +16,7 @@ namespace Esprima.Tests
             var parser = new JavaScriptParser("if (true) { p(); }");
             var program = parser.ParseScript();
 
-            AstVisitor visitor = new AstVisitor();
+            var visitor = new AstVisitor();
             visitor.Visit(program);
         }
 
@@ -25,7 +30,7 @@ namespace Esprima.Tests
 }");
             var program = parser.ParseScript();
 
-            AstVisitor visitor = new AstVisitor();
+            var visitor = new AstVisitor();
             visitor.Visit(program);
         }
 
@@ -39,7 +44,7 @@ namespace Esprima.Tests
 }");
             var program = parser.ParseScript();
 
-            AstVisitor visitor = new AstVisitor();
+            var visitor = new AstVisitor();
             visitor.Visit(program);
         }
 
@@ -49,7 +54,7 @@ namespace Esprima.Tests
             var parser = new JavaScriptParser(@"for (var a = []; ; ) { }");
             var program = parser.ParseScript();
 
-            AstVisitor visitor = new AstVisitor();
+            var visitor = new AstVisitor();
             visitor.Visit(program);
         }
 
@@ -59,8 +64,34 @@ namespace Esprima.Tests
             var parser = new JavaScriptParser(@"for (var elem of list) { }");
             var program = parser.ParseScript();
 
-            AstVisitor visitor = new AstVisitor();
+            var visitor = new AstVisitor();
             visitor.Visit(program);
+        }
+
+        [Theory]
+        [MemberData(nameof(SourceFiles), "Fixtures")]
+        public void CanVisitFixtures(string fixture)
+        {
+            var jsFilePath = Path.Combine(Fixtures.GetFixturesPath(), "Fixtures", fixture);
+            Script program;
+            try
+            {
+                var parser = new JavaScriptParser(File.ReadAllText(jsFilePath), new ParserOptions { Tolerant = true });
+                program = parser.ParseScript();
+            }
+            catch (ParserException )
+            {
+                // OK as we have invalid files to test against
+                return;
+            }
+
+            var visitor = new AstVisitor();
+            visitor.Visit(program);
+        }
+
+        public static IEnumerable<object[]> SourceFiles(string relativePath)
+        {
+            return Fixtures.SourceFiles(relativePath);
         }
     }
 }


### PR DESCRIPTION
While investigating function code analysis for Jint and skipping creation of arguments instance based on AST analysis, found out that the AstVisitor was quite lacking and throwing errors. Added test to visit all test JS files which showed multiple problems. Now both Esprima and Jint are green for AST analysis for code base.

* Add missing branches
* Remove `VisitStatement` and `VisitExpression`, confusing like noted and can be worked around by overriding `Visit`
* Optimize looping code

Will conflict with #148 but I think we can refresh that after this and see if there's more to be done.