### PR TITLE
JavaScriptParser collects comments if options.Comments is true.

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -64,6 +64,16 @@ public partial class JavaScriptParser
     /// </remarks>
     public IReadOnlyList<Token> Tokens => _tokens;
 
+    private protected readonly List<Comment> _comments = new();
+
+    /// <summary>
+    /// Returns the list of comments that were parsed.
+    /// </summary>
+    /// <remarks>
+    /// It requires the parser options to be configured to generate comments.
+    /// </remarks>
+    public IReadOnlyList<Comment> Comments => _comments;
+
     // cache frequently called Func so we don't need to build Func<T> instances all the time
     // can be revisited with NET 7 SDK where things have improved
     private readonly Func<Expression> parseAssignmentExpression;
@@ -204,6 +214,8 @@ public partial class JavaScriptParser
                     node.Start = e.Start;
                     node.End = e.End;
                     node.Loc = e.Loc;
+
+                    _comments.Add(node);
                 }
             }
         }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -371,6 +371,34 @@ class aa {
     }
 
     [Fact]
+    public void ShouldParseLineComment()
+    {
+        var parser = new JavaScriptParser(@"
+//this is a line comment
+", new ParserOptions { Comment = true });
+
+        var comment = parser.Comments.First();
+
+        Assert.Equal(CommentType.Line, comment.Type);
+        Assert.Equal("this is a line comment", comment.Value);
+    }
+
+    [Fact]
+    public void ShouldParseBlockComment()
+    {
+        var parser = new JavaScriptParser(@"
+/*this is a
+block comment*/
+", new ParserOptions { Comment = true });
+
+        var comment = parser.Comments.First();
+
+        Assert.Equal(CommentType.Block, comment.Type);
+        Assert.Equal(@"this is a
+block comment", comment.Value);
+    }
+
+    [Fact]
     public void HoistingScopeShouldWork()
     {
         var parser = new JavaScriptParser(@"


### PR DESCRIPTION
I have use case where the comments in a script are important. As esprima has an [option](https://docs.esprima.org/en/latest/syntactic-analysis.html?highlight=comments#comment-collection) to return an array of comments, I tried to use the `options.Comments` for `JavaScriptParser`. However it seems that the `JavaScriptParser` scans comments and discards them even if the options is set to true. I am suggesting adding a new property JavaScriptParser.Comments for storing and exposing them as a list instead of discarding them. 