### PR TITLE
Further improvements to AstVisitor - double dispatch

### DIFF
--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitArrayExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitArrayExpression(this);
     }
 }

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ArrayExpression : Expression
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Expression> Elements => ref _elements;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitArrayExpression(this);
     }
 }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ArrayPattern : BindingPattern
     {
@@ -14,5 +16,7 @@
 #pragma warning disable 8631
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
 #pragma warning restore 8631
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitArrayPattern(this);
     }
 }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -17,6 +17,6 @@ namespace Esprima.Ast
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
 #pragma warning restore 8631
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitArrayPattern(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitArrayPattern(this);
     }
 }

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ArrowFunctionExpression : Expression, IFunction
     {
@@ -31,5 +33,7 @@
         public ref readonly NodeList<Expression> Params => ref _params;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitArrowFunctionExpression(this);
     }
 }

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -34,6 +34,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitArrowFunctionExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitArrowFunctionExpression(this);
     }
 }

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -23,6 +23,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_params);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitArrowParameterPlaceHolder(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitArrowParameterPlaceHolder(this);
     }
 }

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ArrowParameterPlaceHolder : Expression
     {
@@ -20,5 +22,7 @@
         public bool Async { get; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_params);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitArrowParameterPlaceHolder(this);
     }
 }

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -76,5 +76,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitAssignmentExpression(this);
     }
 }

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -77,6 +77,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitAssignmentExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitAssignmentExpression(this);
     }
 }

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class AssignmentPattern : Expression
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitAssignmentPattern(this);
     }
 }

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitAssignmentPattern(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitAssignmentPattern(this);
     }
 }

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitAwaitExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitAwaitExpression(this);
     }
 }

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class AwaitExpression : Expression
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitAwaitExpression(this);
     }
 }

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -109,5 +109,17 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
+
+        public override void Accept(AstVisitor visitor)
+        {
+            if (Type == Nodes.LogicalExpression)
+            {
+                visitor.VisitLogicalExpression(this);
+            }
+            else
+            {
+                visitor.VisitBinaryExpression(this);
+            }
+        }
     }
 }

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -110,7 +110,7 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right);
 
-        public override void Accept(AstVisitor visitor)
+        protected internal override void Accept(AstVisitor visitor)
         {
             if (Type == Nodes.LogicalExpression)
             {

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitBlockStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitBlockStatement(this);
     }
 }

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class BlockStatement : Statement
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Statement> Body => ref _body;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitBlockStatement(this);
     }
 }

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Label);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitBreakStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitBreakStatement(this);
     }
 }

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class BreakStatement : Statement
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Label);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitBreakStatement(this);
     }
 }

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class CallExpression : Expression
@@ -20,5 +22,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Expression> Arguments => ref _arguments;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, _arguments);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitCallExpression(this);
     }
 }

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -23,6 +23,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, _arguments);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitCallExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitCallExpression(this);
     }
 }

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -16,6 +16,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Param, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitCatchClause(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitCatchClause(this);
     }
 }

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class CatchClause : Statement
@@ -13,5 +15,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Param, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitCatchClause(this);
     }
 }

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public class ChainExpression : Expression
@@ -13,5 +15,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitChainExpression(this);
     }
 }

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -16,6 +16,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitChainExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitChainExpression(this);
     }
 }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ClassBody : Node
     {
@@ -12,5 +14,7 @@
         public ref readonly NodeList<ClassProperty> Body => ref _body;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitClassBody(this);
     }
 }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitClassBody(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitClassBody(this);
     }
 }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -18,6 +18,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, SuperClass, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitClassDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitClassDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ClassDeclaration : Declaration
     {
@@ -15,5 +17,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, SuperClass, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitClassDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -20,6 +20,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, SuperClass, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitClassExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitClassExpression(this);
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ClassExpression : Expression
     {
@@ -17,5 +19,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, SuperClass, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitClassExpression(this);
     }
 }

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -20,6 +20,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Consequent, Alternate);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitConditionalExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitConditionalExpression(this);
     }
 }

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ConditionalExpression : Expression
@@ -17,5 +19,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Consequent, Alternate);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitConditionalExpression(this);
     }
 }

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ContinueStatement : Statement
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Label);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitContinueStatement(this);
     }
 }

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Label);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitContinueStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitContinueStatement(this);
     }
 }

--- a/src/Esprima/Ast/DebuggerStatement.cs
+++ b/src/Esprima/Ast/DebuggerStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class DebuggerStatement: Statement
@@ -5,5 +7,7 @@ namespace Esprima.Ast
         public DebuggerStatement() : base(Nodes.DebuggerStatement) {}
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitDebuggerStatement(this);
     }
 }

--- a/src/Esprima/Ast/DebuggerStatement.cs
+++ b/src/Esprima/Ast/DebuggerStatement.cs
@@ -8,6 +8,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitDebuggerStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitDebuggerStatement(this);
     }
 }

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Body, Test);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitDoWhileStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitDoWhileStatement(this);
     }
 }

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class DoWhileStatement : Statement
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Body, Test);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitDoWhileStatement(this);
     }
 }

--- a/src/Esprima/Ast/EmptyStatement.cs
+++ b/src/Esprima/Ast/EmptyStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class EmptyStatement : Statement
@@ -7,5 +9,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitEmptyStatement(this);
     }
 }

--- a/src/Esprima/Ast/EmptyStatement.cs
+++ b/src/Esprima/Ast/EmptyStatement.cs
@@ -10,6 +10,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitEmptyStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitEmptyStatement(this);
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ExportAllDeclaration : ExportDeclaration
     {
@@ -10,5 +12,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Source);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitExportAllDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Source);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitExportAllDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitExportAllDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Declaration);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitExportDefaultDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitExportDefaultDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ExportDefaultDeclaration : ExportDeclaration
     {
@@ -10,5 +12,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Declaration);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitExportDefaultDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -24,6 +24,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Declaration, _specifiers, Source);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitExportNamedDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitExportNamedDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ExportNamedDeclaration : ExportDeclaration
     {
@@ -21,5 +23,7 @@
         public ref readonly NodeList<ExportSpecifier> Specifiers => ref _specifiers;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Declaration, _specifiers, Source);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitExportNamedDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ExportSpecifier : Statement
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Exported, Local);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitExportSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Exported, Local);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitExportSpecifier(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitExportSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public class ExpressionStatement : Statement
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Expression);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitExpressionStatement(this);
     }
 }

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Expression);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitExpressionStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitExpressionStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -20,6 +20,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitForInStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitForInStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ForInStatement : Statement
@@ -17,5 +19,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitForInStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -23,6 +23,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Left, Right, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitForOfStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitForOfStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ForOfStatement : Statement
     {
@@ -19,6 +21,8 @@
             Await = _await;
         }
 
-        public override NodeCollection ChildNodes => new NodeCollection(Left, Right, Body); 
+        public override NodeCollection ChildNodes => new NodeCollection(Left, Right, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitForOfStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ForStatement : Statement
@@ -22,5 +24,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Init, Test, Update, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitForStatement(this);
     }
 }

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -25,6 +25,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Init, Test, Update, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitForStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitForStatement(this);
     }
 }

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class FunctionDeclaration : Declaration, IFunction
@@ -33,5 +35,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Expression> Params => ref _parameters;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitFunctionDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -36,6 +36,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitFunctionDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitFunctionDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class FunctionExpression : Expression, IFunction
@@ -31,5 +33,7 @@ namespace Esprima.Ast
         public bool Strict { get; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitFunctionExpression(this);
     }
 }

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -34,6 +34,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitFunctionExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitFunctionExpression(this);
     }
 }

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class Identifier : Expression
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitIdentifier(this);
     }
 }

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitIdentifier(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitIdentifier(this);
     }
 }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Consequent, Alternate);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitIfStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitIfStatement(this);
     }
 }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class IfStatement : Statement
@@ -18,5 +20,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Consequent, Alternate);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitIfStatement(this);
     }
 }

--- a/src/Esprima/Ast/Import.cs
+++ b/src/Esprima/Ast/Import.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class Import : Expression
     {
@@ -7,5 +9,7 @@
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitImport(this);
     }
 }

--- a/src/Esprima/Ast/Import.cs
+++ b/src/Esprima/Ast/Import.cs
@@ -10,6 +10,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitImport(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitImport(this);
     }
 }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_specifiers, Source);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitImportDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitImportDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ImportDeclaration : Declaration
     {
@@ -18,5 +20,7 @@
         public ref readonly NodeList<ImportDeclarationSpecifier> Specifiers => ref _specifiers;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_specifiers, Source);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitImportDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Local);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitImportDefaultSpecifier(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitImportDefaultSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ImportDefaultSpecifier : ImportDeclarationSpecifier
     {
@@ -10,5 +12,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Local);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitImportDefaultSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ImportNamespaceSpecifier : ImportDeclarationSpecifier
     {
@@ -10,5 +12,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Local);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitImportNamespaceSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Local);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitImportNamespaceSpecifier(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitImportNamespaceSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ImportSpecifier : ImportDeclarationSpecifier
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Local, Imported);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitImportSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Local, Imported);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitImportSpecifier(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitImportSpecifier(this);
     }
 }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class LabeledStatement : Statement
@@ -13,5 +15,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Label, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitLabeledStatement(this);
     }
 }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -16,6 +16,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Label, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitLabeledStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitLabeledStatement(this);
     }
 }

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -46,5 +47,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitLiteral(this);
     }
 }

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -48,6 +48,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitLiteral(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitLiteral(this);
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -22,6 +22,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Object, Property);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitMemberExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitMemberExpression(this);
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public abstract class MemberExpression : Expression
@@ -19,5 +21,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Object, Property);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitMemberExpression(this);
     }
 }

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Meta, Property);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitMetaProperty(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitMetaProperty(this);
     }
 }

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class MetaProperty : Expression
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Meta, Property);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitMetaProperty(this);
     }
 }

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
             Kind = kind;
         }
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitMethodDefinition(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitMethodDefinition(this);
     }
 }

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class MethodDefinition : ClassProperty
     {
@@ -18,5 +20,7 @@
             Value = value;
             Kind = kind;
         }
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitMethodDefinition(this);
     }
 }

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class NewExpression : Expression
@@ -17,5 +19,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Expression> Arguments => ref _arguments;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitNewExpression(this);
     }
 }

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -20,6 +20,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitNewExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitNewExpression(this);
     }
 }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public abstract NodeCollection ChildNodes { get; }
 
-        public abstract void Accept(AstVisitor visitor);
+        protected internal abstract void Accept(AstVisitor visitor);
     }
 }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public abstract class Node
     {
@@ -8,9 +10,11 @@
         }
 
         public readonly Nodes Type;
-        public Range Range;    
+        public Range Range;
         public Location Location;
 
         public abstract NodeCollection ChildNodes { get; }
+
+        public abstract void Accept(AstVisitor visitor);
     }
 }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitObjectExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitObjectExpression(this);
     }
 }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ObjectExpression : Expression
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Expression> Properties => ref _properties;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitObjectExpression(this);
     }
 }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class ObjectPattern : BindingPattern
     {
@@ -12,5 +14,7 @@
         public ref readonly NodeList<Node> Properties => ref _properties;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitObjectPattern(this);
     }
 }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitObjectPattern(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitObjectPattern(this);
     }
 }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -12,6 +12,6 @@ namespace Esprima.Ast
 
         public abstract ref readonly NodeList<Statement> Body { get; }
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitProgram(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitProgram(this);
     }
 }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public abstract class Program : Statement
@@ -9,5 +11,7 @@ namespace Esprima.Ast
         public abstract SourceType SourceType { get; }
 
         public abstract ref readonly NodeList<Statement> Body { get; }
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitProgram(this);
     }
 }

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -24,6 +24,6 @@ namespace Esprima.Ast
             Shorthand = shorthand;
         }
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitProperty(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitProperty(this);
     }
 }

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class Property : ClassProperty
@@ -21,5 +23,7 @@ namespace Esprima.Ast
             Method = method;
             Shorthand = shorthand;
         }
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitProperty(this);
     }
 }

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -17,6 +17,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitRestElement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitRestElement(this);
     }
 }

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class RestElement : Expression
     {
@@ -14,5 +16,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitRestElement(this);
     }
 }

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitReturnStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitReturnStatement(this);
     }
 }

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ReturnStatement : Statement
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitReturnStatement(this);
     }
 }

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -17,6 +17,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Expressions);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitSequenceExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitSequenceExpression(this);
     }
 }

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class SequenceExpression : Expression
@@ -14,5 +16,7 @@ namespace Esprima.Ast
         internal void UpdateExpressions(in NodeList<Expression> value) => _expressions = value;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Expressions);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitSequenceExpression(this);
     }
 }

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class SpreadElement : Expression
     {
@@ -10,5 +12,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitSpreadElement(this);
     }
 }

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitSpreadElement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitSpreadElement(this);
     }
 }

--- a/src/Esprima/Ast/Super.cs
+++ b/src/Esprima/Ast/Super.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class Super : Expression
     {
@@ -7,5 +9,7 @@
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitSuper(this);
     }
 }

--- a/src/Esprima/Ast/Super.cs
+++ b/src/Esprima/Ast/Super.cs
@@ -10,6 +10,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitSuper(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitSuper(this);
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -17,6 +17,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, _consequent);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitSwitchCase(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitSwitchCase(this);
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class SwitchCase : Node
@@ -14,5 +16,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<Statement> Consequent => ref _consequent;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, _consequent);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitSwitchCase(this);
     }
 }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -18,6 +18,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, _cases);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitSwitchStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitSwitchStatement(this);
     }
 }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class SwitchStatement : Statement
@@ -15,5 +17,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<SwitchCase> Cases => ref _cases;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, _cases);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitSwitchStatement(this);
     }
 }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class TaggedTemplateExpression : Expression
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Tag, Quasi);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitTaggedTemplateExpression(this);
     }
 }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Tag, Quasi);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitTaggedTemplateExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitTaggedTemplateExpression(this);
     }
 }

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class TemplateElement : Node
     {
@@ -18,5 +20,7 @@
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitTemplateElement(this);
     }
 }

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitTemplateElement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitTemplateElement(this);
     }
 }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class TemplateLiteral : Expression
     {
@@ -18,5 +20,7 @@
         public ref readonly NodeList<Expression> Expressions => ref _expressions;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_quasis,  _expressions);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitTemplateLiteral(this);
     }
 }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_quasis,  _expressions);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitTemplateLiteral(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitTemplateLiteral(this);
     }
 }

--- a/src/Esprima/Ast/ThisExpression.cs
+++ b/src/Esprima/Ast/ThisExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ThisExpression : Expression
@@ -7,5 +9,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitThisExpression(this);
     }
 }

--- a/src/Esprima/Ast/ThisExpression.cs
+++ b/src/Esprima/Ast/ThisExpression.cs
@@ -10,6 +10,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitThisExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitThisExpression(this);
     }
 }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class ThrowStatement : Statement
@@ -10,5 +12,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitThrowStatement(this);
     }
 }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -13,6 +13,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitThrowStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitThrowStatement(this);
     }
 }

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class TryStatement : Statement
@@ -18,5 +20,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Block, Handler, Finalizer);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitTryStatement(this);
     }
 }

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -21,6 +21,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Block, Handler, Finalizer);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitTryStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitTryStatement(this);
     }
 }

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -62,6 +62,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitUnaryExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitUnaryExpression(this);
     }
 }

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -61,5 +61,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitUnaryExpression(this);
     }
 }

--- a/src/Esprima/Ast/UpdateExpression.cs
+++ b/src/Esprima/Ast/UpdateExpression.cs
@@ -9,6 +9,6 @@ namespace Esprima.Ast
             Prefix = prefix;
         }
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitUpdateExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitUpdateExpression(this);
     }
 }

--- a/src/Esprima/Ast/UpdateExpression.cs
+++ b/src/Esprima/Ast/UpdateExpression.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class UpdateExpression : UnaryExpression
@@ -6,5 +8,7 @@ namespace Esprima.Ast
         {
             Prefix = prefix;
         }
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitUpdateExpression(this);
     }
 }

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -20,6 +20,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_declarations);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclaration(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class VariableDeclaration : Declaration
@@ -17,5 +19,7 @@ namespace Esprima.Ast
         public ref readonly NodeList<VariableDeclarator> Declarations => ref _declarations;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_declarations);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclaration(this);
     }
 }

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class VariableDeclarator : Node
@@ -13,5 +15,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, Init);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclarator(this);
     }
 }

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -16,6 +16,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Id, Init);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclarator(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitVariableDeclarator(this);
     }
 }

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class WhileStatement : Statement
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitWhileStatement(this);
     }
 }

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Test, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitWhileStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitWhileStatement(this);
     }
 }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Object, Body);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitWithStatement(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitWithStatement(this);
     }
 }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -1,3 +1,5 @@
+using Esprima.Utils;
+
 namespace Esprima.Ast
 {
     public sealed class WithStatement : Statement
@@ -12,5 +14,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Object, Body);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitWithStatement(this);
     }
 }

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima.Ast
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
 {
     public sealed class YieldExpression : Expression
     {
@@ -12,5 +14,7 @@
         }
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
+
+        public override void Accept(AstVisitor visitor) => visitor.VisitYieldExpression(this);
     }
 }

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -15,6 +15,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new NodeCollection(Argument);
 
-        public override void Accept(AstVisitor visitor) => visitor.VisitYieldExpression(this);
+        protected internal override void Accept(AstVisitor visitor) => visitor.VisitYieldExpression(this);
     }
 }

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -294,7 +294,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitProgram(Program program)
+            protected internal override void VisitProgram(Program program)
             {
                 using (StartNodeObject(program))
                 {
@@ -303,10 +303,11 @@ namespace Esprima.Utils
                 }
             }
 
+            [Obsolete("This method may be removed in a future version as it will not be called anymore due to employing double dispatch (instead of switch dispatch).")]
             protected override void VisitUnknownNode(Node node) =>
                 throw new NotSupportedException("Unknown node type: " + node.Type);
 
-            protected override void VisitCatchClause(CatchClause catchClause)
+            protected internal override void VisitCatchClause(CatchClause catchClause)
             {
                 using (StartNodeObject(catchClause))
                 {
@@ -315,7 +316,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+            protected internal override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
             {
                 using (StartNodeObject(functionDeclaration))
                 {
@@ -328,7 +329,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitWithStatement(WithStatement withStatement)
+            protected internal override void VisitWithStatement(WithStatement withStatement)
             {
                 using (StartNodeObject(withStatement))
                 {
@@ -337,7 +338,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitWhileStatement(WhileStatement whileStatement)
+            protected internal override void VisitWhileStatement(WhileStatement whileStatement)
             {
                 using (StartNodeObject(whileStatement))
                 {
@@ -346,7 +347,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+            protected internal override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
             {
                 using (StartNodeObject(variableDeclaration))
                 {
@@ -355,7 +356,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitTryStatement(TryStatement tryStatement)
+            protected internal override void VisitTryStatement(TryStatement tryStatement)
             {
                 using (StartNodeObject(tryStatement))
                 {
@@ -365,7 +366,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitThrowStatement(ThrowStatement throwStatement)
+            protected internal override void VisitThrowStatement(ThrowStatement throwStatement)
             {
                 using (StartNodeObject(throwStatement))
                 {
@@ -373,7 +374,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitAwaitExpression(AwaitExpression awaitExpression)
+            protected internal override void VisitAwaitExpression(AwaitExpression awaitExpression)
             {
                 using (StartNodeObject(awaitExpression))
                 {
@@ -381,7 +382,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitSwitchStatement(SwitchStatement switchStatement)
+            protected internal override void VisitSwitchStatement(SwitchStatement switchStatement)
             {
                 using (StartNodeObject(switchStatement))
                 {
@@ -390,7 +391,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitSwitchCase(SwitchCase switchCase)
+            protected internal override void VisitSwitchCase(SwitchCase switchCase)
             {
                 using (StartNodeObject(switchCase))
                 {
@@ -399,13 +400,13 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitReturnStatement(ReturnStatement returnStatement)
+            protected internal override void VisitReturnStatement(ReturnStatement returnStatement)
             {
                 using (StartNodeObject(returnStatement))
                     Member("argument", returnStatement.Argument);
             }
 
-            protected override void VisitLabeledStatement(LabeledStatement labeledStatement)
+            protected internal override void VisitLabeledStatement(LabeledStatement labeledStatement)
             {
                 using (StartNodeObject(labeledStatement))
                 {
@@ -414,7 +415,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitIfStatement(IfStatement ifStatement)
+            protected internal override void VisitIfStatement(IfStatement ifStatement)
             {
                 using (StartNodeObject(ifStatement))
                 {
@@ -424,13 +425,13 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitEmptyStatement(EmptyStatement emptyStatement) =>
+            protected internal override void VisitEmptyStatement(EmptyStatement emptyStatement) =>
                 EmptyNodeObject(emptyStatement);
 
-            protected override void VisitDebuggerStatement(DebuggerStatement debuggerStatement) =>
+            protected internal override void VisitDebuggerStatement(DebuggerStatement debuggerStatement) =>
                 EmptyNodeObject(debuggerStatement);
 
-            protected override void VisitExpressionStatement(ExpressionStatement expressionStatement)
+            protected internal override void VisitExpressionStatement(ExpressionStatement expressionStatement)
             {
                 using (StartNodeObject(expressionStatement))
                 {
@@ -443,7 +444,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitForStatement(ForStatement forStatement)
+            protected internal override void VisitForStatement(ForStatement forStatement)
             {
                 using (StartNodeObject(forStatement))
                 {
@@ -454,7 +455,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitForInStatement(ForInStatement forInStatement)
+            protected internal override void VisitForInStatement(ForInStatement forInStatement)
             {
                 using (StartNodeObject(forInStatement))
                 {
@@ -465,7 +466,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+            protected internal override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
             {
                 using (StartNodeObject(doWhileStatement))
                 {
@@ -474,7 +475,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+            protected internal override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
             {
                 using (StartNodeObject(arrowFunctionExpression))
                 {
@@ -487,7 +488,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitUnaryExpression(UnaryExpression unaryExpression)
+            protected internal override void VisitUnaryExpression(UnaryExpression unaryExpression)
             {
                 using (StartNodeObject(unaryExpression))
                 {
@@ -497,25 +498,25 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitUpdateExpression(UpdateExpression updateExpression) =>
+            protected internal override void VisitUpdateExpression(UpdateExpression updateExpression) =>
                 VisitUnaryExpression(updateExpression);
 
-            protected override void VisitThisExpression(ThisExpression thisExpression) =>
+            protected internal override void VisitThisExpression(ThisExpression thisExpression) =>
                 EmptyNodeObject(thisExpression);
 
-            protected override void VisitSequenceExpression(SequenceExpression sequenceExpression)
+            protected internal override void VisitSequenceExpression(SequenceExpression sequenceExpression)
             {
                 using (StartNodeObject(sequenceExpression))
                     Member("expressions", sequenceExpression.Expressions);
             }
 
-            protected override void VisitObjectExpression(ObjectExpression objectExpression)
+            protected internal override void VisitObjectExpression(ObjectExpression objectExpression)
             {
                 using (StartNodeObject(objectExpression))
                     Member("properties", objectExpression.Properties);
             }
 
-            protected override void VisitNewExpression(NewExpression newExpression)
+            protected internal override void VisitNewExpression(NewExpression newExpression)
             {
                 using (StartNodeObject(newExpression))
                 {
@@ -524,7 +525,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitMemberExpression(MemberExpression memberExpression)
+            protected internal override void VisitMemberExpression(MemberExpression memberExpression)
             {
                 using (StartNodeObject(memberExpression))
                 {
@@ -535,10 +536,10 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitLogicalExpression(BinaryExpression binaryExpression) =>
+            protected internal override void VisitLogicalExpression(BinaryExpression binaryExpression) =>
                 VisitBinaryExpression(binaryExpression);
 
-            protected override void VisitLiteral(Literal literal)
+            protected internal override void VisitLiteral(Literal literal)
             {
                 using (StartNodeObject(literal))
                 {
@@ -577,7 +578,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitIdentifier(Identifier identifier)
+            protected internal override void VisitIdentifier(Identifier identifier)
             {
                 using (StartNodeObject(identifier))
                 {
@@ -585,7 +586,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitFunctionExpression(IFunction function)
+            protected internal override void VisitFunctionExpression(IFunction function)
             {
                 using (StartNodeObject((Node) function))
                 {
@@ -598,7 +599,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitClassExpression(ClassExpression classExpression)
+            protected internal override void VisitClassExpression(ClassExpression classExpression)
             {
                 using (StartNodeObject(classExpression))
                 {
@@ -608,25 +609,25 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitChainExpression(ChainExpression chainExpression)
+            protected internal override void VisitChainExpression(ChainExpression chainExpression)
             {
                 using (StartNodeObject(chainExpression))
                     Member("expression", chainExpression.Expression);
             }
 
-            protected override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+            protected internal override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
             {
                 using (StartNodeObject(exportDefaultDeclaration))
                     Member("declaration", exportDefaultDeclaration.Declaration);
             }
 
-            protected override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+            protected internal override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
             {
                 using (StartNodeObject(exportAllDeclaration))
                     Member("source", exportAllDeclaration.Source);
             }
 
-            protected override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+            protected internal override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
             {
                 using (StartNodeObject(exportNamedDeclaration))
                 {
@@ -636,7 +637,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+            protected internal override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
             {
                 using (StartNodeObject(exportSpecifier))
                 {
@@ -645,14 +646,14 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitImport(Import import)
+            protected internal override void VisitImport(Import import)
             {
                 using (StartNodeObject(import))
                 {
                 }
             }
 
-            protected override void VisitImportDeclaration(ImportDeclaration importDeclaration)
+            protected internal override void VisitImportDeclaration(ImportDeclaration importDeclaration)
             {
                 using (StartNodeObject(importDeclaration))
                 {
@@ -661,19 +662,19 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+            protected internal override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
             {
                 using (StartNodeObject(importNamespaceSpecifier))
                     Member("local", importNamespaceSpecifier.Local);
             }
 
-            protected override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+            protected internal override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
             {
                 using (StartNodeObject(importDefaultSpecifier))
                     Member("local", importDefaultSpecifier.Local);
             }
 
-            protected override void VisitImportSpecifier(ImportSpecifier importSpecifier)
+            protected internal override void VisitImportSpecifier(ImportSpecifier importSpecifier)
             {
                 using (StartNodeObject(importSpecifier))
                 {
@@ -682,7 +683,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitMethodDefinition(MethodDefinition methodDefinition)
+            protected internal override void VisitMethodDefinition(MethodDefinition methodDefinition)
             {
                 using (StartNodeObject(methodDefinition))
                 {
@@ -694,7 +695,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitForOfStatement(ForOfStatement forOfStatement)
+            protected internal override void VisitForOfStatement(ForOfStatement forOfStatement)
             {
                 using (StartNodeObject(forOfStatement))
                 {
@@ -705,7 +706,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitClassDeclaration(ClassDeclaration classDeclaration)
+            protected internal override void VisitClassDeclaration(ClassDeclaration classDeclaration)
             {
                 using (StartNodeObject(classDeclaration))
                 {
@@ -715,13 +716,13 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitClassBody(ClassBody classBody)
+            protected internal override void VisitClassBody(ClassBody classBody)
             {
                 using (StartNodeObject(classBody))
                     Member("body", classBody.Body);
             }
 
-            protected override void VisitYieldExpression(YieldExpression yieldExpression)
+            protected internal override void VisitYieldExpression(YieldExpression yieldExpression)
             {
                 using (StartNodeObject(yieldExpression))
                 {
@@ -730,7 +731,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+            protected internal override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
             {
                 using (StartNodeObject(taggedTemplateExpression))
                 {
@@ -739,10 +740,10 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitSuper(Super super) =>
+            protected internal override void VisitSuper(Super super) =>
                 EmptyNodeObject(super);
 
-            protected override void VisitMetaProperty(MetaProperty metaProperty)
+            protected internal override void VisitMetaProperty(MetaProperty metaProperty)
             {
                 using (StartNodeObject(metaProperty))
                 {
@@ -751,7 +752,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
+            protected internal override void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
             {
                 // Seems that ArrowParameterPlaceHolder nodes never appear
                 // in the final tree and only used during the construction of
@@ -760,7 +761,7 @@ namespace Esprima.Utils
                 throw new NotImplementedException();
             }
 
-            protected override void VisitObjectPattern(ObjectPattern objectPattern)
+            protected internal override void VisitObjectPattern(ObjectPattern objectPattern)
             {
                 using (StartNodeObject(objectPattern))
                 {
@@ -768,7 +769,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitSpreadElement(SpreadElement spreadElement)
+            protected internal override void VisitSpreadElement(SpreadElement spreadElement)
             {
                 using (StartNodeObject(spreadElement))
                 {
@@ -776,7 +777,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+            protected internal override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
             {
                 using (StartNodeObject(assignmentPattern))
                 {
@@ -785,7 +786,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitArrayPattern(ArrayPattern arrayPattern)
+            protected internal override void VisitArrayPattern(ArrayPattern arrayPattern)
             {
                 using (StartNodeObject(arrayPattern))
                 {
@@ -793,7 +794,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+            protected internal override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
             {
                 using (StartNodeObject(variableDeclarator))
                 {
@@ -802,7 +803,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+            protected internal override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
             {
                 using (StartNodeObject(templateLiteral))
                 {
@@ -811,7 +812,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitTemplateElement(TemplateElement templateElement)
+            protected internal override void VisitTemplateElement(TemplateElement templateElement)
             {
                 using (StartNodeObject(templateElement))
                 {
@@ -824,7 +825,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitRestElement(RestElement restElement)
+            protected internal override void VisitRestElement(RestElement restElement)
             {
                 using (StartNodeObject(restElement))
                 {
@@ -832,7 +833,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitProperty(Property property)
+            protected internal override void VisitProperty(Property property)
             {
                 using (StartNodeObject(property))
                 {
@@ -845,7 +846,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+            protected internal override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
             {
                 using (StartNodeObject(conditionalExpression))
                 {
@@ -855,7 +856,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitCallExpression(CallExpression callExpression)
+            protected internal override void VisitCallExpression(CallExpression callExpression)
             {
                 using (StartNodeObject(callExpression))
                 {
@@ -865,7 +866,7 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitBinaryExpression(BinaryExpression binaryExpression)
+            protected internal override void VisitBinaryExpression(BinaryExpression binaryExpression)
             {
                 using (StartNodeObject(binaryExpression))
                 {
@@ -875,13 +876,13 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitArrayExpression(ArrayExpression arrayExpression)
+            protected internal override void VisitArrayExpression(ArrayExpression arrayExpression)
             {
                 using (StartNodeObject(arrayExpression))
                     Member("elements", arrayExpression.Elements);
             }
 
-            protected override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+            protected internal override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
             {
                 using (StartNodeObject(assignmentExpression))
                 {
@@ -891,19 +892,19 @@ namespace Esprima.Utils
                 }
             }
 
-            protected override void VisitContinueStatement(ContinueStatement continueStatement)
+            protected internal override void VisitContinueStatement(ContinueStatement continueStatement)
             {
                 using (StartNodeObject(continueStatement))
                     Member("label", continueStatement.Label);
             }
 
-            protected override void VisitBreakStatement(BreakStatement breakStatement)
+            protected internal override void VisitBreakStatement(BreakStatement breakStatement)
             {
                 using (StartNodeObject(breakStatement))
                     Member("label", breakStatement.Label);
             }
 
-            protected override void VisitBlockStatement(BlockStatement blockStatement)
+            protected internal override void VisitBlockStatement(BlockStatement blockStatement)
             {
                 using (StartNodeObject(blockStatement))
                     Member("body", blockStatement.Body, e => (Statement) e);

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -8,222 +8,10 @@ namespace Esprima.Utils
     {
         public virtual void Visit(Node node)
         {
-            switch (node.Type)
-            {
-                case Nodes.AssignmentExpression:
-                    VisitAssignmentExpression(node.As<AssignmentExpression>());
-                    break;
-                case Nodes.ArrayExpression:
-                    VisitArrayExpression(node.As<ArrayExpression>());
-                    break;
-                case Nodes.AwaitExpression:
-                    VisitAwaitExpression(node.As<AwaitExpression>());
-                    break;
-                case Nodes.BlockStatement:
-                    VisitBlockStatement(node.As<BlockStatement>());
-                    break;
-                case Nodes.BinaryExpression:
-                    VisitBinaryExpression(node.As<BinaryExpression>());
-                    break;
-                case Nodes.BreakStatement:
-                    VisitBreakStatement(node.As<BreakStatement>());
-                    break;
-                case Nodes.CallExpression:
-                    VisitCallExpression(node.As<CallExpression>());
-                    break;
-                case Nodes.CatchClause:
-                    VisitCatchClause(node.As<CatchClause>());
-                    break;
-                case Nodes.ConditionalExpression:
-                    VisitConditionalExpression(node.As<ConditionalExpression>());
-                    break;
-                case Nodes.ContinueStatement:
-                    VisitContinueStatement(node.As<ContinueStatement>());
-                    break;
-                case Nodes.DoWhileStatement:
-                    VisitDoWhileStatement(node.As<DoWhileStatement>());
-                    break;
-                case Nodes.DebuggerStatement:
-                    VisitDebuggerStatement(node.As<DebuggerStatement>());
-                    break;
-                case Nodes.EmptyStatement:
-                    VisitEmptyStatement(node.As<EmptyStatement>());
-                    break;
-                case Nodes.ExpressionStatement:
-                    VisitExpressionStatement(node.As<ExpressionStatement>());
-                    break;
-                case Nodes.ForStatement:
-                    VisitForStatement(node.As<ForStatement>());
-                    break;
-                case Nodes.ForInStatement:
-                    VisitForInStatement(node.As<ForInStatement>());
-                    break;
-                case Nodes.FunctionDeclaration:
-                    VisitFunctionDeclaration(node.As<FunctionDeclaration>());
-                    break;
-                case Nodes.FunctionExpression:
-                    VisitFunctionExpression(node.As<FunctionExpression>());
-                    break;
-                case Nodes.Identifier:
-                    VisitIdentifier(node.As<Identifier>());
-                    break;
-                case Nodes.IfStatement:
-                    VisitIfStatement(node.As<IfStatement>());
-                    break;
-                case Nodes.Literal:
-                    VisitLiteral(node.As<Literal>());
-                    break;
-                case Nodes.LabeledStatement:
-                    VisitLabeledStatement(node.As<LabeledStatement>());
-                    break;
-                case Nodes.LogicalExpression:
-                    VisitLogicalExpression(node.As<BinaryExpression>());
-                    break;
-                case Nodes.MemberExpression:
-                    VisitMemberExpression(node.As<MemberExpression>());
-                    break;
-                case Nodes.NewExpression:
-                    VisitNewExpression(node.As<NewExpression>());
-                    break;
-                case Nodes.ObjectExpression:
-                    VisitObjectExpression(node.As<ObjectExpression>());
-                    break;
-                case Nodes.Program:
-                    VisitProgram(node.As<Program>());
-                    break;
-                case Nodes.Property:
-                    VisitProperty(node.As<Property>());
-                    break;
-                case Nodes.RestElement:
-                    VisitRestElement(node.As<RestElement>());
-                    break;
-                case Nodes.ReturnStatement:
-                    VisitReturnStatement(node.As<ReturnStatement>());
-                    break;
-                case Nodes.SequenceExpression:
-                    VisitSequenceExpression(node.As<SequenceExpression>());
-                    break;
-                case Nodes.SwitchStatement:
-                    VisitSwitchStatement(node.As<SwitchStatement>());
-                    break;
-                case Nodes.SwitchCase:
-                    VisitSwitchCase(node.As<SwitchCase>());
-                    break;
-                case Nodes.TemplateElement:
-                    VisitTemplateElement(node.As<TemplateElement>());
-                    break;
-                case Nodes.TemplateLiteral:
-                    VisitTemplateLiteral(node.As<TemplateLiteral>());
-                    break;
-                case Nodes.ThisExpression:
-                    VisitThisExpression(node.As<ThisExpression>());
-                    break;
-                case Nodes.ThrowStatement:
-                    VisitThrowStatement(node.As<ThrowStatement>());
-                    break;
-                case Nodes.TryStatement:
-                    VisitTryStatement(node.As<TryStatement>());
-                    break;
-                case Nodes.UnaryExpression:
-                    VisitUnaryExpression(node.As<UnaryExpression>());
-                    break;
-                case Nodes.UpdateExpression:
-                    VisitUpdateExpression(node.As<UpdateExpression>());
-                    break;
-                case Nodes.VariableDeclaration:
-                    VisitVariableDeclaration(node.As<VariableDeclaration>());
-                    break;
-                case Nodes.VariableDeclarator:
-                    VisitVariableDeclarator(node.As<VariableDeclarator>());
-                    break;
-                case Nodes.WhileStatement:
-                    VisitWhileStatement(node.As<WhileStatement>());
-                    break;
-                case Nodes.WithStatement:
-                    VisitWithStatement(node.As<WithStatement>());
-                    break;
-                case Nodes.ArrayPattern:
-                    VisitArrayPattern(node.As<ArrayPattern>());
-                    break;
-                case Nodes.AssignmentPattern:
-                    VisitAssignmentPattern(node.As<AssignmentPattern>());
-                    break;
-                case Nodes.SpreadElement:
-                    VisitSpreadElement(node.As<SpreadElement>());
-                    break;
-                case Nodes.ObjectPattern:
-                    VisitObjectPattern(node.As<ObjectPattern>());
-                    break;
-                case Nodes.ArrowParameterPlaceHolder:
-                    VisitArrowParameterPlaceHolder(node.As<ArrowParameterPlaceHolder>());
-                    break;
-                case Nodes.MetaProperty:
-                    VisitMetaProperty(node.As<MetaProperty>());
-                    break;
-                case Nodes.Super:
-                    VisitSuper(node.As<Super>());
-                    break;
-                case Nodes.TaggedTemplateExpression:
-                    VisitTaggedTemplateExpression(node.As<TaggedTemplateExpression>());
-                    break;
-                case Nodes.YieldExpression:
-                    VisitYieldExpression(node.As<YieldExpression>());
-                    break;
-                case Nodes.ArrowFunctionExpression:
-                    VisitArrowFunctionExpression(node.As<ArrowFunctionExpression>());
-                    break;
-                case Nodes.ClassBody:
-                    VisitClassBody(node.As<ClassBody>());
-                    break;
-                case Nodes.ClassDeclaration:
-                    VisitClassDeclaration(node.As<ClassDeclaration>());
-                    break;
-                case Nodes.ForOfStatement:
-                    VisitForOfStatement(node.As<ForOfStatement>());
-                    break;
-                case Nodes.MethodDefinition:
-                    VisitMethodDefinition(node.As<MethodDefinition>());
-                    break;
-                case Nodes.ImportSpecifier:
-                    VisitImportSpecifier(node.As<ImportSpecifier>());
-                    break;
-                case Nodes.ImportDefaultSpecifier:
-                    VisitImportDefaultSpecifier(node.As<ImportDefaultSpecifier>());
-                    break;
-                case Nodes.ImportNamespaceSpecifier:
-                    VisitImportNamespaceSpecifier(node.As<ImportNamespaceSpecifier>());
-                    break;
-                case Nodes.Import:
-                    VisitImport(node.As<Import>());
-                    break;
-                case Nodes.ImportDeclaration:
-                    VisitImportDeclaration(node.As<ImportDeclaration>());
-                    break;
-                case Nodes.ExportSpecifier:
-                    VisitExportSpecifier(node.As<ExportSpecifier>());
-                    break;
-                case Nodes.ExportNamedDeclaration:
-                    VisitExportNamedDeclaration(node.As<ExportNamedDeclaration>());
-                    break;
-                case Nodes.ExportAllDeclaration:
-                    VisitExportAllDeclaration(node.As<ExportAllDeclaration>());
-                    break;
-                case Nodes.ExportDefaultDeclaration:
-                    VisitExportDefaultDeclaration(node.As<ExportDefaultDeclaration>());
-                    break;
-                case Nodes.ClassExpression:
-                    VisitClassExpression(node.As<ClassExpression>());
-                    break;
-                case Nodes.ChainExpression:
-                    VisitChainExpression(node.As<ChainExpression>());
-                    break;
-                default:
-                    VisitUnknownNode(node);
-                    break;
-            }
+            node.Accept(this);
         }
 
-        protected virtual void VisitProgram(Program program)
+        protected internal virtual void VisitProgram(Program program)
         {
             ref readonly var statements = ref program.Body;
             for (var i = 0; i < statements.Count; i++)
@@ -232,12 +20,13 @@ namespace Esprima.Utils
             }
         }
 
+        [Obsolete("This method may be removed in a future version as it will not be called anymore due to employing double dispatch (instead of switch dispatch).")]
         protected virtual void VisitUnknownNode(Node node)
         {
             throw new NotImplementedException($"AST visitor doesn't support nodes of type {node.Type}, you can override VisitUnknownNode to handle this case.");
         }
 
-        protected virtual void VisitCatchClause(CatchClause catchClause)
+        protected internal virtual void VisitCatchClause(CatchClause catchClause)
         {
             if (catchClause.Param is not null)
             {
@@ -246,7 +35,7 @@ namespace Esprima.Utils
             Visit(catchClause.Body);
         }
 
-        protected virtual void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        protected internal virtual void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
         {
             if (functionDeclaration.Id is not null)
             {
@@ -262,19 +51,19 @@ namespace Esprima.Utils
             Visit(functionDeclaration.Body);
         }
 
-        protected virtual void VisitWithStatement(WithStatement withStatement)
+        protected internal virtual void VisitWithStatement(WithStatement withStatement)
         {
             Visit(withStatement.Object);
             Visit(withStatement.Body);
         }
 
-        protected virtual void VisitWhileStatement(WhileStatement whileStatement)
+        protected internal virtual void VisitWhileStatement(WhileStatement whileStatement)
         {
             Visit(whileStatement.Test);
             Visit(whileStatement.Body);
         }
 
-        protected virtual void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        protected internal virtual void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
         {
             ref readonly var declarations = ref variableDeclaration.Declarations;
             for (var i = 0; i < declarations.Count; i++)
@@ -283,7 +72,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitTryStatement(TryStatement tryStatement)
+        protected internal virtual void VisitTryStatement(TryStatement tryStatement)
         {
             Visit(tryStatement.Block);
             if (tryStatement.Handler != null)
@@ -297,12 +86,12 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitThrowStatement(ThrowStatement throwStatement)
+        protected internal virtual void VisitThrowStatement(ThrowStatement throwStatement)
         {
             Visit(throwStatement.Argument);
         }
 
-        protected virtual void VisitSwitchStatement(SwitchStatement switchStatement)
+        protected internal virtual void VisitSwitchStatement(SwitchStatement switchStatement)
         {
             Visit(switchStatement.Discriminant);
             ref readonly var cases = ref switchStatement.Cases;
@@ -312,7 +101,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitSwitchCase(SwitchCase switchCase)
+        protected internal virtual void VisitSwitchCase(SwitchCase switchCase)
         {
             if (switchCase.Test != null)
             {
@@ -327,20 +116,20 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitReturnStatement(ReturnStatement returnStatement)
+        protected internal virtual void VisitReturnStatement(ReturnStatement returnStatement)
         {
             if (returnStatement.Argument == null)
                 return;
             Visit(returnStatement.Argument);
         }
 
-        protected virtual void VisitLabeledStatement(LabeledStatement labeledStatement)
+        protected internal virtual void VisitLabeledStatement(LabeledStatement labeledStatement)
         {
             Visit(labeledStatement.Label);
             Visit(labeledStatement.Body);
         }
 
-        protected virtual void VisitIfStatement(IfStatement ifStatement)
+        protected internal virtual void VisitIfStatement(IfStatement ifStatement)
         {
             Visit(ifStatement.Test);
             Visit(ifStatement.Consequent);
@@ -350,20 +139,20 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitEmptyStatement(EmptyStatement emptyStatement)
+        protected internal virtual void VisitEmptyStatement(EmptyStatement emptyStatement)
         {
         }
 
-        protected virtual void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        protected internal virtual void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
         {
         }
 
-        protected virtual void VisitExpressionStatement(ExpressionStatement expressionStatement)
+        protected internal virtual void VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
             Visit(expressionStatement.Expression);
         }
 
-        protected virtual void VisitForStatement(ForStatement forStatement)
+        protected internal virtual void VisitForStatement(ForStatement forStatement)
         {
             if (forStatement.Init is not null)
             {
@@ -380,20 +169,20 @@ namespace Esprima.Utils
             Visit(forStatement.Body);
         }
 
-        protected virtual void VisitForInStatement(ForInStatement forInStatement)
+        protected internal virtual void VisitForInStatement(ForInStatement forInStatement)
         {
             Visit(forInStatement.Left);
             Visit(forInStatement.Right);
             Visit(forInStatement.Body);
         }
 
-        protected virtual void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        protected internal virtual void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
         {
             Visit(doWhileStatement.Body);
             Visit(doWhileStatement.Test);
         }
 
-        protected virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+        protected internal virtual void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
             ref readonly var parameters = ref arrowFunctionExpression.Params;
             for (var i = 0; i < parameters.Count; i++)
@@ -405,21 +194,21 @@ namespace Esprima.Utils
             Visit(arrowFunctionExpression.Body);
         }
 
-        protected virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected internal virtual void VisitUnaryExpression(UnaryExpression unaryExpression)
         {
             Visit(unaryExpression.Argument);
         }
 
-        protected virtual void VisitUpdateExpression(UpdateExpression updateExpression)
+        protected internal virtual void VisitUpdateExpression(UpdateExpression updateExpression)
         {
             Visit(updateExpression.Argument);
         }
 
-        protected virtual void VisitThisExpression(ThisExpression thisExpression)
+        protected internal virtual void VisitThisExpression(ThisExpression thisExpression)
         {
         }
 
-        protected virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
+        protected internal virtual void VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
             ref readonly var expressions = ref sequenceExpression.Expressions;
             for (var i = 0; i < expressions.Count; i++)
@@ -428,7 +217,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitObjectExpression(ObjectExpression objectExpression)
+        protected internal virtual void VisitObjectExpression(ObjectExpression objectExpression)
         {
             ref readonly var properties = ref objectExpression.Properties;
             for (var i = 0; i < properties.Count; i++)
@@ -441,7 +230,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitNewExpression(NewExpression newExpression)
+        protected internal virtual void VisitNewExpression(NewExpression newExpression)
         {
             ref readonly var arguments = ref newExpression.Arguments;
             for (var i = 0; i < arguments.Count; i++)
@@ -453,26 +242,26 @@ namespace Esprima.Utils
             Visit(newExpression.Callee);
         }
 
-        protected virtual void VisitMemberExpression(MemberExpression memberExpression)
+        protected internal virtual void VisitMemberExpression(MemberExpression memberExpression)
         {
             Visit(memberExpression.Object);
             Visit(memberExpression.Property);
         }
 
-        protected virtual void VisitLogicalExpression(BinaryExpression binaryExpression)
+        protected internal virtual void VisitLogicalExpression(BinaryExpression binaryExpression)
         {
             Visit(binaryExpression.Left);
             Visit(binaryExpression.Right);        }
 
-        protected virtual void VisitLiteral(Literal literal)
+        protected internal virtual void VisitLiteral(Literal literal)
         {
         }
 
-        protected virtual void VisitIdentifier(Identifier identifier)
+        protected internal virtual void VisitIdentifier(Identifier identifier)
         {
         }
 
-        protected virtual void VisitFunctionExpression(IFunction function)
+        protected internal virtual void VisitFunctionExpression(IFunction function)
         {
             if (function.Id is not null)
             {
@@ -489,12 +278,12 @@ namespace Esprima.Utils
             Visit(function.Body);
         }
 
-        protected virtual void VisitChainExpression(ChainExpression chainExpression)
+        protected internal virtual void VisitChainExpression(ChainExpression chainExpression)
         {
             Visit(chainExpression.Expression);
         }
 
-        protected virtual void VisitClassExpression(ClassExpression classExpression)
+        protected internal virtual void VisitClassExpression(ClassExpression classExpression)
         {
             if (classExpression.Id is not null)
             {
@@ -509,17 +298,17 @@ namespace Esprima.Utils
             Visit(classExpression.Body);
         }
 
-        protected virtual void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected internal virtual void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
         {
             Visit(exportDefaultDeclaration.Declaration);
         }
 
-        protected virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+        protected internal virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
             Visit(exportAllDeclaration.Source);
         }
 
-        protected virtual void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+        protected internal virtual void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
         {
             ref readonly var specifiers = ref exportNamedDeclaration.Specifiers;
             for (var i = 0; i < specifiers.Count; i++)
@@ -538,17 +327,17 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+        protected internal virtual void VisitExportSpecifier(ExportSpecifier exportSpecifier)
         {
             Visit(exportSpecifier.Exported);
             Visit(exportSpecifier.Local);
         }
 
-        protected virtual void VisitImport(Import import)
+        protected internal virtual void VisitImport(Import import)
         {
         }
 
-        protected virtual void VisitImportDeclaration(ImportDeclaration importDeclaration)
+        protected internal virtual void VisitImportDeclaration(ImportDeclaration importDeclaration)
         {
             ref readonly var specifiers = ref importDeclaration.Specifiers;
             for (var i = 0; i < specifiers.Count; i++)
@@ -559,36 +348,36 @@ namespace Esprima.Utils
             Visit(importDeclaration.Source);
         }
 
-        protected virtual void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        protected internal virtual void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
         {
             Visit(importNamespaceSpecifier.Local);
         }
 
-        protected virtual void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+        protected internal virtual void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
             Visit(importDefaultSpecifier.Local);
         }
 
-        protected virtual void VisitImportSpecifier(ImportSpecifier importSpecifier)
+        protected internal virtual void VisitImportSpecifier(ImportSpecifier importSpecifier)
         {
             Visit(importSpecifier.Local);
             Visit(importSpecifier.Imported);
         }
 
-        protected virtual void VisitMethodDefinition(MethodDefinition methodDefinition)
+        protected internal virtual void VisitMethodDefinition(MethodDefinition methodDefinition)
         {
             Visit(methodDefinition.Key);
             Visit(methodDefinition.Value);
         }
 
-        protected virtual void VisitForOfStatement(ForOfStatement forOfStatement)
+        protected internal virtual void VisitForOfStatement(ForOfStatement forOfStatement)
         {
             Visit(forOfStatement.Left);
             Visit(forOfStatement.Right);
             Visit(forOfStatement.Body);
         }
 
-        protected virtual void VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected internal virtual void VisitClassDeclaration(ClassDeclaration classDeclaration)
         {
             if (classDeclaration.Id is not null)
             {
@@ -601,7 +390,7 @@ namespace Esprima.Utils
             Visit(classDeclaration.Body);
         }
 
-        protected virtual void VisitClassBody(ClassBody classBody)
+        protected internal virtual void VisitClassBody(ClassBody classBody)
         {
             ref readonly var body = ref classBody.Body;
             for (var i = 0; i < body.Count; i++)
@@ -611,7 +400,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitYieldExpression(YieldExpression yieldExpression)
+        protected internal virtual void VisitYieldExpression(YieldExpression yieldExpression)
         {
             if (yieldExpression.Argument is not null)
             {
@@ -619,28 +408,28 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        protected internal virtual void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
             Visit(taggedTemplateExpression.Tag);
             Visit(taggedTemplateExpression.Quasi);
         }
 
-        protected virtual void VisitSuper(Super super)
+        protected internal virtual void VisitSuper(Super super)
         {
         }
 
-        protected virtual void VisitMetaProperty(MetaProperty metaProperty)
+        protected internal virtual void VisitMetaProperty(MetaProperty metaProperty)
         {
             Visit(metaProperty.Meta);
             Visit(metaProperty.Property);
         }
 
-        protected virtual void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
+        protected internal virtual void VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
         {
             // ArrowParameterPlaceHolder nodes never appear in the final tree and only used during the construction of a tree.
         }
 
-        protected virtual void VisitObjectPattern(ObjectPattern objectPattern)
+        protected internal virtual void VisitObjectPattern(ObjectPattern objectPattern)
         {
             ref readonly var properties = ref objectPattern.Properties;
             for (var i = 0; i < properties.Count; i++)
@@ -650,18 +439,18 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitSpreadElement(SpreadElement spreadElement)
+        protected internal virtual void VisitSpreadElement(SpreadElement spreadElement)
         {
             Visit(spreadElement.Argument);
         }
 
-        protected virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected internal virtual void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
             Visit(assignmentPattern.Left);
             Visit(assignmentPattern.Right);
         }
 
-        protected virtual void VisitArrayPattern(ArrayPattern arrayPattern)
+        protected internal virtual void VisitArrayPattern(ArrayPattern arrayPattern)
         {
             ref readonly var elements = ref arrayPattern.Elements;
             for (var i = 0; i < elements.Count; i++)
@@ -674,7 +463,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        protected internal virtual void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
         {
             Visit(variableDeclarator.Id);
             if (variableDeclarator.Init is not null)
@@ -683,7 +472,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        protected internal virtual void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
             ref readonly var quasis = ref templateLiteral.Quasis;
             for (var i = 0; i < quasis.Count; i++)
@@ -698,16 +487,16 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitTemplateElement(TemplateElement templateElement)
+        protected internal virtual void VisitTemplateElement(TemplateElement templateElement)
         {
         }
 
-        protected virtual void VisitRestElement(RestElement restElement)
+        protected internal virtual void VisitRestElement(RestElement restElement)
         {
             Visit(restElement.Argument);
         }
 
-        protected virtual void VisitProperty(Property property)
+        protected internal virtual void VisitProperty(Property property)
         {
             Visit(property.Key);
 
@@ -733,19 +522,19 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitAwaitExpression(AwaitExpression awaitExpression)
+        protected internal virtual void VisitAwaitExpression(AwaitExpression awaitExpression)
         {
             Visit(awaitExpression.Argument);
         }
 
-        protected virtual void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected internal virtual void VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
             Visit(conditionalExpression.Test);
             Visit(conditionalExpression.Consequent);
             Visit(conditionalExpression.Alternate);
         }
 
-        protected virtual void VisitCallExpression(CallExpression callExpression)
+        protected internal virtual void VisitCallExpression(CallExpression callExpression)
         {
             Visit(callExpression.Callee);
             ref readonly var arguments = ref callExpression.Arguments;
@@ -756,13 +545,13 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected internal virtual void VisitBinaryExpression(BinaryExpression binaryExpression)
         {
             Visit(binaryExpression.Left);
             Visit(binaryExpression.Right);
         }
 
-        protected virtual void VisitArrayExpression(ArrayExpression arrayExpression)
+        protected internal virtual void VisitArrayExpression(ArrayExpression arrayExpression)
         {
             ref readonly var elements = ref arrayExpression.Elements;
             for (var i = 0; i < elements.Count; i++)
@@ -775,13 +564,13 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected internal virtual void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
             Visit(assignmentExpression.Left);
             Visit(assignmentExpression.Right);
         }
 
-        protected virtual void VisitContinueStatement(ContinueStatement continueStatement)
+        protected internal virtual void VisitContinueStatement(ContinueStatement continueStatement)
         {
             if (continueStatement.Label is not null)
             {
@@ -789,7 +578,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitBreakStatement(BreakStatement breakStatement)
+        protected internal virtual void VisitBreakStatement(BreakStatement breakStatement)
         {
             if (breakStatement.Label is not null)
             {
@@ -797,7 +586,7 @@ namespace Esprima.Utils
             }
         }
 
-        protected virtual void VisitBlockStatement(BlockStatement blockStatement)
+        protected internal virtual void VisitBlockStatement(BlockStatement blockStatement)
         {
             ref readonly var body = ref blockStatement.Body;
             for (var i = 0; i < body.Count; i++)

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -156,13 +156,14 @@ namespace Esprima.Utils
             VisitedNode?.Invoke(this, node);
         }
 
-        protected override void VisitProgram(Program program)
+        protected internal override void VisitProgram(Program program)
         {
             VisitingProgram?.Invoke(this, program);
             base.VisitProgram(program);
             VisitedProgram?.Invoke(this, program);
         }
 
+        [Obsolete("This method may be removed in a future version as it will not be called anymore due to employing double dispatch (instead of switch dispatch).")]
         protected override void VisitUnknownNode(Node node)
         {
             VisitingUnknownNode?.Invoke(this, node);
@@ -170,462 +171,462 @@ namespace Esprima.Utils
             VisitedUnknownNode?.Invoke(this, node);
         }
 
-        protected override void VisitCatchClause(CatchClause catchClause)
+        protected internal override void VisitCatchClause(CatchClause catchClause)
         {
             VisitingCatchClause?.Invoke(this, catchClause);
             base.VisitCatchClause(catchClause);
             VisitedCatchClause?.Invoke(this, catchClause);
         }
 
-        protected override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        protected internal override void VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
         {
             VisitingFunctionDeclaration?.Invoke(this, functionDeclaration);
             base.VisitFunctionDeclaration(functionDeclaration);
             VisitedFunctionDeclaration?.Invoke(this, functionDeclaration);
         }
 
-        protected override void VisitWithStatement(WithStatement withStatement)
+        protected internal override void VisitWithStatement(WithStatement withStatement)
         {
             VisitingWithStatement?.Invoke(this, withStatement);
             base.VisitWithStatement(withStatement);
             VisitedWithStatement?.Invoke(this, withStatement);
         }
 
-        protected override void VisitWhileStatement(WhileStatement whileStatement)
+        protected internal override void VisitWhileStatement(WhileStatement whileStatement)
         {
             VisitingWhileStatement?.Invoke(this, whileStatement);
             base.VisitWhileStatement(whileStatement);
             VisitedWhileStatement?.Invoke(this, whileStatement);
         }
 
-        protected override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        protected internal override void VisitVariableDeclaration(VariableDeclaration variableDeclaration)
         {
             VisitingVariableDeclaration?.Invoke(this, variableDeclaration);
             base.VisitVariableDeclaration(variableDeclaration);
             VisitedVariableDeclaration?.Invoke(this, variableDeclaration);
         }
 
-        protected override void VisitTryStatement(TryStatement tryStatement)
+        protected internal override void VisitTryStatement(TryStatement tryStatement)
         {
             VisitingTryStatement?.Invoke(this, tryStatement);
             base.VisitTryStatement(tryStatement);
             VisitedTryStatement?.Invoke(this, tryStatement);
         }
 
-        protected override void VisitThrowStatement(ThrowStatement throwStatement)
+        protected internal override void VisitThrowStatement(ThrowStatement throwStatement)
         {
             VisitingThrowStatement?.Invoke(this, throwStatement);
             base.VisitThrowStatement(throwStatement);
             VisitedThrowStatement?.Invoke(this, throwStatement);
         }
 
-        protected override void VisitSwitchStatement(SwitchStatement switchStatement)
+        protected internal override void VisitSwitchStatement(SwitchStatement switchStatement)
         {
             VisitingSwitchStatement?.Invoke(this, switchStatement);
             base.VisitSwitchStatement(switchStatement);
             VisitedSwitchStatement?.Invoke(this, switchStatement);
         }
 
-        protected override void VisitSwitchCase(SwitchCase switchCase)
+        protected internal override void VisitSwitchCase(SwitchCase switchCase)
         {
             VisitingSwitchCase?.Invoke(this, switchCase);
             base.VisitSwitchCase(switchCase);
             VisitedSwitchCase?.Invoke(this, switchCase);
         }
 
-        protected override void VisitReturnStatement(ReturnStatement returnStatement)
+        protected internal override void VisitReturnStatement(ReturnStatement returnStatement)
         {
             VisitingReturnStatement?.Invoke(this, returnStatement);
             base.VisitReturnStatement(returnStatement);
             VisitedReturnStatement?.Invoke(this, returnStatement);
         }
 
-        protected override void VisitLabeledStatement(LabeledStatement labeledStatement)
+        protected internal override void VisitLabeledStatement(LabeledStatement labeledStatement)
         {
             VisitingLabeledStatement?.Invoke(this, labeledStatement);
             base.VisitLabeledStatement(labeledStatement);
             VisitedLabeledStatement?.Invoke(this, labeledStatement);
         }
 
-        protected override void VisitIfStatement(IfStatement ifStatement)
+        protected internal override void VisitIfStatement(IfStatement ifStatement)
         {
             VisitingIfStatement?.Invoke(this, ifStatement);
             base.VisitIfStatement(ifStatement);
             VisitedIfStatement?.Invoke(this, ifStatement);
         }
 
-        protected override void VisitEmptyStatement(EmptyStatement emptyStatement)
+        protected internal override void VisitEmptyStatement(EmptyStatement emptyStatement)
         {
             VisitingEmptyStatement?.Invoke(this, emptyStatement);
             base.VisitEmptyStatement(emptyStatement);
             VisitedEmptyStatement?.Invoke(this, emptyStatement);
         }
 
-        protected override void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        protected internal override void VisitDebuggerStatement(DebuggerStatement debuggerStatement)
         {
             VisitingDebuggerStatement?.Invoke(this, debuggerStatement);
             base.VisitDebuggerStatement(debuggerStatement);
             VisitedDebuggerStatement?.Invoke(this, debuggerStatement);
         }
 
-        protected override void VisitExpressionStatement(ExpressionStatement expressionStatement)
+        protected internal override void VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
             VisitingExpressionStatement?.Invoke(this, expressionStatement);
             base.VisitExpressionStatement(expressionStatement);
             VisitedExpressionStatement?.Invoke(this, expressionStatement);
         }
 
-        protected override void VisitForStatement(ForStatement forStatement)
+        protected internal override void VisitForStatement(ForStatement forStatement)
         {
             VisitingForStatement?.Invoke(this, forStatement);
             base.VisitForStatement(forStatement);
             VisitedForStatement?.Invoke(this, forStatement);
         }
 
-        protected override void VisitForInStatement(ForInStatement forInStatement)
+        protected internal override void VisitForInStatement(ForInStatement forInStatement)
         {
             VisitingForInStatement?.Invoke(this, forInStatement);
             base.VisitForInStatement(forInStatement);
             VisitedForInStatement?.Invoke(this, forInStatement);
         }
 
-        protected override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        protected internal override void VisitDoWhileStatement(DoWhileStatement doWhileStatement)
         {
             VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
             base.VisitDoWhileStatement(doWhileStatement);
             VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
         }
 
-        protected override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+        protected internal override void VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
         {
             VisitingArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
             base.VisitArrowFunctionExpression(arrowFunctionExpression);
             VisitedArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
         }
 
-        protected override void VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected internal override void VisitUnaryExpression(UnaryExpression unaryExpression)
         {
             VisitingUnaryExpression?.Invoke(this, unaryExpression);
             base.VisitUnaryExpression(unaryExpression);
             VisitedUnaryExpression?.Invoke(this, unaryExpression);
         }
 
-        protected override void VisitUpdateExpression(UpdateExpression updateExpression)
+        protected internal override void VisitUpdateExpression(UpdateExpression updateExpression)
         {
             VisitingUpdateExpression?.Invoke(this, updateExpression);
             base.VisitUpdateExpression(updateExpression);
             VisitedUpdateExpression?.Invoke(this, updateExpression);
         }
 
-        protected override void VisitThisExpression(ThisExpression thisExpression)
+        protected internal override void VisitThisExpression(ThisExpression thisExpression)
         {
             VisitingThisExpression?.Invoke(this, thisExpression);
             base.VisitThisExpression(thisExpression);
             VisitedThisExpression?.Invoke(this, thisExpression);
         }
 
-        protected override void VisitSequenceExpression(SequenceExpression sequenceExpression)
+        protected internal override void VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
             VisitingSequenceExpression?.Invoke(this, sequenceExpression);
             base.VisitSequenceExpression(sequenceExpression);
             VisitedSequenceExpression?.Invoke(this, sequenceExpression);
         }
 
-        protected override void VisitObjectExpression(ObjectExpression objectExpression)
+        protected internal override void VisitObjectExpression(ObjectExpression objectExpression)
         {
             VisitingObjectExpression?.Invoke(this, objectExpression);
             base.VisitObjectExpression(objectExpression);
             VisitedObjectExpression?.Invoke(this, objectExpression);
         }
 
-        protected override void VisitNewExpression(NewExpression newExpression)
+        protected internal override void VisitNewExpression(NewExpression newExpression)
         {
             VisitingNewExpression?.Invoke(this, newExpression);
             base.VisitNewExpression(newExpression);
             VisitedNewExpression?.Invoke(this, newExpression);
         }
 
-        protected override void VisitMemberExpression(MemberExpression memberExpression)
+        protected internal override void VisitMemberExpression(MemberExpression memberExpression)
         {
             VisitingMemberExpression?.Invoke(this, memberExpression);
             base.VisitMemberExpression(memberExpression);
             VisitedMemberExpression?.Invoke(this, memberExpression);
         }
 
-        protected override void VisitLogicalExpression(BinaryExpression binaryExpression)
+        protected internal override void VisitLogicalExpression(BinaryExpression binaryExpression)
         {
             VisitingLogicalExpression?.Invoke(this, binaryExpression);
             base.VisitLogicalExpression(binaryExpression);
             VisitedLogicalExpression?.Invoke(this, binaryExpression);
         }
 
-        protected override void VisitLiteral(Literal literal)
+        protected internal override void VisitLiteral(Literal literal)
         {
             VisitingLiteral?.Invoke(this, literal);
             base.VisitLiteral(literal);
             VisitedLiteral?.Invoke(this, literal);
         }
 
-        protected override void VisitIdentifier(Identifier identifier)
+        protected internal override void VisitIdentifier(Identifier identifier)
         {
             VisitingIdentifier?.Invoke(this, identifier);
             base.VisitIdentifier(identifier);
             VisitedIdentifier?.Invoke(this, identifier);
         }
 
-        protected override void VisitFunctionExpression(IFunction function)
+        protected internal override void VisitFunctionExpression(IFunction function)
         {
             VisitingFunctionExpression?.Invoke(this, function);
             base.VisitFunctionExpression(function);
             VisitedFunctionExpression?.Invoke(this, function);
         }
 
-        protected override void VisitChainExpression(ChainExpression chainExpression)
+        protected internal override void VisitChainExpression(ChainExpression chainExpression)
         {
             VisitingChainExpression?.Invoke(this, chainExpression);
             base.VisitChainExpression(chainExpression);
             VisitedChainExpression?.Invoke(this, chainExpression);
         }
 
-        protected override void VisitClassExpression(ClassExpression classExpression)
+        protected internal override void VisitClassExpression(ClassExpression classExpression)
         {
             VisitingClassExpression?.Invoke(this, classExpression);
             base.VisitClassExpression(classExpression);
             VisitedClassExpression?.Invoke(this, classExpression);
         }
 
-        protected override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected internal override void VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
         {
             VisitingExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
             base.VisitExportDefaultDeclaration(exportDefaultDeclaration);
             VisitedExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
         }
 
-        protected override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+        protected internal override void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
             VisitingExportAllDeclaration?.Invoke(this, exportAllDeclaration);
             base.VisitExportAllDeclaration(exportAllDeclaration);
             VisitedExportAllDeclaration?.Invoke(this, exportAllDeclaration);
         }
 
-        protected override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+        protected internal override void VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
         {
             VisitingExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
             base.VisitExportNamedDeclaration(exportNamedDeclaration);
             VisitedExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
         }
 
-        protected override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
+        protected internal override void VisitExportSpecifier(ExportSpecifier exportSpecifier)
         {
             VisitingExportSpecifier?.Invoke(this, exportSpecifier);
             base.VisitExportSpecifier(exportSpecifier);
             VisitedExportSpecifier?.Invoke(this, exportSpecifier);
         }
 
-        protected override void VisitImport(Import import)
+        protected internal override void VisitImport(Import import)
         {
             VisitingImport?.Invoke(this, import);
             base.VisitImport(import);
             VisitedImport?.Invoke(this, import);
         }
 
-        protected override void VisitImportDeclaration(ImportDeclaration importDeclaration)
+        protected internal override void VisitImportDeclaration(ImportDeclaration importDeclaration)
         {
             VisitingImportDeclaration?.Invoke(this, importDeclaration);
             base.VisitImportDeclaration(importDeclaration);
             VisitedImportDeclaration?.Invoke(this, importDeclaration);
         }
 
-        protected override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        protected internal override void VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
         {
             VisitingImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
             base.VisitImportNamespaceSpecifier(importNamespaceSpecifier);
             VisitedImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
         }
 
-        protected override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+        protected internal override void VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
             VisitingImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
             base.VisitImportDefaultSpecifier(importDefaultSpecifier);
             VisitedImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
         }
 
-        protected override void VisitImportSpecifier(ImportSpecifier importSpecifier)
+        protected internal override void VisitImportSpecifier(ImportSpecifier importSpecifier)
         {
             VisitingImportSpecifier?.Invoke(this, importSpecifier);
             base.VisitImportSpecifier(importSpecifier);
             VisitedImportSpecifier?.Invoke(this, importSpecifier);
         }
 
-        protected override void VisitMethodDefinition(MethodDefinition methodDefinition)
+        protected internal override void VisitMethodDefinition(MethodDefinition methodDefinition)
         {
             VisitingMethodDefinition?.Invoke(this, methodDefinition);
             base.VisitMethodDefinition(methodDefinition);
             VisitedMethodDefinition?.Invoke(this, methodDefinition);
         }
 
-        protected override void VisitForOfStatement(ForOfStatement forOfStatement)
+        protected internal override void VisitForOfStatement(ForOfStatement forOfStatement)
         {
             VisitingForOfStatement?.Invoke(this, forOfStatement);
             base.VisitForOfStatement(forOfStatement);
             VisitedForOfStatement?.Invoke(this, forOfStatement);
         }
 
-        protected override void VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected internal override void VisitClassDeclaration(ClassDeclaration classDeclaration)
         {
             VisitingClassDeclaration?.Invoke(this, classDeclaration);
             base.VisitClassDeclaration(classDeclaration);
             VisitedClassDeclaration?.Invoke(this, classDeclaration);
         }
 
-        protected override void VisitClassBody(ClassBody classBody)
+        protected internal override void VisitClassBody(ClassBody classBody)
         {
             VisitingClassBody?.Invoke(this, classBody);
             base.VisitClassBody(classBody);
             VisitedClassBody?.Invoke(this, classBody);
         }
 
-        protected override void VisitYieldExpression(YieldExpression yieldExpression)
+        protected internal override void VisitYieldExpression(YieldExpression yieldExpression)
         {
             VisitingYieldExpression?.Invoke(this, yieldExpression);
             base.VisitYieldExpression(yieldExpression);
             VisitedYieldExpression?.Invoke(this, yieldExpression);
         }
 
-        protected override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        protected internal override void VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
         {
             VisitingTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
             base.VisitTaggedTemplateExpression(taggedTemplateExpression);
             VisitedTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
         }
 
-        protected override void VisitSuper(Super super)
+        protected internal override void VisitSuper(Super super)
         {
             VisitingSuper?.Invoke(this, super);
             base.VisitSuper(super);
             VisitedSuper?.Invoke(this, super);
         }
 
-        protected override void VisitMetaProperty(MetaProperty metaProperty)
+        protected internal override void VisitMetaProperty(MetaProperty metaProperty)
         {
             VisitingMetaProperty?.Invoke(this, metaProperty);
             base.VisitMetaProperty(metaProperty);
             VisitedMetaProperty?.Invoke(this, metaProperty);
         }
 
-        protected override void VisitObjectPattern(ObjectPattern objectPattern)
+        protected internal override void VisitObjectPattern(ObjectPattern objectPattern)
         {
             VisitingObjectPattern?.Invoke(this, objectPattern);
             base.VisitObjectPattern(objectPattern);
             VisitedObjectPattern?.Invoke(this, objectPattern);
         }
 
-        protected override void VisitSpreadElement(SpreadElement spreadElement)
+        protected internal override void VisitSpreadElement(SpreadElement spreadElement)
         {
             VisitingSpreadElement?.Invoke(this, spreadElement);
             base.VisitSpreadElement(spreadElement);
             VisitedSpreadElement?.Invoke(this, spreadElement);
         }
 
-        protected override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected internal override void VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
             VisitingAssignmentPattern?.Invoke(this, assignmentPattern);
             base.VisitAssignmentPattern(assignmentPattern);
             VisitedAssignmentPattern?.Invoke(this, assignmentPattern);
         }
 
-        protected override void VisitArrayPattern(ArrayPattern arrayPattern)
+        protected internal override void VisitArrayPattern(ArrayPattern arrayPattern)
         {
             VisitingArrayPattern?.Invoke(this, arrayPattern);
             base.VisitArrayPattern(arrayPattern);
             VisitedArrayPattern?.Invoke(this, arrayPattern);
         }
 
-        protected override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        protected internal override void VisitVariableDeclarator(VariableDeclarator variableDeclarator)
         {
             VisitingVariableDeclarator?.Invoke(this, variableDeclarator);
             base.VisitVariableDeclarator(variableDeclarator);
             VisitedVariableDeclarator?.Invoke(this, variableDeclarator);
         }
 
-        protected override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        protected internal override void VisitTemplateLiteral(TemplateLiteral templateLiteral)
         {
             VisitingTemplateLiteral?.Invoke(this, templateLiteral);
             base.VisitTemplateLiteral(templateLiteral);
             VisitedTemplateLiteral?.Invoke(this, templateLiteral);
         }
 
-        protected override void VisitTemplateElement(TemplateElement templateElement)
+        protected internal override void VisitTemplateElement(TemplateElement templateElement)
         {
             VisitingTemplateElement?.Invoke(this, templateElement);
             base.VisitTemplateElement(templateElement);
             VisitedTemplateElement?.Invoke(this, templateElement);
         }
 
-        protected override void VisitRestElement(RestElement restElement)
+        protected internal override void VisitRestElement(RestElement restElement)
         {
             VisitingRestElement?.Invoke(this, restElement);
             base.VisitRestElement(restElement);
             VisitedRestElement?.Invoke(this, restElement);
         }
 
-        protected override void VisitProperty(Property property)
+        protected internal override void VisitProperty(Property property)
         {
             VisitingProperty?.Invoke(this, property);
             base.VisitProperty(property);
             VisitedProperty?.Invoke(this, property);
         }
 
-        protected override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected internal override void VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
             VisitingConditionalExpression?.Invoke(this, conditionalExpression);
             base.VisitConditionalExpression(conditionalExpression);
             VisitedConditionalExpression?.Invoke(this, conditionalExpression);
         }
 
-        protected override void VisitCallExpression(CallExpression callExpression)
+        protected internal override void VisitCallExpression(CallExpression callExpression)
         {
             VisitingCallExpression?.Invoke(this, callExpression);
             base.VisitCallExpression(callExpression);
             VisitedCallExpression?.Invoke(this, callExpression);
         }
 
-        protected override void VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected internal override void VisitBinaryExpression(BinaryExpression binaryExpression)
         {
             VisitingBinaryExpression?.Invoke(this, binaryExpression);
             base.VisitBinaryExpression(binaryExpression);
             VisitedBinaryExpression?.Invoke(this, binaryExpression);
         }
 
-        protected override void VisitArrayExpression(ArrayExpression arrayExpression)
+        protected internal override void VisitArrayExpression(ArrayExpression arrayExpression)
         {
             VisitingArrayExpression?.Invoke(this, arrayExpression);
             base.VisitArrayExpression(arrayExpression);
             VisitedArrayExpression?.Invoke(this, arrayExpression);
         }
 
-        protected override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected internal override void VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
             VisitingAssignmentExpression?.Invoke(this, assignmentExpression);
             base.VisitAssignmentExpression(assignmentExpression);
             VisitedAssignmentExpression?.Invoke(this, assignmentExpression);
         }
 
-        protected override void VisitContinueStatement(ContinueStatement continueStatement)
+        protected internal override void VisitContinueStatement(ContinueStatement continueStatement)
         {
             VisitingContinueStatement?.Invoke(this, continueStatement);
             base.VisitContinueStatement(continueStatement);
             VisitedContinueStatement?.Invoke(this, continueStatement);
         }
 
-        protected override void VisitBreakStatement(BreakStatement breakStatement)
+        protected internal override void VisitBreakStatement(BreakStatement breakStatement)
         {
             VisitingBreakStatement?.Invoke(this, breakStatement);
             base.VisitBreakStatement(breakStatement);
             VisitedBreakStatement?.Invoke(this, breakStatement);
         }
 
-        protected override void VisitBlockStatement(BlockStatement blockStatement)
+        protected internal override void VisitBlockStatement(BlockStatement blockStatement)
         {
             VisitingBlockStatement?.Invoke(this, blockStatement);
             base.VisitBlockStatement(blockStatement);


### PR DESCRIPTION
This is a proposal to use the standard double dispatch approach of the visitor design pattern instead of the current switch dispatch.

Performance-wise the two approaches are practically the same:

``` ini

BenchmarkDotNet=v0.13.0, OS=Windows 10.0.19041.1165 (2004/May2020Update/20H1)
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET SDK=5.0.400
  [Host]             : .NET 5.0.9 (5.0.921.35908), X64 RyuJIT
  .NET 5.0           : .NET 5.0.9 (5.0.921.35908), X64 RyuJIT
  .NET Core 3.1      : .NET Core 3.1.18 (CoreCLR 4.700.21.35901, CoreFX 4.700.21.36305), X64 RyuJIT
  .NET Framework 4.8 : .NET Framework 4.8 (4.8.4400.0), X64 RyuJIT


```
|         Method |                Job |            Runtime |     Mean |   Error |  StdDev | Rank |
|--------------- |------------------- |------------------- |---------:|--------:|--------:|-----:|
| SwitchDispatch |           .NET 5.0 |           .NET 5.0 | 562.6 ms | 3.67 ms | 2.86 ms |    1 |
| DoubleDispatch |           .NET 5.0 |           .NET 5.0 | 596.6 ms | 2.22 ms | 2.07 ms |    2 |
| SwitchDispatch |      .NET Core 3.1 |      .NET Core 3.1 | 555.8 ms | 2.46 ms | 2.18 ms |    1 |
| DoubleDispatch |      .NET Core 3.1 |      .NET Core 3.1 | 609.0 ms | 4.74 ms | 4.20 ms |    3 |
| SwitchDispatch | .NET Framework 4.8 | .NET Framework 4.8 | 656.8 ms | 2.55 ms | 2.26 ms |    4 |
| DoubleDispatch | .NET Framework 4.8 | .NET Framework 4.8 | 650.7 ms | 7.25 ms | 6.78 ms |    4 |

(The table shows the time needed for entirely traversing a script of ~60000 nodes one thousand times. So a single visitation took 550-600 µs on average.)

However, from a maintenance point of view, double dispatch has some benefits over switch dispatch:
* it's exhaustive by nature (no need for `VisitUnknownNode`),
* makes impossible to forget about the visitor aspect when adding a new AST node type (because of the abstract `Accept` method of the `Node` base class)
