### PR TITLE
AST polymorphism improvements

### DIFF
--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -2,11 +2,16 @@
 
 namespace Esprima.Ast
 {
-    public sealed class ClassDeclaration : Declaration
+    public sealed class ClassDeclaration : Declaration, IClass
     {
         public readonly Identifier? Id;
+        Identifier? IClass.Id => Id;
+
         public readonly Expression? SuperClass; // Identifier || CallExpression
+        Expression? IClass.SuperClass => SuperClass;
+
         public readonly ClassBody Body;
+        ClassBody IClass.Body => Body;
 
         public ClassDeclaration(Identifier? id, Expression? superClass, ClassBody body) :
             base(Nodes.ClassDeclaration)

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -2,14 +2,19 @@
 
 namespace Esprima.Ast
 {
-    public sealed class ClassExpression : Expression
+    public sealed class ClassExpression : Expression, IClass
     {
         public readonly Identifier? Id;
+        Identifier? IClass.Id => Id;
+
         public readonly Expression? SuperClass;
+        Expression? IClass.SuperClass => SuperClass;
+
         public readonly ClassBody Body;
+        ClassBody IClass.Body => Body;
 
         public ClassExpression(
-            Identifier? id, 
+            Identifier? id,
             Expression? superClass,
             ClassBody body) : base(Nodes.ClassExpression)
         {

--- a/src/Esprima/Ast/IClass.cs
+++ b/src/Esprima/Ast/IClass.cs
@@ -1,0 +1,13 @@
+﻿namespace Esprima.Ast
+{
+    /// <summary>
+    /// Represents either a <see cref="ClassDeclaration"/> or an <see cref="ClassExpression"/>
+    /// </summary>
+    public interface IClass
+    {
+        Identifier? Id { get; }
+        Expression? SuperClass { get; }
+        ClassBody Body { get; }
+        NodeCollection ChildNodes { get; }
+    }
+}

--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -1,7 +1,7 @@
 ﻿namespace Esprima.Ast
 {
     /// <summary>
-    /// Represents either a <see cref="FunctionDeclaration"/> or a <see cref="FunctionExpression"/>
+    /// Represents either a <see cref="FunctionDeclaration"/>, a <see cref="FunctionExpression"/> or an <see cref="ArrowFunctionExpression"/>
     /// </summary>
     public interface IFunction
     {

--- a/src/Esprima/Ast/IImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/IImportDeclarationSpecifier.cs
@@ -1,0 +1,8 @@
+﻿namespace Esprima.Ast
+{
+    public interface IImportDeclarationSpecifier
+    {
+        Identifier Local { get; }
+        NodeCollection ChildNodes { get; }
+    }
+}

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -1,9 +1,12 @@
 ﻿namespace Esprima.Ast
 {
-    public abstract class ImportDeclarationSpecifier : Declaration
+    public abstract class ImportDeclarationSpecifier : Declaration, IImportDeclarationSpecifier
     {
         protected ImportDeclarationSpecifier(Nodes type) : base(type)
         {
         }
+
+        Identifier IImportDeclarationSpecifier.Local => LocalId;
+        protected abstract Identifier LocalId { get; }
     }
 }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -5,6 +5,7 @@ namespace Esprima.Ast
     public sealed class ImportDefaultSpecifier : ImportDeclarationSpecifier
     {
         public readonly Identifier Local;
+        protected override Identifier LocalId => Local;
 
         public ImportDefaultSpecifier(Identifier local) : base(Nodes.ImportDefaultSpecifier)
         {

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -5,6 +5,7 @@ namespace Esprima.Ast
     public sealed class ImportNamespaceSpecifier : ImportDeclarationSpecifier
     {
         public readonly Identifier Local;
+        protected override Identifier LocalId => Local;
 
         public ImportNamespaceSpecifier(Identifier local) : base(Nodes.ImportNamespaceSpecifier)
         {

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -5,6 +5,8 @@ namespace Esprima.Ast
     public sealed class ImportSpecifier : ImportDeclarationSpecifier
     {
         public readonly Identifier Local;
+        protected override Identifier LocalId => Local;
+
         public readonly Identifier Imported;
 
         public ImportSpecifier(Identifier local, Identifier imported) : base(Nodes.ImportSpecifier)


### PR DESCRIPTION
This one addresses https://github.com/sebastienros/esprima-dotnet/issues/180

Note: I think it's better not to move `Local` identifier of the `Import*Specifier` classes to the base class because unfortunatly it's declared as field and because of that we'd have an ABI BC.