### PR TITLE
AST polymorphism improvements (second thought)

### DIFF
--- a/src/Esprima/Ast/IImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/IImportDeclarationSpecifier.cs
@@ -1,8 +1,0 @@
-﻿namespace Esprima.Ast
-{
-    public interface IImportDeclarationSpecifier
-    {
-        Identifier Local { get; }
-        NodeCollection ChildNodes { get; }
-    }
-}

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -1,12 +1,12 @@
 ﻿namespace Esprima.Ast
 {
-    public abstract class ImportDeclarationSpecifier : Declaration, IImportDeclarationSpecifier
+    public abstract class ImportDeclarationSpecifier : Declaration
     {
         protected ImportDeclarationSpecifier(Nodes type) : base(type)
         {
         }
 
-        Identifier IImportDeclarationSpecifier.Local => LocalId;
+        public Identifier Local => LocalId;
         protected abstract Identifier LocalId { get; }
     }
 }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -4,7 +4,7 @@ namespace Esprima.Ast
 {
     public sealed class ImportDefaultSpecifier : ImportDeclarationSpecifier
     {
-        public readonly Identifier Local;
+        public new readonly Identifier Local;
         protected override Identifier LocalId => Local;
 
         public ImportDefaultSpecifier(Identifier local) : base(Nodes.ImportDefaultSpecifier)

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -4,7 +4,7 @@ namespace Esprima.Ast
 {
     public sealed class ImportNamespaceSpecifier : ImportDeclarationSpecifier
     {
-        public readonly Identifier Local;
+        public new readonly Identifier Local;
         protected override Identifier LocalId => Local;
 
         public ImportNamespaceSpecifier(Identifier local) : base(Nodes.ImportNamespaceSpecifier)

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -4,7 +4,7 @@ namespace Esprima.Ast
 {
     public sealed class ImportSpecifier : ImportDeclarationSpecifier
     {
-        public readonly Identifier Local;
+        public new readonly Identifier Local;
         protected override Identifier LocalId => Local;
 
         public readonly Identifier Imported;


### PR DESCRIPTION
This is related to https://github.com/sebastienros/esprima-dotnet/pull/188.

Sorry for splitting hairs but in the meantime I realized that introducing a new interface for import specifiers is not really necessary. So I suggest getting rid of it because 
* having a base class and an interface for import specifiers seems a bit redundant,
* [as mentioned in the first PR](https://github.com/sebastienros/esprima-dotnet/pull/188#issuecomment-901861260), fields of AST nodes might be changed to properties in the future, in which case the `IImportDeclarationSpecifier` interface would become redundant anyway.
 

 