### PR TITLE
Allow assigning __proto__ in object literals

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -973,7 +973,7 @@ namespace Esprima
                 {
                     if (!computed && IsPropertyKey(key, "__proto__"))
                     {
-                        if (hasProto.Value != null)
+                        if (hasProto.BooleanValue)
                         {
                             TolerateError(Messages.DuplicateProtoProperty);
                         }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -188,5 +188,19 @@ f(values);
             var parser = new JavaScriptParser("class Edge { [util.inspect.custom] () { return this.toJSON() } }");
             parser.ParseScript();
         }
+
+        [Fact]
+        public void AllowsSingleProto()
+        {
+            var parser = new JavaScriptParser("if({ __proto__: [] } instanceof Array) {}", new ParserOptions { Tolerant = false });
+            parser.ParseScript();
+        }
+
+        [Fact]
+        public void ThrowsErrorForDuplicateProto()
+        {
+            var parser = new JavaScriptParser("if({ __proto__: [], __proto__: [] } instanceof Array) {}", new ParserOptions { Tolerant = false });
+            Assert.Throws<ParserException>(() => parser.ParseScript());
+        }
     }
 }


### PR DESCRIPTION
Basically, this should work: `({ __proto__: [] })`

This should fail: `({ __proto__: [], __proto__: [] })`