### PR TITLE
Prevent infinite loop in TestRegExp

### DIFF
--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1640,6 +1640,10 @@ namespace Esprima
                             newPattern = newPattern.Substring(0, index) + @"\r?" + newPattern.Substring(index);
                             index += 4;
                         }
+                        else
+                        {
+                            index++;
+                        }
                     }
 
                     pattern = newPattern;

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -24,5 +24,13 @@ namespace Esprima.Tests
 
             Assert.Equal(new[] { "11-28" }, results);
         }
+
+        [Fact]
+        public void ShouldPreventInfiniteLoopWhenAdaptingMultiLine()
+        {
+            var scanner = new Scanner("", new ParserOptions { AdaptRegexp = true });
+            var regex = scanner.TestRegExp("\\$", "gm");
+            Assert.NotNull(regex);
+        }
     }
 }


### PR DESCRIPTION
Basically need to advance search always to not to be caught in a loop.  Jint test suite passes with this change.

Seems that I'm also changing some whitespace here..

fixes #212