### PR TITLE
Fix module import/export identifier parsing

### DIFF
--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -5,13 +5,17 @@ namespace Esprima.Ast
     public sealed class ExportAllDeclaration : ExportDeclaration
     {
         public readonly Literal Source;
-        public readonly Identifier? Exported;
+
+        /// <summary>
+        /// Identifier | StringLiteral
+        /// </summary>
+        public readonly Expression? Exported;
 
         public ExportAllDeclaration(Literal source) : this(source, null)
         {
         }
 
-        public ExportAllDeclaration(Literal source, Identifier? exported) : base(Nodes.ExportAllDeclaration)
+        public ExportAllDeclaration(Literal source, Expression? exported) : base(Nodes.ExportAllDeclaration)
         {
             Source = source;
             Exported = exported;

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -4,10 +4,17 @@ namespace Esprima.Ast
 {
     public sealed class ExportSpecifier : Statement
     {
-        public readonly Identifier Exported;
-        public readonly Identifier Local;
+        /// <summary>
+        /// Identifier | StringLiteral
+        /// </summary>
+        public readonly Expression Exported;
 
-        public ExportSpecifier(Identifier local, Identifier exported) : base(Nodes.ExportSpecifier)
+        /// <summary>
+        /// Identifier | StringLiteral
+        /// </summary>
+        public readonly Expression Local;
+
+        public ExportSpecifier(Expression local, Expression exported) : base(Nodes.ExportSpecifier)
         {
             Exported = exported;
             Local = local;

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -2,11 +2,14 @@
 {
     public abstract class ImportDeclarationSpecifier : Declaration
     {
-        protected ImportDeclarationSpecifier(Nodes type) : base(type)
-        {
-        }
+        /// <summary>
+        /// Identifier | StringLiteral
+        /// </summary>
+        public readonly Expression Local;
 
-        public Identifier Local => LocalId;
-        protected abstract Identifier LocalId { get; }
+        protected ImportDeclarationSpecifier(Expression local, Nodes type) : base(type)
+        {
+            Local = local;
+        }
     }
 }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -4,12 +4,8 @@ namespace Esprima.Ast
 {
     public sealed class ImportDefaultSpecifier : ImportDeclarationSpecifier
     {
-        public new readonly Identifier Local;
-        protected override Identifier LocalId => Local;
-
-        public ImportDefaultSpecifier(Identifier local) : base(Nodes.ImportDefaultSpecifier)
+        public ImportDefaultSpecifier(Identifier local) : base(local, Nodes.ImportDefaultSpecifier)
         {
-            Local = local;
         }
 
         public override NodeCollection ChildNodes => new(Local);

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -4,12 +4,8 @@ namespace Esprima.Ast
 {
     public sealed class ImportNamespaceSpecifier : ImportDeclarationSpecifier
     {
-        public new readonly Identifier Local;
-        protected override Identifier LocalId => Local;
-
-        public ImportNamespaceSpecifier(Identifier local) : base(Nodes.ImportNamespaceSpecifier)
+        public ImportNamespaceSpecifier(Identifier local) : base(local, Nodes.ImportNamespaceSpecifier)
         {
-            Local = local;
         }
 
         public override NodeCollection ChildNodes => new(Local);

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -4,14 +4,13 @@ namespace Esprima.Ast
 {
     public sealed class ImportSpecifier : ImportDeclarationSpecifier
     {
-        public new readonly Identifier Local;
-        protected override Identifier LocalId => Local;
+        /// <summary>
+        /// Identifier | StringLiteral
+        /// </summary>
+        public readonly Expression Imported;
 
-        public readonly Identifier Imported;
-
-        public ImportSpecifier(Identifier local, Identifier imported) : base(Nodes.ImportSpecifier)
+        public ImportSpecifier(Expression local, Expression imported) : base(local, Nodes.ImportSpecifier)
         {
-            Local = local;
             Imported = imported;
         }
 

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -4672,7 +4672,8 @@ namespace Esprima
         {
             var node = CreateNode();
 
-            Identifier local, imported;
+            Expression local;
+            Expression imported;
 
             if (_lookahead.Type == TokenType.Identifier)
             {
@@ -4686,7 +4687,10 @@ namespace Esprima
             }
             else
             {
-                imported = ParseIdentifierName();
+                imported = this._lookahead.Type == TokenType.StringLiteral
+                    ? ParseModuleSpecifier()
+                    : ParseIdentifierName();
+
                 local = imported;
                 if (MatchContextualKeyword("as"))
                 {
@@ -4824,12 +4828,17 @@ namespace Esprima
         {
             var node = CreateNode();
 
-            var local = ParseIdentifierName();
+            Expression local = this._lookahead.Type == TokenType.StringLiteral
+                ? ParseModuleSpecifier()
+                : ParseIdentifierName();
+
             var exported = local;
             if (MatchContextualKeyword("as"))
             {
                 NextToken();
-                exported = ParseIdentifierName();
+                exported = this._lookahead.Type == TokenType.StringLiteral
+                    ? ParseModuleSpecifier()
+                    : ParseIdentifierName();
             }
 
             return Finalize(node, new ExportSpecifier(local, exported));
@@ -4898,11 +4907,13 @@ namespace Esprima
                 NextToken();
 
                 //export * as ns from 'foo'
-                Identifier? exported = null;
+                Expression? exported = null;
                 if (MatchContextualKeyword("as"))
                 {
                     NextToken();
-                    exported = ParseIdentifierName();
+                    exported = this._lookahead.Type == TokenType.StringLiteral
+                        ? ParseModuleSpecifier()
+                        : ParseIdentifierName();
                 }
 
                 if (!MatchContextualKeyword("from"))

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -104,6 +104,16 @@ namespace Esprima.Tests
             Assert.Equal(expected, literal.NumericValue);
         }
 
+        [Theory]
+        [InlineData("export { Mercury as \"☿\" } from \"./export-expname_FIXTURE.js\";")]
+        [InlineData("export * as \"All\" from \"./export-expname_FIXTURE.js\";")]
+        [InlineData("export { \"☿\" as Ami } from \"./export-expname_FIXTURE.js\"")]
+        [InlineData("import { \"☿\" as Ami } from \"./export-expname_FIXTURE.js\";")]
+        public void ShouldParseModuleImportExportWithStringIdentifiers(string source)
+        {
+            new JavaScriptParser(source).ParseModule();
+        }
+
         [Fact]
         public void ShouldParseClassInheritance()
         {


### PR DESCRIPTION
[Per specification](https://tc39.es/ecma262/#prod-ModuleExportName), module `export`s/`import`s can either have `Identifier` or `StringLiteral` as value. 

This PR fixes the issue. Is a breaking change as API changes from `Identifier`s to `Expression`s, but there's no other way to fix the issue. This PR unblocks failing tests in Jint PR.