### PR TITLE
Support class static blocks

### DIFF
--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -2,11 +2,16 @@
 
 namespace Esprima.Ast
 {
-    public sealed class BlockStatement : Statement
+    public class BlockStatement : Statement
     {
         private readonly NodeList<Statement> _body;
 
         public BlockStatement(in NodeList<Statement> body) : base(Nodes.BlockStatement)
+        {
+            _body = body;
+        }
+
+        internal BlockStatement(in NodeList<Statement> body, Nodes type) : base(type)
         {
             _body = body;
         }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -4,14 +4,14 @@ namespace Esprima.Ast
 {
     public sealed class ClassBody : Node
     {
-        private readonly NodeList<ClassProperty> _body;
+        private readonly NodeList<Node> _body;
 
-        public ClassBody(in NodeList<ClassProperty> body) : base(Nodes.ClassBody)
+        public ClassBody(in NodeList<Node> body) : base(Nodes.ClassBody)
         {
             _body = body;
         }
 
-        public ref readonly NodeList<ClassProperty> Body => ref _body;
+        public ref readonly NodeList<Node> Body => ref _body;
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 

--- a/src/Esprima/Ast/Nodes.cs
+++ b/src/Esprima/Ast/Nodes.cs
@@ -36,6 +36,7 @@
         RestElement,
         ReturnStatement,
         SequenceExpression,
+        StaticBlock,
         SwitchStatement,
         SwitchCase,
         TemplateElement,

--- a/src/Esprima/Ast/StaticBlock.cs
+++ b/src/Esprima/Ast/StaticBlock.cs
@@ -1,0 +1,16 @@
+﻿using Esprima.Utils;
+
+namespace Esprima.Ast
+{
+    public sealed class StaticBlock : BlockStatement
+    {
+        public StaticBlock(in NodeList<Statement> body) : base(body, Nodes.StaticBlock)
+        {
+        }
+
+        protected internal override void Accept(AstVisitor visitor)
+        {
+            visitor.VisitStaticBlock(this);
+        }
+    }
+}

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -588,5 +588,14 @@ namespace Esprima.Utils
                 Visit(body[i]);
             }
         }
+
+        protected internal virtual void VisitStaticBlock(StaticBlock blockStatement)
+        {
+            ref readonly var body = ref blockStatement.Body;
+            for (var i = 0; i < body.Count; i++)
+            {
+                Visit(body[i]);
+            }
+        }
     }
 }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -122,6 +122,26 @@ namespace Esprima.Tests
         }
 
         [Fact]
+        public void ShouldParseClassStaticBlocks()
+        {
+            const string Code = @"
+class aa {
+    static qq() {
+    }
+    static staticProperty1 = 'Property 1';
+    static staticProperty2;
+    static {
+      this.staticProperty2 = 'Property 2';
+    }
+    static staticProperty3;
+    static {
+      this.staticProperty3 = 'Property 3';
+    }
+}";
+            new JavaScriptParser(Code).ParseScript();
+        }
+
+        [Fact]
         public void ShouldSymbolPropertyKey()
         {
             var parser = new JavaScriptParser("var a = { [Symbol.iterator]: undefined }");


### PR DESCRIPTION
commit b6ec3c79d317ed0d8d861c72567730a0f723ba3e from esprima-next - parse class "static blocks"