### PR TITLE
Replace hasProto token with ref bool

### DIFF
--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -44,25 +44,5 @@ namespace Esprima
         public object? Value;
         public RegexValue? RegexValue;
         public BigInteger? BigIntValue;
-
-        public void Clear()
-        {
-            Type = TokenType.BooleanLiteral;
-            Literal = null;
-            Start = 0;
-            End = 0;
-            LineNumber = 0;
-            LineStart = 0;
-            Location = default;
-            Octal = false;
-            Head = false;
-            Tail = false;
-            RawTemplate = null;
-            BooleanValue = false;
-            NumericValue = 0;
-            Value = null;
-            RegexValue = null;
-            BigIntValue = null;
-        }
     }
 }


### PR DESCRIPTION
The old code inherited from esprima used a token to pass info about proto being present to avoid JS's copy by value semantics, in C# it makes more sense just just ref bool.