### PR TITLE
Use preview-GITHUB_RUN_NUMBER for MyGet feed version

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -35,7 +35,7 @@ jobs:
       run: dotnet test --configuration Release --logger:"console;verbosity=quiet"
 
     - name: Pack with dotnet
-      run: dotnet pack --output artifacts --configuration Release -p:VersionSuffix=preview-$GITHUB_RUN_NUMBER
+      run: dotnet pack --output artifacts --configuration Release -p:PackageVersion=3.0.0-preview-$GITHUB_RUN_NUMBER
 
     - name: Push with dotnet
       run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/esprimadotnet/api/v2/package


### PR DESCRIPTION
We probably want to make some breaking changes and fix API issues so safe to mark as 3.x already, less problematic for these version numbers too...

Tested to work on Jint side already. The previous version didn't kick in due to Build.props having specific PackageVersion key...