### PR TITLE
ImportDeclarationSpecifier AST correction 

### DIFF
--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -2,12 +2,9 @@
 {
     public abstract class ImportDeclarationSpecifier : Declaration
     {
-        /// <summary>
-        /// Identifier | StringLiteral
-        /// </summary>
-        public readonly Expression Local;
+        public readonly Identifier Local;
 
-        protected ImportDeclarationSpecifier(Expression local, Nodes type) : base(type)
+        protected ImportDeclarationSpecifier(Identifier local, Nodes type) : base(type)
         {
             Local = local;
         }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -9,7 +9,7 @@ namespace Esprima.Ast
         /// </summary>
         public readonly Expression Imported;
 
-        public ImportSpecifier(Expression local, Expression imported) : base(local, Nodes.ImportSpecifier)
+        public ImportSpecifier(Identifier local, Expression imported) : base(local, Nodes.ImportSpecifier)
         {
             Imported = imported;
         }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -4691,13 +4691,13 @@ namespace Esprima
         {
             var node = CreateNode();
 
-            Expression local;
+            Identifier local;
             Expression imported;
 
             if (_lookahead.Type == TokenType.Identifier)
             {
-                imported = ParseVariableIdentifier(allowAwaitKeyword: true);
-                local = imported;
+                imported = local = ParseVariableIdentifier(allowAwaitKeyword: true);
+
                 if (MatchContextualKeyword("as"))
                 {
                     NextToken();
@@ -4710,7 +4710,6 @@ namespace Esprima
                     ? ParseModuleSpecifier()
                     : ParseIdentifierName();
 
-                local = imported;
                 if (MatchContextualKeyword("as"))
                 {
                     NextToken();
@@ -4719,6 +4718,7 @@ namespace Esprima
                 else
                 {
                     ThrowUnexpectedToken(NextToken());
+                    local = default!; // never executes, just keeps the compilery happy
                 }
             }
 


### PR DESCRIPTION
Hi guys!

I'm happy to see that you're keeping up the good work and new JS features are getting covered one after the other! Finally I've also found some time to update my library built on Esprima, so I'm trying to catch up with the changes and additions since v2.0.3. There are quite a few... :)

Going over the logs I also found some minor issues.

One of those was introduced by https://github.com/sebastienros/esprima-dotnet/pull/217. The type of `ImportDeclarationSpecifier.Local` was changed from `Identifier` to `Expression` with [a comment](https://github.com/sebastienros/esprima-dotnet/pull/217/commits/24b12f829c6d075cf9999b3dcbb57cd1e1197ed7#diff-6a5763a6c6b7d9b5bc3d7b102ef0f2e61f4107c12e9d6a900abf2e8a77a94c9bR5) suggesting that `Local` is allowed to be a `StringLiteral` too. However this makes no sense to me. How could an import binding which is not an `Identifier` be referenced in the code? Also the [language specs](https://tc39.es/ecma262/#prod-ImportedBinding) seem to say that it's strictly an identifier.

Am I missing something here? If not, this PR addresses the anomaly.
