### PR TITLE
AstVisitor corrections

### DIFF
--- a/src/Esprima/Ast/StaticBlock.cs
+++ b/src/Esprima/Ast/StaticBlock.cs
@@ -1,16 +1,9 @@
-﻿using Esprima.Utils;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public sealed class StaticBlock : BlockStatement
     {
         public StaticBlock(in NodeList<Statement> body) : base(body, Nodes.StaticBlock)
         {
-        }
-
-        protected internal override void Accept(AstVisitor visitor)
-        {
-            visitor.VisitStaticBlock(this);
         }
     }
 }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -593,14 +593,5 @@ namespace Esprima.Utils
                 Visit(body[i]);
             }
         }
-
-        protected internal virtual void VisitStaticBlock(StaticBlock blockStatement)
-        {
-            ref readonly var body = ref blockStatement.Body;
-            for (var i = 0; i < body.Count; i++)
-            {
-                Visit(body[i]);
-            }
-        }
     }
 }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -315,6 +315,11 @@ namespace Esprima.Utils
 
         protected internal virtual void VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
         {
+            if (exportAllDeclaration.Exported is not null)
+            {
+                Visit(exportAllDeclaration.Exported);
+            }
+
             Visit(exportAllDeclaration.Source);
         }
 

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -350,7 +350,7 @@ namespace Esprima.Utils
 
         protected internal virtual void VisitImport(Import import)
         {
-            if (import.Source != null)
+            if (import.Source is not null)
             {
                 Visit(import.Source);
             }


### PR DESCRIPTION
I've found two minor issues related to `AstVisitor` in the recent commits:

1. `VisitExportAllDeclaration` was not updated by #196 to include the visitation of the new `ExportAllDeclaration.Exported` property.
2. Addition of `VisitStaticBlock` is rather questionable because it adds redundancy (at least, from the visitor's POV). `StaticBlock` is just a special case of `BlockStatement`, has no additional attributes. In such cases we (usually) haven't introduced dedicated visit methods, just left it to the base class to handle the visitation aspect. For example, in the cases of `ExpressionStatement` and `Directive` or `MemberExpression` and `StaticMemberExpression`. I think it'd be a good idea to keep up this convention.