### PR TITLE
Allow supplying match timeout to regex

### DIFF
--- a/src/Esprima/Ast/RegexValue.cs
+++ b/src/Esprima/Ast/RegexValue.cs
@@ -1,14 +1,3 @@
-﻿namespace Esprima.Ast
-{
-    public sealed class RegexValue
-    {
-        public readonly string Pattern;
-        public readonly string Flags;
+﻿namespace Esprima.Ast;
 
-        public RegexValue(string pattern, string flags)
-        {
-            Pattern = pattern;
-            Flags = flags;
-        }
-    }
-}
+public sealed record RegexValue(string Pattern, string Flags);

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -55,6 +55,11 @@
         public bool AdaptRegexp { get; set; } = true;
 
         /// <summary>
+        /// Default timeout for created regexes, defaults to 10 seconds.
+        /// </summary>
+        public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
         /// Gets or sets whether to parse script as JSX code.
         /// </summary>
         public bool Jsx { get; set; } = false;

--- a/test/Esprima.Tests/Esprima.Tests.csproj
+++ b/test/Esprima.Tests/Esprima.Tests.csproj
@@ -7,6 +7,7 @@
     <DefineConstants Condition="'$(Checked)' == true or $(Configuration) == 'Debug'">$(DefineConstants);LOCATION_ASSERTS</DefineConstants>
     <AssemblyOriginatorKeyFile>../../src/Esprima.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />

--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -190,7 +191,7 @@ namespace Esprima.Tests
         public void ShouldPreventInfiniteLoopWhenAdaptingMultiLine()
         {
             var scanner = new Scanner("", new ParserOptions { AdaptRegexp = true });
-            var regex = scanner.ParseRegex("\\$", "gm");
+            var regex = scanner.ParseRegex("\\$", "gm", TimeSpan.FromSeconds(10));
             Assert.NotNull(regex);
         }
 


### PR DESCRIPTION
Jint has to parse all regexes again as it wants to supply default timeout (10 seconds). Adding option to define (defaults to 10 seconds) and forcing API users to consider the timeout.