### PR TITLE
Update GitHubActionsTestLogger to latest preview

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,7 +25,7 @@ jobs:
       run: dotnet tool restore && dotnet test262 generate
 
     - name: Test
-      run: dotnet test --configuration Release --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --configuration Release --logger GitHubActions
 
   linux:
     runs-on: ubuntu-latest
@@ -49,4 +49,4 @@ jobs:
       run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release -- --update-allow-list
 
     - name: Test
-      run: dotnet test --configuration Release --framework net6.0 --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --configuration Release --framework net6.0 --logger GitHubActions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
       run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release -- --update-allow-list
 
     - name: Test
-      run: dotnet test --configuration Release --framework net6.0 --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --configuration Release --framework net6.0 --logger GitHubActions
 
     - name: Pack with dotnet
       run: |

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -32,7 +32,7 @@ jobs:
       run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release -- --update-allow-list
 
     - name: Test
-      run: dotnet test --configuration Release --logger "GitHubActions;report-warnings=false"
+      run: dotnet test --configuration Release --logger GitHubActions
 
     - name: Pack with dotnet
       run: dotnet pack --output artifacts --configuration Release -p:PackageVersion=3.0.0-preview-$GITHUB_RUN_NUMBER

--- a/test/Esprima.Tests.Test262/Esprima.Tests.Test262.csproj
+++ b/test/Esprima.Tests.Test262/Esprima.Tests.Test262.csproj
@@ -7,11 +7,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="GitHubActionsTestLogger" Version="1.4.1" />
-      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+      <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0-alpha" PrivateAssets="all" />
+      <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
       <PackageReference Include="NUnit" Version="3.13.3" />
       <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-      <PackageReference Include="Spectre.Console" Version="0.43.0" />
+      <PackageReference Include="Spectre.Console" Version="0.44.0" />
       <PackageReference Include="Test262Harness" Version="0.0.17" />
       <PackageReference Include="YamlDotNet" Version="11.2.1" />
     </ItemGroup>

--- a/test/Esprima.Tests/Esprima.Tests.csproj
+++ b/test/Esprima.Tests/Esprima.Tests.csproj
@@ -13,12 +13,12 @@
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="GitHubActionsTestLogger" Version="1.4.1" />
+    <PackageReference Include="GitHubActionsTestLogger" Version="2.0.0-alpha" PrivateAssets="all" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" PrivateAssets="all" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This will reduce summary size which seems to be a problem with Esprima-size output.