### PR TITLE
Treat warnings as errors in test project

### DIFF
--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -12,7 +12,7 @@
     <PackageTags>javascript, parser, ecmascript</PackageTags>
     <PackageProjectUrl>https://github.com/sebastienros/esprima-dotnet</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <Version>2.0.0-beta-$(BuildNumber)</Version>
+    <Version>3.0.0-beta-$(BuildNumber)</Version>
 
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
@@ -31,5 +31,5 @@
   <ItemGroup>
     <Using Remove="System.Net.Http" />
   </ItemGroup>
-  
+
 </Project>

--- a/test/Esprima.Tests/AstVisitorEventSourceTests.cs
+++ b/test/Esprima.Tests/AstVisitorEventSourceTests.cs
@@ -1,7 +1,5 @@
-﻿using System.Linq;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Esprima.Utils;
-using Xunit;
 
 namespace Esprima.Tests
 {
@@ -18,7 +16,7 @@ namespace Esprima.Tests
             var expression = ParseExpression<MemberExpression>("foo.bar");
 
             var visitor = new AstVisitorEventSource();
-            MemberExpression memberExpression = null;
+            MemberExpression? memberExpression = null;
             var identifiers = new System.Collections.Generic.List<Identifier>();
             visitor.VisitingMemberExpression += (_, arg) => memberExpression = arg;
             visitor.VisitedIdentifier += (_, arg) => identifiers.Add(arg);
@@ -36,9 +34,9 @@ namespace Esprima.Tests
             var expression = ParseExpression<ObjectExpression>("{ x: 42 }");
 
             var visitor = new AstVisitorEventSource();
-            Property property = null;
-            Identifier key = null;
-            Literal value = null;
+            Property? property = null;
+            Identifier? key = null;
+            Literal? value = null;
             visitor.VisitingProperty += (_, arg) => property = arg;
             visitor.VisitedIdentifier += (_, arg) => key = arg;
             visitor.VisitedLiteral += (_, arg) => value = arg;
@@ -56,8 +54,8 @@ namespace Esprima.Tests
             var expression = ParseExpression<UpdateExpression>("x++");
 
             var visitor = new AstVisitorEventSource();
-            UpdateExpression updateExpression = null;
-            Identifier argument = null;
+            UpdateExpression? updateExpression = null;
+            Identifier? argument = null;
             visitor.VisitingUnaryExpression += (_, arg) => updateExpression = (UpdateExpression) arg;
             visitor.VisitedIdentifier += (_, arg) => argument = arg;
             visitor.Visit(expression);

--- a/test/Esprima.Tests/Breaking.cs
+++ b/test/Esprima.Tests/Breaking.cs
@@ -55,7 +55,7 @@ namespace Esprima.Tests
         }
 
         public BreakingCollection(int count) :
-            this(Enumerable.Repeat(default(T), count).ToList())
+            this(Enumerable.Repeat(default(T)!, count).ToList())
         {
         }
 

--- a/test/Esprima.Tests/Esprima.Tests.csproj
+++ b/test/Esprima.Tests/Esprima.Tests.csproj
@@ -9,6 +9,8 @@
     <SignAssembly>true</SignAssembly>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Esprima\Esprima.csproj" />
@@ -21,5 +23,8 @@
     <PackageReference Include="xunit.analyzers" Version="0.10.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+  </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
   </ItemGroup>
 </Project>

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -1,12 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Reflection;
+﻿using System.Reflection;
 using Esprima.Ast;
 using Esprima.Utils;
 using Newtonsoft.Json.Linq;
-using Xunit;
 
 namespace Esprima.Test
 {
@@ -79,17 +74,18 @@ namespace Esprima.Test
 
             string treeFilePath, failureFilePath, moduleFilePath;
             var jsFilePath = Path.Combine(GetFixturesPath(), "Fixtures", fixture);
+            var jsFileDirectoryName = Path.GetDirectoryName(jsFilePath)!;
             if (jsFilePath.EndsWith(".source.js"))
             {
-                treeFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".tree.json";
-                failureFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".failure.json";
-                moduleFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".module.json";
+                treeFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".tree.json";
+                failureFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".failure.json";
+                moduleFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".module.json";
             }
             else
             {
-                treeFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(jsFilePath)) + ".tree.json";
-                failureFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(jsFilePath)) + ".failure.json";
-                moduleFilePath = Path.Combine(Path.GetDirectoryName(jsFilePath), Path.GetFileNameWithoutExtension(jsFilePath)) + ".module.json";
+                treeFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(jsFilePath)) + ".tree.json";
+                failureFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(jsFilePath)) + ".failure.json";
+                moduleFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(jsFilePath)) + ".module.json";
             }
 
             var script = File.ReadAllText(jsFilePath);
@@ -97,7 +93,7 @@ namespace Esprima.Test
             {
                 var parser = new JavaScriptParser(script);
                 var program = parser.ParseScript();
-                var source = program.Body.First().As<VariableDeclaration>().Declarations.First().As<VariableDeclarator>().Init.As<Literal>().StringValue;
+                var source = program.Body.First().As<VariableDeclaration>().Declarations.First().As<VariableDeclarator>().Init!.As<Literal>().StringValue!;
                 script = source;
             }
 
@@ -201,8 +197,8 @@ namespace Esprima.Test
             var assemblyPath = typeof(Fixtures).GetTypeInfo().Assembly.Location;
             var assemblyDirectory = new FileInfo(assemblyPath).Directory;
 #endif
-            var root = assemblyDirectory.Parent.Parent.Parent.FullName;
-            return root;
+            var root = assemblyDirectory?.Parent?.Parent?.Parent?.FullName;
+            return root ?? "";
         }
 
         [Fact]

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Linq;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Esprima.Test;
-using Xunit;
 
 namespace Esprima.Tests
 {
@@ -74,8 +71,8 @@ namespace Esprima.Tests
             var p = program.Body.First().As<FunctionDeclaration>();
             var q = p.Body.As<BlockStatement>().Body.Skip(1).First().As<FunctionDeclaration>();
 
-            Assert.Equal("p", p.Id.Name);
-            Assert.Equal("q", q.Id.Name);
+            Assert.Equal("p", p.Id?.Name);
+            Assert.Equal("q", q.Id?.Name);
 
             Assert.True(p.Strict);
             Assert.True(q.Strict);
@@ -103,7 +100,7 @@ namespace Esprima.Tests
             var literal = expression as Literal;
 
             Assert.NotNull(literal);
-            Assert.Equal(expected, literal.NumericValue);
+            Assert.Equal(expected, literal?.NumericValue);
         }
 
         [Theory]
@@ -323,7 +320,7 @@ class aa {
 
             Assert.Equal(8, variableDeclarations.Count);
         }
-        
+
         [Fact]
         public void AncestorNodesShouldHandleNullNodes()
         {
@@ -337,8 +334,8 @@ class aa {
 
             Assert.Equal(28, variableDeclarations.Count);
         }
-        
-        [Theory] 
+
+        [Theory]
         [InlineData("`a`", "a")]
         [InlineData("`a${b}`", "a", "b")]
         [InlineData("`a${b}c`", "a", "b", "c")]
@@ -355,13 +352,13 @@ class aa {
                 Assert.Equal(raw,rawFromNode);
             }
 
-            static string GetRawItem(Node item)
+            static string? GetRawItem(Node item)
             {
                 if (item is TemplateElement element)
                 {
                     return element.Value.Raw;
                 }
-                
+
                 if (item is Identifier identifier)
                 {
                     return identifier.Name;

--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using System.Text.RegularExpressions;
 using Esprima.Test;
-using Xunit;
 
 namespace Esprima.Tests
 {
@@ -21,7 +17,7 @@ namespace Esprima.Tests
         {
             var options = new ParserOptions { AdaptRegexp = true };
             var token = new Scanner(code, options).ScanRegExp();
-            return (Regex) token.Value;
+            return (Regex) token.Value!;
         }
 
         [Theory]

--- a/test/Esprima.Tests/SeparatorTests.cs
+++ b/test/Esprima.Tests/SeparatorTests.cs
@@ -9,7 +9,7 @@ namespace Esprima.Tests
         public void CanParseSeperators()
         {
             var script = new JavaScriptParser("var foo=12_3_456").ParseScript();
-            Assert.Equal(123456, (double) ((Literal) ((VariableDeclaration) script.Body[0]).Declarations[0].Init).Value);
+            Assert.Equal(123456, (double) ((Literal) ((VariableDeclaration) script.Body[0]).Declarations[0].Init!).Value!);
         }
 
         [Fact]

--- a/test/Esprima.Tests/StrictModeTests.cs
+++ b/test/Esprima.Tests/StrictModeTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Xunit;
 
 namespace Esprima.Tests
@@ -19,7 +18,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var f = function() { 'use strict'; }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var function = (FunctionExpression) variable.Declarations.First().Init;
+            var function = (FunctionExpression) variable.Declarations.First().Init!;
             Assert.True(function.Strict);
         }
 
@@ -28,7 +27,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var f = () => { 'use strict'; }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var function = (ArrowFunctionExpression) variable.Declarations.First().Init;
+            var function = (ArrowFunctionExpression) variable.Declarations.First().Init!;
             Assert.True(function.Strict);
         }
 
@@ -37,7 +36,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var obj = { method() { 'use strict'; } }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init;
+            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
             var property = (Property) objectExpression.Properties.First();
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
@@ -48,7 +47,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var obj = { async method() { 'use strict'; } }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init;
+            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
             var property = (Property) objectExpression.Properties.First();
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
@@ -59,7 +58,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var obj = { async method() { } }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init;
+            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
             var property = (Property) objectExpression.Properties.First();
             var function = (FunctionExpression) property.Value;
             Assert.False(function.Strict);
@@ -70,7 +69,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var obj = { get prop() { 'use strict'; } }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init;
+            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
             var property = (Property) objectExpression.Properties.First();
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
@@ -81,7 +80,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var obj = { set prop(val) { 'use strict'; } }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init;
+            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
             var property = (Property) objectExpression.Properties.First();
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
@@ -100,7 +99,7 @@ namespace Esprima.Tests
         {
             var script = new JavaScriptParser("var f = function*() { 'use strict'; yield 1; }").ParseScript();
             var variable = (VariableDeclaration) script.Body.First();
-            var function = (FunctionExpression) variable.Declarations.First().Init;
+            var function = (FunctionExpression) variable.Declarations.First().Init!;
             Assert.True(function.Strict);
         }
     }


### PR DESCRIPTION
Too much build output from warnings already. Making them errors and fixing them.