### PR TITLE
Update AstJson

### DIFF
--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -347,6 +347,11 @@ public class AstToJsonConverter : AstJson.IConverter
             {
                 Member("body", program.Body, e => (Node) e);
                 Member("sourceType", program.SourceType);
+
+                if (program is Script s)
+                {
+                    Member("strict", s.Strict);
+                }
             }
 
             return program;
@@ -377,6 +382,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", functionDeclaration.Body);
                 Member("generator", functionDeclaration.Generator);
                 Member("expression", functionDeclaration.Expression);
+                Member("strict", functionDeclaration.Strict);
                 Member("async", functionDeclaration.Async);
             }
 
@@ -576,6 +582,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", arrowFunctionExpression.Body);
                 Member("generator", arrowFunctionExpression.Generator);
                 Member("expression", arrowFunctionExpression.Expression);
+                Member("strict", arrowFunctionExpression.Strict);
                 Member("async", arrowFunctionExpression.Async);
             }
 
@@ -705,6 +712,16 @@ public class AstToJsonConverter : AstJson.IConverter
             return identifier;
         }
 
+        protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+        {
+            using (StartNodeObject(privateIdentifier))
+            {
+                Member("name", privateIdentifier.Name);
+            }
+
+            return privateIdentifier;
+        }
+
         protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
         {
             using (StartNodeObject(functionExpression))
@@ -714,10 +731,25 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", functionExpression.Body);
                 Member("generator", functionExpression.Generator);
                 Member("expression", functionExpression.Expression);
+                Member("strict", functionExpression.Strict);
                 Member("async", functionExpression.Async);
             }
 
             return functionExpression;
+        }
+
+        protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+        {
+            using (StartNodeObject(propertyDefinition))
+            {
+                Member("key", propertyDefinition.Key);
+                Member("computed", propertyDefinition.Computed);
+                Member("value", propertyDefinition.Value);
+                Member("kind", propertyDefinition.Kind);
+                Member("static", propertyDefinition.Static);
+            }
+
+            return propertyDefinition;
         }
 
         protected internal override object? VisitDecorator(Decorator decorator)
@@ -741,7 +773,7 @@ public class AstToJsonConverter : AstJson.IConverter
                     Member("decorators", accessorProperty.Decorators);
                 }
             }
-            
+
             return accessorProperty;
         }
 
@@ -827,6 +859,8 @@ public class AstToJsonConverter : AstJson.IConverter
         {
             using (StartNodeObject(import))
             {
+                Member("source", import.Source);
+
                 if (import.Attributes is not null)
                 {
                     Member("attributes", import.Attributes);
@@ -835,7 +869,7 @@ public class AstToJsonConverter : AstJson.IConverter
 
             return import;
         }
-        
+
         protected internal override object? VisitImportAttribute(ImportAttribute importAttribute)
         {
             using (StartNodeObject(importAttribute))

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -23,6 +23,14 @@ public static class AstJson
         public bool IncludingLineColumn { get; private set; }
         public bool IncludingRange { get; private set; }
         public LocationMembersPlacement LocationMembersPlacement { get; private set; }
+        /// <summary>
+        /// This switch is intended for enabling a compatibility mode for <see cref="AstToJsonConverter"/> to build a JSON output
+        /// which matches the format of the test fixtures of the original Esprima project.
+        /// </summary>
+        /// <remarks>
+        /// However this is just partially implemented currently because not the original fixtures are used now.
+        /// </remarks>
+        internal bool TestCompatibilityMode { get; private set; }
 
         public Options() { }
 
@@ -46,6 +54,11 @@ public static class AstJson
         public Options WithLocationMembersPlacement(LocationMembersPlacement value)
         {
             return value == LocationMembersPlacement ? this : new Options(this) { LocationMembersPlacement = value };
+        }
+
+        internal Options WithTestCompatibilityMode(bool value)
+        {
+            return value == TestCompatibilityMode ? this : new Options(this) { TestCompatibilityMode = value };
         }
     }
 
@@ -148,9 +161,7 @@ public class AstToJsonConverter : AstJson.IConverter
 
     private protected virtual VisitorBase CreateVisitor(JsonWriter writer, AstJson.Options options)
     {
-        return new Visitor(writer,
-            options.IncludingLineColumn, options.IncludingRange,
-            options.LocationMembersPlacement);
+        return new Visitor(writer, options);
     }
 
     public void WriteJson(Node node, JsonWriter writer, AstJson.Options options)
@@ -161,21 +172,29 @@ public class AstToJsonConverter : AstJson.IConverter
     private protected abstract class VisitorBase : AstVisitor
     {
         private readonly JsonWriter _writer;
+        private protected readonly bool _includeLineColumn;
+        private protected readonly bool _includeRange;
+        private protected readonly LocationMembersPlacement _locationMembersPlacement;
+        private protected readonly bool _testCompatibilityMode;
         private readonly ObservableStack<Node> _stack;
 
-        public VisitorBase(JsonWriter writer,
-            bool includeLineColumn, bool includeRange,
-            LocationMembersPlacement locationMembersPlacement)
+        public VisitorBase(JsonWriter writer, AstJson.Options options)
         {
             _writer = writer ?? ThrowArgumentNullException<JsonWriter>(nameof(writer));
+
+            _includeLineColumn = options.IncludingLineColumn;
+            _includeRange = options.IncludingRange;
+            _locationMembersPlacement = options.LocationMembersPlacement;
+            _testCompatibilityMode = options.TestCompatibilityMode;
+
             _stack = new ObservableStack<Node>();
 
             _stack.Pushed += node =>
             {
                 _writer.StartObject();
 
-                if ((includeLineColumn || includeRange)
-                    && locationMembersPlacement == LocationMembersPlacement.Start)
+                if ((_includeLineColumn || _includeRange)
+                    && _locationMembersPlacement == LocationMembersPlacement.Start)
                 {
                     WriteLocationInfo(node);
                 }
@@ -185,8 +204,8 @@ public class AstToJsonConverter : AstJson.IConverter
 
             _stack.Popped += node =>
             {
-                if ((includeLineColumn || includeRange)
-                    && locationMembersPlacement == LocationMembersPlacement.End)
+                if ((_includeLineColumn || _includeRange)
+                    && _locationMembersPlacement == LocationMembersPlacement.End)
                 {
                     WriteLocationInfo(node);
                 }
@@ -201,7 +220,7 @@ public class AstToJsonConverter : AstJson.IConverter
                     return;
                 }
 
-                if (includeRange)
+                if (_includeRange)
                 {
                     _writer.Member("range");
                     _writer.StartArray();
@@ -210,7 +229,7 @@ public class AstToJsonConverter : AstJson.IConverter
                     _writer.EndArray();
                 }
 
-                if (includeLineColumn)
+                if (_includeLineColumn)
                 {
                     _writer.Member("loc");
                     _writer.StartObject();
@@ -348,7 +367,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", program.Body, e => (Node) e);
                 Member("sourceType", program.SourceType);
 
-                if (program is Script s)
+                if (!_testCompatibilityMode && program is Script s)
                 {
                     Member("strict", s.Strict);
                 }
@@ -382,7 +401,10 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", functionDeclaration.Body);
                 Member("generator", functionDeclaration.Generator);
                 Member("expression", functionDeclaration.Expression);
-                Member("strict", functionDeclaration.Strict);
+                if (!_testCompatibilityMode)
+                {
+                    Member("strict", functionDeclaration.Strict);
+                }
                 Member("async", functionDeclaration.Async);
             }
 
@@ -582,7 +604,10 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", arrowFunctionExpression.Body);
                 Member("generator", arrowFunctionExpression.Generator);
                 Member("expression", arrowFunctionExpression.Expression);
-                Member("strict", arrowFunctionExpression.Strict);
+                if (!_testCompatibilityMode)
+                {
+                    Member("strict", arrowFunctionExpression.Strict);
+                }
                 Member("async", arrowFunctionExpression.Async);
             }
 
@@ -731,7 +756,10 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("body", functionExpression.Body);
                 Member("generator", functionExpression.Generator);
                 Member("expression", functionExpression.Expression);
-                Member("strict", functionExpression.Strict);
+                if (!_testCompatibilityMode)
+                {
+                    Member("strict", functionExpression.Strict);
+                }
                 Member("async", functionExpression.Async);
             }
 
@@ -859,11 +887,14 @@ public class AstToJsonConverter : AstJson.IConverter
         {
             using (StartNodeObject(import))
             {
-                Member("source", import.Source);
-
-                if (import.Attributes is not null)
+                if (!_testCompatibilityMode)
                 {
-                    Member("attributes", import.Attributes);
+                    Member("source", import.Source);
+
+                    if (import.Attributes is not null)
+                    {
+                        Member("attributes", import.Attributes);
+                    }
                 }
             }
 
@@ -1217,8 +1248,8 @@ public class AstToJsonConverter : AstJson.IConverter
 
     private sealed class Visitor : VisitorBase
     {
-        public Visitor(JsonWriter writer, bool includeLineColumn, bool includeRange, LocationMembersPlacement locationMembersPlacement)
-            : base(writer, includeLineColumn, includeRange, locationMembersPlacement)
+        public Visitor(JsonWriter writer, AstJson.Options options)
+            : base(writer, options)
         {
         }
     }

--- a/src/Esprima/Utils/Jsx/JsxAstJson.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstJson.cs
@@ -11,15 +11,13 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
 
     private protected override VisitorBase CreateVisitor(JsonWriter writer, AstJson.Options options)
     {
-        return new Visitor(writer,
-            options.IncludingLineColumn, options.IncludingRange,
-            options.LocationMembersPlacement);
+        return new Visitor(writer, options);
     }
 
     private sealed class Visitor : VisitorBase, IJsxAstVisitor
     {
-        public Visitor(JsonWriter writer, bool includeLineColumn, bool includeRange, LocationMembersPlacement locationMembersPlacement)
-            : base(writer, includeLineColumn, includeRange, locationMembersPlacement)
+        public Visitor(JsonWriter writer, AstJson.Options options)
+            : base(writer, options)
         {
         }
 

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -30,7 +30,8 @@ namespace Esprima.Test
             return program.ToJsonString(
                 AstJson.Options.Default
                     .WithIncludingLineColumn(true)
-                    .WithIncludingRange(true),
+                    .WithIncludingRange(true)
+                    .WithTestCompatibilityMode(true),
                 indent,
                 converter
             );

--- a/test/Esprima.Tests/Fixtures/ES2017/async/methods/async-line-terminator-method.tree.json
+++ b/test/Esprima.Tests/Fixtures/ES2017/async/methods/async-line-terminator-method.tree.json
@@ -26,8 +26,29 @@
         "type": "ClassBody",
         "body": [
           {
-            "type": "Identifier",
-            "name": "async",
+            "type": "PropertyDefinition",
+            "key": {
+              "type": "Identifier",
+              "name": "async",
+              "range": [
+                10,
+                15
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 10
+                },
+                "end": {
+                  "line": 1,
+                  "column": 15
+                }
+              }
+            },
+            "computed": false,
+            "value": null,
+            "kind": "none",
+            "static": false,
             "range": [
               10,
               15

--- a/test/Esprima.Tests/Fixtures/ES2017/async/methods/async-line-terminator-static-method.tree.json
+++ b/test/Esprima.Tests/Fixtures/ES2017/async/methods/async-line-terminator-static-method.tree.json
@@ -26,16 +26,37 @@
         "type": "ClassBody",
         "body": [
           {
-            "type": "Identifier",
-            "name": "async",
+            "type": "PropertyDefinition",
+            "key": {
+              "type": "Identifier",
+              "name": "async",
+              "range": [
+                17,
+                22
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 17
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
+              }
+            },
+            "computed": false,
+            "value": null,
+            "kind": "none",
+            "static": true,
             "range": [
-              17,
+              10,
               22
             ],
             "loc": {
               "start": {
                 "line": 1,
-                "column": 17
+                "column": 10
               },
               "end": {
                 "line": 1,


### PR DESCRIPTION
It would be nice to update `AstJson` before releasing the new major version because it's still somewhat bit rotten (missing overrides, missing handling of a few properties). I didn't touch this as part of https://github.com/sebastienros/esprima-dotnet/pull/253 because it would result in a ton of failed tests. Any idea how to approach this?