### PR TITLE
Minor build-related improvements

### DIFF
--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -23,13 +23,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="IsExternalInit" Version="1.0.2" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition=" '$(TargetFramework)' != 'netstandard2.1'" />
   </ItemGroup>
 
   <ItemGroup>
     <Using Remove="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Shared\Compatibility\IsExternalInit.cs" Link="Compatibility\IsExternalInit.cs" />
   </ItemGroup>
 
 </Project>

--- a/src/Shared/Compatibility/IsExternalInit.cs
+++ b/src/Shared/Compatibility/IsExternalInit.cs
@@ -1,0 +1,22 @@
+﻿#if !NET5_0_OR_GREATER
+
+// Source: https://github.com/dotnet/runtime/blob/v6.0.5/src/libraries/Common/src/System/Runtime/CompilerServices/IsExternalInit.cs
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices
+{
+    /// <summary>
+    /// Reserved to be used by the compiler for tracking metadata.
+    /// This class should not be used by developers in source code.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    internal static class IsExternalInit
+    {
+    }
+}
+
+#endif

--- a/test/Esprima.Tests.Test262/Esprima.Tests.Test262.csproj
+++ b/test/Esprima.Tests.Test262/Esprima.Tests.Test262.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <GenerateProgramFile>false</GenerateProgramFile>
+        <GeneratedTestSuiteDir>$(MSBuildThisFileDirectory)Generated</GeneratedTestSuiteDir>
     </PropertyGroup>
 
     <ItemGroup>
@@ -27,5 +28,17 @@
     <ItemGroup>
       <Content Include=".config\dotnet-tools.json" />
     </ItemGroup>
+
+    <!-- Based on the idea presented at https://mhut.ch/journal/2015/06/30/build-time-code-generation-in-msbuild -->
+    <Target Name="GenerateTestSuite" DependsOnTargets="_GenerateTestSuite" BeforeTargets="BeforeBuild;BeforeRebuild" Condition="!Exists($(GeneratedTestSuiteDir))">
+      <ItemGroup>
+        <Compile Include="$(GeneratedTestSuiteDir)\**\*.cs" />
+      </ItemGroup>
+    </Target>
+
+    <Target Name="_GenerateTestSuite">
+      <Exec Command="dotnet tool restore" />
+      <Exec Command="dotnet test262 generate" />
+    </Target>
 
 </Project>


### PR DESCRIPTION
This PR is a suggestion on getting rid of a few build-related issues (or, rather, some weirdness which I consider issues).

1. ~~Targeting `net462` looks redundant to me, I see no .NET Framework-specific things in the code. As [shown in this table](https://docs.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version), .NET Framework already implements .NET Standard 2.0 since version 4.6.1 (see also [this SO answer](https://stackoverflow.com/questions/46539591/can-i-use-a-net-standard-2-0-package-in-a-classic-net-4-6-1-application)). Tests run fine on .NET Framework after removing the `net462` target framework. Am I missing here something maybe?~~
2. I have an annoying issue with building the project: rebuilding fails with "CS0518 Predefined type 'System.Runtime.CompilerServices.IsExternalInit' is not defined or imported" errors. Build works but interestingly rebuild doesn't. (I'm on the latest VS 2022). The issue is apparently boils down to the referenced `IsExternalInit` package. I haven't dug deeper though because I think that reference is a bad idea anyway.
   The disaster of [`left-pad`, `event-stream` & co.](https://javascript.plainenglish.io/the-biggest-scandals-of-npm-d739c11a2406) taught me to be careful with 3rd party dependencies: I believe 3rd party packages should be used only when it's well-justified. A package adding a single tiny class is far from that IMHO. So I suggest dropping this dependency and adding that class "manually". [It can be done elegantly using `Directory.Build.props`](https://github.com/sebastienros/esprima-dotnet/commit/0b07db7c6a606defbea8c3abe5af6a30f54e0906#diff-5c1900dca99df01c3ddc3a884282164b04deee76e79b176e2d34cfa47f3b8907R25). This method will be also beneficial if we want to add other shims, for e.g. [null-state code analysis annotations](https://www.meziantou.net/how-to-use-nullable-reference-types-in-dotnet-standard-2-0-and-dotnet-.htm). (Unless there's some NuGet packages for those as well... :D)

There's a third one but I haven't touch this because I'm not sure about it: I can't build the `Esprima.Tests.Test262` project, it compiles with the following errors:
* CS0759	No defining declaration found for implementing declaration of partial method 'TestHarness.InitializeCustomState()'
* CS0759	No defining declaration found for implementing declaration of partial method 'Test262Test.ShouldThrow(Test262File, bool)'

As I see, this is @lahma's domain. What may go wrong here?