### PR TITLE
Fix bug in UpdateWith methods

### DIFF
--- a/src/Esprima/Ast/AccessorProperty.cs
+++ b/src/Esprima/Ast/AccessorProperty.cs
@@ -36,7 +36,7 @@ public sealed class AccessorProperty : Node
             return this;
         }
 
-        return new AccessorProperty(key, value, Computed, Static, decorators);
+        return new AccessorProperty(key, value, Computed, Static, decorators).SetAdditionalInfo(this);
     }
 
     private IEnumerable<Node> CreateChildNodes()

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ArrayExpression(elements);
+            return new ArrayExpression(elements).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ArrayPattern(elements);
+            return new ArrayPattern(elements).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -46,7 +46,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ArrowFunctionExpression(parameters, body, Expression, Strict, Async);
+            return new ArrowFunctionExpression(parameters, body, Expression, Strict, Async).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -38,7 +38,7 @@ namespace Esprima.Ast
             this(ParseAssignmentOperator(op), left, right)
         {
         }
-        
+
         internal AssignmentExpression(
             AssignmentOperator op,
             Expression left,
@@ -89,7 +89,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new AssignmentExpression(Operator, left, right);
+            return new AssignmentExpression(Operator, left, right).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new AssignmentPattern(left, right);
+            return new AssignmentPattern(left, right).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new AwaitExpression(argument);
+            return new AwaitExpression(argument).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -98,7 +98,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new BinaryExpression(Operator, left, right);
+            return new BinaryExpression(Operator, left, right).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -37,7 +37,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return Rewrite(body);
+            return Rewrite(body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new BreakStatement(label);
+            return new BreakStatement(label).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -35,7 +35,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new CallExpression(callee, arguments, Optional);
+            return new CallExpression(callee, arguments, Optional).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -28,7 +28,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new CatchClause(param, body);
+            return new CatchClause(param, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -28,7 +28,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ChainExpression(expression);
+            return new ChainExpression(expression).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -30,7 +30,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ClassBody(body);
+            return new ClassBody(body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -35,16 +35,16 @@ namespace Esprima.Ast
             return visitor.VisitClassDeclaration(this);
         }
 
-        public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body,  in NodeList<Decorator> decorators)
+        public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
         {
             if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
             {
                 return this;
             }
 
-            return new ClassDeclaration(id, superClass, body, decorators);
+            return new ClassDeclaration(id, superClass, body, decorators).SetAdditionalInfo(this);
         }
-        
+
         private IEnumerable<Node> CreateChildNodes()
         {
             if (Id is not null)

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -42,7 +42,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ClassExpression(id, superClass, body, Decorators);
+            return new ClassExpression(id, superClass, body, Decorators).SetAdditionalInfo(this);
         }
 
         private IEnumerable<Node> CreateChildNodes()

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -32,7 +32,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ConditionalExpression(test, consequent, alternate);
+            return new ConditionalExpression(test, consequent, alternate).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ContinueStatement(label);
+            return new ContinueStatement(label).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/Decorator.cs
+++ b/src/Esprima/Ast/Decorator.cs
@@ -25,6 +25,6 @@ public sealed class Decorator : Node
             return this;
         }
 
-        return new Decorator(expression);
+        return new Decorator(expression).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new DoWhileStatement(body, test);
+            return new DoWhileStatement(body, test).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -10,7 +10,7 @@ namespace Esprima.Ast
         /// <see cref="Identifier" /> | StringLiteral <see cref="Literal" />
         /// </summary>
         public readonly Expression? Exported;
-        
+
         public readonly NodeList<ImportAttribute> Assertions;
 
         public ExportAllDeclaration(Literal source) : this(source, null, new NodeList<ImportAttribute>())
@@ -38,18 +38,18 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ExportAllDeclaration(source, exported, assertions);
+            return new ExportAllDeclaration(source, exported, assertions).SetAdditionalInfo(this);
         }
-        
+
         private IEnumerable<Node> CreateChildNodes()
         {
             yield return Source;
-            
+
             if (Exported is not null)
             {
                 yield return Exported;
             }
-            
+
             foreach (var assertion in Assertions)
             {
                 yield return assertion;

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ExportDefaultDeclaration(declaration);
+            return new ExportDefaultDeclaration(declaration).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -9,7 +9,7 @@ namespace Esprima.Ast
         public readonly StatementListItem? Declaration;
         public readonly Literal? Source;
         public readonly NodeList<ImportAttribute> Assertions;
-        
+
         public ExportNamedDeclaration(
             StatementListItem? declaration,
             in NodeList<ExportSpecifier> specifiers,
@@ -39,24 +39,26 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ExportNamedDeclaration(declaration, specifiers, source, assertions);
+            return new ExportNamedDeclaration(declaration, specifiers, source, assertions).SetAdditionalInfo(this);
         }
-                
+
         private IEnumerable<Node> CreateChildNodes()
         {
-            if(Declaration is not null){
+            if (Declaration is not null)
+            {
                 yield return Declaration;
             }
-            
+
             foreach (var node in _specifiers)
             {
                 yield return node;
             }
 
-            if(Source is not null){
+            if (Source is not null)
+            {
                 yield return Source;
             }
-            
+
             foreach (var node in Assertions)
             {
                 yield return node;

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -34,7 +34,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ExportSpecifier(local, exported);
+            return new ExportSpecifier(local, exported).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -30,7 +30,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return Rewrite(expression);
+            return Rewrite(expression).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -32,7 +32,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ForInStatement(left, right, body);
+            return new ForInStatement(left, right, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -35,7 +35,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ForOfStatement(left, right, body, Await);
+            return new ForOfStatement(left, right, body, Await).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -37,7 +37,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ForStatement(init, test, update, body);
+            return new ForStatement(init, test, update, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -48,7 +48,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new FunctionDeclaration(id, parameters, body, Generator, Strict, Async);
+            return new FunctionDeclaration(id, parameters, body, Generator, Strict, Async).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -46,7 +46,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new FunctionExpression(id, parameters, body, Generator, Strict, Async);
+            return new FunctionExpression(id, parameters, body, Generator, Strict, Async).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -33,7 +33,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new IfStatement(test, consequent, alternate);
+            return new IfStatement(test, consequent, alternate).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/Import.cs
+++ b/src/Esprima/Ast/Import.cs
@@ -31,7 +31,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new Import(source, attributes);
+            return new Import(source, attributes).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ImportAttribute.cs
+++ b/src/Esprima/Ast/ImportAttribute.cs
@@ -9,7 +9,7 @@ public sealed class ImportAttribute : Node
     /// </summary>
     public readonly Expression Key;
     public readonly Literal Value;
-    
+
     public ImportAttribute(Expression key, Literal value) : base(Nodes.ImportAttribute)
     {
         Key = key;
@@ -22,7 +22,7 @@ public sealed class ImportAttribute : Node
     {
         return visitor.VisitImportAttribute(this);
     }
-    
+
     public ImportAttribute UpdateWith(Expression key, Literal value)
     {
         if (key == Key && value == Value)
@@ -30,6 +30,6 @@ public sealed class ImportAttribute : Node
             return this;
         }
 
-        return new ImportAttribute(key, value);
+        return new ImportAttribute(key, value).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -36,9 +36,9 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ImportDeclaration(specifiers, source, assertions);
+            return new ImportDeclaration(specifiers, source, assertions).SetAdditionalInfo(this);
         }
-        
+
         private IEnumerable<Node> CreateChildNodes()
         {
             foreach (var node in _specifiers)
@@ -47,7 +47,7 @@ namespace Esprima.Ast
             }
 
             yield return Source;
-            
+
             foreach (var node in Assertions)
             {
                 yield return node;

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -22,7 +22,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ImportDefaultSpecifier(local);
+            return new ImportDefaultSpecifier(local).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -22,7 +22,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ImportNamespaceSpecifier(local);
+            return new ImportNamespaceSpecifier(local).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -28,7 +28,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ImportSpecifier(local, imported);
+            return new ImportSpecifier(local, imported).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxAttribute.cs
@@ -27,6 +27,6 @@ public sealed class JsxAttribute : JsxExpression
             return this;
         }
 
-        return new JsxAttribute(name, value);
+        return new JsxAttribute(name, value).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxClosingElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxClosingElement.cs
@@ -25,6 +25,6 @@ public sealed class JsxClosingElement : JsxExpression
             return this;
         }
 
-        return new JsxClosingElement(name);
+        return new JsxClosingElement(name).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -31,6 +31,6 @@ public sealed class JsxElement : JsxExpression
             return this;
         }
 
-        return new JsxElement(openingElement, children, closingElement);
+        return new JsxElement(openingElement, children, closingElement).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
@@ -25,6 +25,6 @@ public sealed class JsxExpressionContainer : JsxExpression
             return this;
         }
 
-        return new JsxExpressionContainer(expression);
+        return new JsxExpressionContainer(expression).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
@@ -27,6 +27,6 @@ public sealed class JsxMemberExpression : JsxExpression
             return this;
         }
 
-        return new JsxMemberExpression(obj, property);
+        return new JsxMemberExpression(obj, property).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
+++ b/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
@@ -29,6 +29,6 @@ public sealed class JsxNamespacedName : JsxExpression
             return this;
         }
 
-        return new JsxNamespacedName(@namespace, name);
+        return new JsxNamespacedName(@namespace, name).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
@@ -31,6 +31,6 @@ public sealed class JsxOpeningElement : JsxExpression
             return this;
         }
 
-        return new JsxOpeningElement(name, SelfClosing, attributes);
+        return new JsxOpeningElement(name, SelfClosing, attributes).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
@@ -25,6 +25,6 @@ public sealed class JsxSpreadAttribute : JsxExpression
             return this;
         }
 
-        return new JsxSpreadAttribute(argument);
+        return new JsxSpreadAttribute(argument).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -28,7 +28,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new LabeledStatement(label, body);
+            return new LabeledStatement(label, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -36,7 +36,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return Rewrite(obj, property);
+            return Rewrite(obj, property).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new MetaProperty(meta, property);
+            return new MetaProperty(meta, property).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -36,7 +36,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new MethodDefinition(key, Computed, value, Kind, Static, decorators);
+            return new MethodDefinition(key, Computed, value, Kind, Static, decorators).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -32,7 +32,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new NewExpression(callee, arguments);
+            return new NewExpression(callee, arguments).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/NodeExtensions.cs
+++ b/src/Esprima/Ast/NodeExtensions.cs
@@ -98,5 +98,19 @@ namespace Esprima.Ast
                 return false;
             }
         }
+
+        internal static T SetAdditionalInfo<T>(this T node, Node sourceNode) where T : Node
+        {
+            node.Location = sourceNode.Location;
+            node.Range = sourceNode.Range;
+            return node;
+        }
+
+        internal static T SetAdditionalInfo<T>(this T node, Statement sourceNode) where T : Statement
+        {
+            node.LabelSet = sourceNode.LabelSet;
+            node.SetAdditionalInfo((Node) sourceNode);
+            return node;
+        }
     }
 }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ObjectExpression(properties);
+            return new ObjectExpression(properties).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ObjectPattern(properties);
+            return new ObjectPattern(properties).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -26,7 +26,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return Rewrite(body);
+            return Rewrite(body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -36,7 +36,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new Property(Kind, key, Computed, value, Method, Shorthand);
+            return new Property(Kind, key, Computed, value, Method, Shorthand).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -35,7 +35,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new PropertyDefinition(key, Computed, value, Static, decorators);
+            return new PropertyDefinition(key, Computed, value, Static, decorators).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -29,7 +29,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new RestElement(argument);
+            return new RestElement(argument).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ReturnStatement(argument);
+            return new ReturnStatement(argument).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -32,7 +32,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new SequenceExpression(expressions);
+            return new SequenceExpression(expressions).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new SpreadElement(argument);
+            return new SpreadElement(argument).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -29,7 +29,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new SwitchCase(test, consequent);
+            return new SwitchCase(test, consequent).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -30,7 +30,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new SwitchStatement(discriminant, cases);
+            return new SwitchStatement(discriminant, cases).SetAdditionalInfo(this);
         }
 
     }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new TaggedTemplateExpression(tag, quasi);
+            return new TaggedTemplateExpression(tag, quasi).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -33,7 +33,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new TemplateLiteral(quasis, expressions);
+            return new TemplateLiteral(quasis, expressions).SetAdditionalInfo(this);
         }
 
         private IEnumerable<Node> CreateChildNodes()

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ThrowStatement(argument);
+            return new ThrowStatement(argument).SetAdditionalInfo(this);
         }
 
     }

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -33,7 +33,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new TryStatement(block, handler, finalizer);
+            return new TryStatement(block, handler, finalizer).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -77,7 +77,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return Rewrite(argument);
+            return Rewrite(argument).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -32,7 +32,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new VariableDeclaration(declarations, Kind);
+            return new VariableDeclaration(declarations, Kind).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -28,7 +28,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new VariableDeclarator(id, init);
+            return new VariableDeclarator(id, init).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new WhileStatement(test, body);
+            return new WhileStatement(test, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new WithStatement(obj, body);
+            return new WithStatement(obj, body).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -27,7 +27,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new YieldExpression(argument, Delegate);
+            return new YieldExpression(argument, Delegate).SetAdditionalInfo(this);
         }
     }
 }


### PR DESCRIPTION
Some general properties like `Location`, `Range`, etc. were not copied in the `UpdateWith` methods. This PR fixes this.