### PR TITLE
Change fields to properties in AST public API

### DIFF
--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -3,7 +3,8 @@
     <AssemblyName>Esprima.Benchmark</AssemblyName>
     <OutputType>Exe</OutputType>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net462;netcoreapp3.1;net6.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\test\Esprima.Tests\Fixtures\3rdparty\**" CopyToOutputDirectory="PreserveNewest" LinkBase="3rdparty" />

--- a/samples/Esprima.Benchmark/VisitorBenchmark.cs
+++ b/samples/Esprima.Benchmark/VisitorBenchmark.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using Esprima.Utils;
+
+namespace Esprima.Benchmark
+{
+    [MemoryDiagnoser]
+    [RankColumn]
+    [CsvExporter]
+    [MarkdownExporterAttribute.GitHub]
+    public class VisitorBenchmark
+    {
+        private const string FileName = "bundle";
+
+        private Ast.Program _ast;
+        private AstVisitor _visitor;
+        private AstRewriter _rewriter;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            var filePath = Path.Combine(AppContext.BaseDirectory, "3rdparty", $"{FileName}.js");
+            var code = File.ReadAllText(filePath);
+            _ast = new JavaScriptParser(code).ParseScript();
+
+            _visitor = new AstVisitor();
+            _rewriter = new AstRewriter();
+        }
+
+        [Benchmark]
+        public object Visit()
+        {
+            return _visitor.Visit(_ast);
+        }
+
+        [Benchmark]
+        public object Rewrite()
+        {
+            return _rewriter.Visit(_ast);
+        }
+    }
+}

--- a/src/Esprima/Ast/AccessorProperty.cs
+++ b/src/Esprima/Ast/AccessorProperty.cs
@@ -1,17 +1,11 @@
+using System.Runtime.CompilerServices;
 using Esprima.Utils;
 
 namespace Esprima.Ast;
 
 public sealed class AccessorProperty : Node
 {
-    /// <summary>
-    /// <see cref="Expression" /> | <see cref="PrivateIdentifier" />
-    /// </summary>
-    public readonly Expression Key;
-    public readonly Expression? Value;
-    public readonly bool Computed;
-    public readonly bool Static;
-    public readonly NodeList<Decorator> Decorators;
+    private readonly NodeList<Decorator> _decorators;
 
     public AccessorProperty(Expression key, Expression? value, bool computed, bool isStatic, in NodeList<Decorator> decorators) : base(Nodes.AccessorProperty)
     {
@@ -19,8 +13,17 @@ public sealed class AccessorProperty : Node
         Value = value;
         Computed = computed;
         Static = isStatic;
-        Decorators = decorators;
+        _decorators = decorators;
     }
+
+    /// <remarks>
+    /// <see cref="Expression" /> | <see cref="PrivateIdentifier" />
+    /// </remarks>
+    public Expression Key { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public bool Computed { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
     public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -11,9 +12,9 @@ namespace Esprima.Ast
             _elements = elements;
         }
 
-        public ref readonly NodeList<Expression?> Elements => ref _elements;
+        public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(_elements!);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(Elements!);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -11,9 +12,9 @@ namespace Esprima.Ast
             _elements = elements;
         }
 
-        public ref readonly NodeList<Expression?> Elements => ref _elements;
+        public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(_elements!);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(Elements!);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -14,23 +15,23 @@ namespace Esprima.Ast
             bool async)
             : base(Nodes.ArrowFunctionExpression)
         {
-            Id = null;
             _params = parameters;
             Body = body;
-            Generator = false;
             Expression = expression;
             Strict = strict;
             Async = async;
         }
 
-        public Identifier? Id { get; }
-        public Node Body { get; } // : BlockStatement | Expression;
-        public bool Generator { get; }
-        public bool Expression { get; }
-        public bool Strict { get; }
-        public bool Async { get; }
-
-        public ref readonly NodeList<Expression> Params => ref _params;
+        Identifier? IFunction.Id => null;
+        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
+        /// <remarks>
+        /// <see cref="BlockStatement" /> | <see cref="Ast.Expression" />
+        /// </remarks>
+        public Node Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        bool IFunction.Generator => false;
+        public bool Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params, Body);
 

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -17,11 +18,10 @@ namespace Esprima.Ast
             _params = parameters;
         }
 
-        public ref readonly NodeList<Expression> Params => ref _params;
+        public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
 
-        public bool Async { get; }
-
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_params);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
@@ -25,12 +26,6 @@ namespace Esprima.Ast
 
     public sealed class AssignmentExpression : Expression
     {
-        public readonly AssignmentOperator Operator;
-
-        // Can be something else than Expression (ObjectPattern, ArrayPattern) in case of destructuring assignment
-        public readonly Expression Left;
-        public readonly Expression Right;
-
         public AssignmentExpression(
             string op,
             Expression left,
@@ -39,7 +34,7 @@ namespace Esprima.Ast
         {
         }
 
-        internal AssignmentExpression(
+        public AssignmentExpression(
             AssignmentOperator op,
             Expression left,
             Expression right) :
@@ -49,7 +44,6 @@ namespace Esprima.Ast
             Left = left;
             Right = right;
         }
-
 
         public static AssignmentOperator ParseAssignmentOperator(string op)
         {
@@ -74,6 +68,13 @@ namespace Esprima.Ast
                 _ => ThrowArgumentOutOfRangeException<AssignmentOperator>(nameof(op), "Invalid assignment operator: " + op)
             };
         }
+
+        public AssignmentOperator Operator { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <remarks>
+        /// Can be something else than Expression (<see cref="ObjectPattern"/>, <see cref="ArrayPattern"/>) in case of destructuring assignment
+        /// </remarks>
+        public Expression Left { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Left, Right);
 

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -1,17 +1,20 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class AssignmentPattern : Expression
     {
-        public readonly Expression Left;
-        public Expression Right;
+        internal Expression _right;
 
         public AssignmentPattern(Expression left, Expression right) : base(Nodes.AssignmentPattern)
         {
             Left = left;
-            Right = right;
+            _right = right;
         }
+
+        public Expression Left { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _right; }
 
         public override NodeCollection ChildNodes => new(Left, Right);
 

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class AwaitExpression : Expression
     {
-        public readonly Expression Argument;
-
         public AwaitExpression(Expression argument) : base(Nodes.AwaitExpression)
         {
             Argument = argument;
         }
+
+        public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/BigIntLiteral.cs
+++ b/src/Esprima/Ast/BigIntLiteral.cs
@@ -1,16 +1,16 @@
 ﻿using System.Numerics;
+using System.Runtime.CompilerServices;
 
 namespace Esprima.Ast
 {
     public sealed class BigIntLiteral : Literal
     {
-        public readonly string BigInt;
-
-        public new BigInteger? BigIntValue => (BigInteger?) Value;
-
         public BigIntLiteral(BigInteger value, string raw) : base(TokenType.BigIntLiteral, value, raw)
         {
-            BigInt = raw;
         }
+
+        public string BigInt { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Raw; }
+
+        public new BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => (BigInteger?) Value; }
     }
 }

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
@@ -34,16 +35,12 @@ namespace Esprima.Ast
 
     public sealed class BinaryExpression : Expression
     {
-        public readonly BinaryOperator Operator;
-        public readonly Expression Left;
-        public readonly Expression Right;
-
         public BinaryExpression(string op, Expression left, Expression right) :
             this(ParseBinaryOperator(op), left, right)
         {
         }
 
-        internal BinaryExpression(BinaryOperator op, Expression left, Expression right) :
+        public BinaryExpression(BinaryOperator op, Expression left, Expression right) :
             base(op == BinaryOperator.LogicalAnd || op == BinaryOperator.LogicalOr || op == BinaryOperator.NullishCoalescing ? Nodes.LogicalExpression : Nodes.BinaryExpression)
         {
             Operator = op;
@@ -83,6 +80,10 @@ namespace Esprima.Ast
                 _ => ThrowArgumentOutOfRangeException<BinaryOperator>(nameof(op), "Invalid binary operator: " + op)
             };
         }
+
+        public BinaryOperator Operator { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Left { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Left, Right);
 

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -16,9 +17,9 @@ namespace Esprima.Ast
             _body = body;
         }
 
-        public ref readonly NodeList<Statement> Body => ref _body;
+        public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
-        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
+        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
         protected internal sealed override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class BreakStatement : Statement
     {
-        public readonly Identifier? Label;
-
         public BreakStatement(Identifier? label) : base(Nodes.BreakStatement)
         {
             Label = label;
         }
+
+        public Identifier? Label { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Label);
 

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -1,13 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class CallExpression : Expression
     {
         private readonly NodeList<Expression> _arguments;
-
-        public readonly Expression Callee;
-        public readonly bool Optional;
 
         public CallExpression(
             Expression callee,
@@ -19,9 +17,11 @@ namespace Esprima.Ast
             Optional = optional;
         }
 
-        public ref readonly NodeList<Expression> Arguments => ref _arguments;
+        public Expression Callee { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _arguments; }
+        public bool Optional { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, _arguments);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -1,18 +1,22 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class CatchClause : Statement
     {
-        public readonly Expression? Param; // BindingIdentifier | BindingPattern | null;
-        public readonly BlockStatement Body;
-
         public CatchClause(Expression? param, BlockStatement body) :
             base(Nodes.CatchClause)
         {
             Param = param;
             Body = body;
         }
+
+        /// <remarks>
+        /// BindingIdentifier | <see cref="BindingPattern"/> | <see langword="null"/>
+        /// </remarks>
+        public Expression? Param { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Param, Body);
 

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -1,18 +1,19 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ChainExpression : Expression
     {
-        /// <summary>
-        /// <see cref="CallExpression" /> | <see cref="ComputedMemberExpression" />| <see cref="StaticMemberExpression" />
-        /// </summary>
-        public readonly Expression Expression;
-
         public ChainExpression(Expression expression) : base(Nodes.ChainExpression)
         {
             Expression = expression;
         }
+
+        /// <remarks>
+        /// <see cref="CallExpression" /> | <see cref="ComputedMemberExpression" />| <see cref="StaticMemberExpression" />
+        /// </remarks>
+        public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -11,12 +12,12 @@ namespace Esprima.Ast
             _body = body;
         }
 
-        /// <summary>
+        /// <remarks>
         /// <see cref="MethodDefinition" /> | <see cref="PropertyDefinition" /> | <see cref="StaticBlock" /> | <see cref="AccessorProperty" />
-        /// </summary>
-        public ref readonly NodeList<Node> Body => ref _body;
+        /// </remarks>
+        public ref readonly NodeList<Node> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -1,23 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ClassDeclaration : Declaration, IClass
     {
-        public readonly Identifier? Id;
-        Identifier? IClass.Id => Id;
-
-        /// <summary>
-        /// <see cref="Identifier" /> | <see cref="CallExpression" />
-        /// </summary>
-        public readonly Expression? SuperClass;
-        Expression? IClass.SuperClass => SuperClass;
-
-        public readonly ClassBody Body;
-        ClassBody IClass.Body => Body;
-
-        public readonly NodeList<Decorator> Decorators;
-        NodeList<Decorator> IClass.Decorators => Decorators;
+        private readonly NodeList<Decorator> _decorators;
 
         public ClassDeclaration(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators) :
             base(Nodes.ClassDeclaration)
@@ -25,8 +13,16 @@ namespace Esprima.Ast
             Id = id;
             SuperClass = superClass;
             Body = body;
-            Decorators = decorators;
+            _decorators = decorators;
         }
+
+        public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <remarks>
+        /// <see cref="Identifier" /> | <see cref="CallExpression" />
+        /// </remarks>
+        public Expression? SuperClass { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ClassBody Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 

--- a/src/Esprima/Ast/ClassElement.cs
+++ b/src/Esprima/Ast/ClassElement.cs
@@ -1,15 +1,9 @@
-﻿namespace Esprima.Ast
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast
 {
     public abstract class ClassProperty : Expression
     {
-        public readonly PropertyKind Kind;
-
-        public readonly Expression Key; // Identifier, Literal, '[' Expression ']'
-        public readonly bool Computed;
-
-        public Expression? Value => GetValue();
-        protected abstract Expression? GetValue();
-
         protected ClassProperty(Nodes type, PropertyKind kind, Expression key, bool computed) : base(type)
         {
             Kind = kind;
@@ -17,6 +11,13 @@
             Computed = computed;
         }
 
-        public override NodeCollection ChildNodes => new(Key, Value);
+        public PropertyKind Kind { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Key { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }  // Identifier, Literal, '[' Expression ']'
+        public bool Computed { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+        public Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => GetValue(); }
+        protected abstract Expression? GetValue();
+
+        public override NodeCollection ChildNodes => new(Key, GetValue());
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -1,20 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ClassExpression : Expression, IClass
     {
-        public readonly Identifier? Id;
-        Identifier? IClass.Id => Id;
-
-        public readonly Expression? SuperClass;
-        Expression? IClass.SuperClass => SuperClass;
-
-        public readonly ClassBody Body;
-        ClassBody IClass.Body => Body;
-
-        public readonly NodeList<Decorator> Decorators;
-        NodeList<Decorator> IClass.Decorators => Decorators;
+        private readonly NodeList<Decorator> _decorators;
 
         public ClassExpression(
             Identifier? id,
@@ -25,8 +16,16 @@ namespace Esprima.Ast
             Id = id;
             SuperClass = superClass;
             Body = body;
-            Decorators = decorators;
+            _decorators = decorators;
         }
+
+        public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <remarks>
+        /// <see cref="Identifier" /> | <see cref="CallExpression" />
+        /// </remarks>
+        public Expression? SuperClass { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ClassBody Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -42,7 +41,7 @@ namespace Esprima.Ast
                 return this;
             }
 
-            return new ClassExpression(id, superClass, body, Decorators).SetAdditionalInfo(this);
+            return new ClassExpression(id, superClass, body, decorators).SetAdditionalInfo(this);
         }
 
         private IEnumerable<Node> CreateChildNodes()

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -1,13 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ConditionalExpression : Expression
     {
-        public readonly Expression Test;
-        public readonly Expression Consequent;
-        public readonly Expression Alternate;
-
         public ConditionalExpression(
             Expression test,
             Expression consequent,
@@ -17,6 +14,10 @@ namespace Esprima.Ast
             Consequent = consequent;
             Alternate = alternate;
         }
+
+        public Expression Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Alternate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Test, Consequent, Alternate);
 

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ContinueStatement : Statement
     {
-        public readonly Identifier? Label;
-
         public ContinueStatement(Identifier? label) : base(Nodes.ContinueStatement)
         {
             Label = label;
         }
+
+        public Identifier? Label { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Label);
 

--- a/src/Esprima/Ast/Decorator.cs
+++ b/src/Esprima/Ast/Decorator.cs
@@ -1,15 +1,16 @@
+using System.Runtime.CompilerServices;
 using Esprima.Utils;
 
 namespace Esprima.Ast;
 
 public sealed class Decorator : Node
 {
-    public readonly Expression Expression;
-
     public Decorator(Expression expression) : base(Nodes.Decorator)
     {
         Expression = expression;
     }
+
+    public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Expression);
 

--- a/src/Esprima/Ast/Directive.cs
+++ b/src/Esprima/Ast/Directive.cs
@@ -1,13 +1,15 @@
-﻿namespace Esprima.Ast
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast
 {
     public sealed class Directive : ExpressionStatement
     {
-        public readonly string Directiv;
-
         public Directive(Expression expression, string directive) : base(expression)
         {
             Directiv = directive;
         }
+
+        public string Directiv { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         protected override ExpressionStatement Rewrite(Expression expression)
         {

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class DoWhileStatement : Statement
     {
-        public readonly Statement Body;
-        public readonly Expression Test;
-
         public DoWhileStatement(Statement body, Expression test) : base(Nodes.DoWhileStatement)
         {
             Body = body;
             Test = test;
         }
+
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Body, Test);
 

--- a/src/Esprima/Ast/EmptyStatement.cs
+++ b/src/Esprima/Ast/EmptyStatement.cs
@@ -9,7 +9,7 @@ namespace Esprima.Ast
         }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
-        
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitEmptyStatement(this);

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -1,17 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ExportAllDeclaration : ExportDeclaration
     {
-        public readonly Literal Source;
-
-        /// <summary>
-        /// <see cref="Identifier" /> | StringLiteral <see cref="Literal" />
-        /// </summary>
-        public readonly Expression? Exported;
-
-        public readonly NodeList<ImportAttribute> Assertions;
+        private readonly NodeList<ImportAttribute> _assertions;
 
         public ExportAllDeclaration(Literal source) : this(source, null, new NodeList<ImportAttribute>())
         {
@@ -21,8 +15,15 @@ namespace Esprima.Ast
         {
             Source = source;
             Exported = exported;
-            Assertions = assertions;
+            _assertions = assertions;
         }
+
+        public Literal Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <remarks>
+        /// <see cref="Identifier" /> | StringLiteral (<see cref="Literal" />)
+        /// </remarks>
+        public Expression? Exported { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -1,15 +1,19 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ExportDefaultDeclaration : ExportDeclaration
     {
-        public readonly StatementListItem Declaration; //: BindingIdentifier | BindingPattern | ClassDeclaration | Expression | FunctionDeclaration;
-
         public ExportDefaultDeclaration(StatementListItem declaration) : base(Nodes.ExportDefaultDeclaration)
         {
             Declaration = declaration;
         }
+
+        /// <remarks>
+        /// BindingIdentifier | <see cref="BindingPattern" /> | <see cref="ClassDeclaration" /> | <see cref="Expression" /> | <see cref="FunctionDeclaration" />
+        /// </remarks>
+        public StatementListItem Declaration { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Declaration);
 

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -1,14 +1,12 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ExportNamedDeclaration : ExportDeclaration
     {
         private readonly NodeList<ExportSpecifier> _specifiers;
-
-        public readonly StatementListItem? Declaration;
-        public readonly Literal? Source;
-        public readonly NodeList<ImportAttribute> Assertions;
+        private readonly NodeList<ImportAttribute> _assertions;
 
         public ExportNamedDeclaration(
             StatementListItem? declaration,
@@ -20,10 +18,13 @@ namespace Esprima.Ast
             Declaration = declaration;
             _specifiers = specifiers;
             Source = source;
-            Assertions = assertions;
+            _assertions = assertions;
         }
 
-        public ref readonly NodeList<ExportSpecifier> Specifiers => ref _specifiers;
+        public StatementListItem? Declaration { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<ExportSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _specifiers; }
+        public Literal? Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -49,7 +50,7 @@ namespace Esprima.Ast
                 yield return Declaration;
             }
 
-            foreach (var node in _specifiers)
+            foreach (var node in Specifiers)
             {
                 yield return node;
             }

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -1,24 +1,24 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ExportSpecifier : Statement
     {
-        /// <summary>
-        /// <see cref="Identifier" /> | <see cref="Literal" />
-        /// </summary>
-        public readonly Expression Exported;
-
-        /// <summary>
-        /// <see cref="Identifier" /> | StringLiteral <see cref="Literal" />
-        /// </summary>
-        public readonly Expression Local;
-
         public ExportSpecifier(Expression local, Expression exported) : base(Nodes.ExportSpecifier)
         {
-            Exported = exported;
             Local = local;
+            Exported = exported;
         }
+
+        /// <remarks>
+        /// <see cref="Identifier" /> | StringLiteral (<see cref="Literal" />)
+        /// </remarks>
+        public Expression Local { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <remarks>
+        /// <see cref="Identifier" /> | <see cref="Literal" />
+        /// </remarks>
+        public Expression Exported { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Exported, Local);
 

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public class ExpressionStatement : Statement
     {
-        public readonly Expression Expression;
-
         public ExpressionStatement(Expression expression) : base(Nodes.ExpressionStatement)
         {
             Expression = expression;
         }
+
+        public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public sealed override NodeCollection ChildNodes => new(Expression);
 

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -1,13 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ForInStatement : Statement
     {
-        public readonly Node Left;
-        public readonly Expression Right;
-        public readonly Statement Body;
-
         public ForInStatement(
             Node left,
             Expression right,
@@ -17,6 +14,10 @@ namespace Esprima.Ast
             Right = right;
             Body = body;
         }
+
+        public Node Left { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Left, Right, Body);
 

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -1,25 +1,26 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ForOfStatement : Statement
     {
-        public readonly bool Await;
-        public readonly Node Left;
-        public readonly Expression Right;
-        public readonly Statement Body;
-
         public ForOfStatement(
             Node left,
             Expression right,
             Statement body,
-            bool _await) : base(Nodes.ForOfStatement)
+            bool await) : base(Nodes.ForOfStatement)
         {
             Left = left;
             Right = right;
             Body = body;
-            Await = _await;
+            Await = await;
         }
+
+        public Node Left { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Await { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Left, Right, Body);
 

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -1,15 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ForStatement : Statement
     {
-        // can be a Statement (var i) or an Expression (i=0)
-        public readonly StatementListItem? Init;
-        public readonly Expression? Test;
-        public readonly Expression? Update;
-        public readonly Statement Body;
-
         public ForStatement(
             StatementListItem? init,
             Expression? test,
@@ -22,6 +17,14 @@ namespace Esprima.Ast
             Update = update;
             Body = body;
         }
+
+        /// <remarks>
+        /// <see cref="Statement"/> (var i) | <see cref="Expression"/> (i=0)
+        /// </remarks>
+        public StatementListItem? Init { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression? Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression? Update { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Init, Test, Update, Body);
 

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -1,10 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class FunctionDeclaration : Declaration, IFunction
     {
-        private readonly NodeList<Expression> _parameters;
+        private readonly NodeList<Expression> _params;
 
         public FunctionDeclaration(
             Identifier? id,
@@ -16,25 +17,25 @@ namespace Esprima.Ast
             : base(Nodes.FunctionDeclaration)
         {
             Id = id;
-            _parameters = parameters;
+            _params = parameters;
             Body = body;
             Generator = generator;
-            Expression = false;
             Strict = strict;
             Async = async;
         }
 
-        public Identifier? Id { get; }
+        public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
 
-        public Node Body { get; }
-        public bool Generator { get; }
-        public bool Expression { get; }
-        public bool Async { get; }
-        public bool Strict { get; }
+        public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        Node IFunction.Body => Body;
 
-        public ref readonly NodeList<Expression> Params => ref _parameters;
+        public bool Generator { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        bool IFunction.Expression => false;
+        public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -1,10 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class FunctionExpression : Expression, IFunction
     {
-        private readonly NodeList<Expression> _parameters;
+        private readonly NodeList<Expression> _params;
 
         public FunctionExpression(
             Identifier? id,
@@ -16,23 +17,25 @@ namespace Esprima.Ast
             base(Nodes.FunctionExpression)
         {
             Id = id;
-            _parameters = parameters;
+            _params = parameters;
             Body = body;
             Generator = generator;
-            Expression = false;
             Strict = strict;
             Async = async;
         }
 
-        public Identifier? Id { get; }
-        public ref readonly NodeList<Expression> Params => ref _parameters;
-        public Node Body { get; }
-        public bool Generator { get; }
-        public bool Expression { get; }
-        public bool Async { get; }
-        public bool Strict { get; }
+        public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _parameters, Body);
+        public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        Node IFunction.Body => Body;
+
+        public bool Generator { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        bool IFunction.Expression => false;
+        public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/IClass.cs
+++ b/src/Esprima/Ast/IClass.cs
@@ -8,7 +8,7 @@
         Identifier? Id { get; }
         Expression? SuperClass { get; }
         ClassBody Body { get; }
+        ref readonly NodeList<Decorator> Decorators { get; }
         NodeCollection ChildNodes { get; }
-        NodeList<Decorator> Decorators { get; }
     }
 }

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Esprima.Utils;
 
 namespace Esprima.Ast
@@ -6,12 +7,12 @@ namespace Esprima.Ast
     [DebuggerDisplay("{Name,nq}")]
     public sealed class Identifier : Expression
     {
-        public readonly string? Name;
-
         public Identifier(string? name) : base(Nodes.Identifier)
         {
             Name = name;
         }
+
+        public string? Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -1,13 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class IfStatement : Statement
     {
-        public readonly Expression Test;
-        public readonly Statement Consequent;
-        public readonly Statement? Alternate;
-
         public IfStatement(
             Expression test,
             Statement consequent,
@@ -18,6 +15,10 @@ namespace Esprima.Ast
             Consequent = consequent;
             Alternate = alternate;
         }
+
+        public Expression Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement? Alternate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Test, Consequent, Alternate);
 

--- a/src/Esprima/Ast/Import.cs
+++ b/src/Esprima/Ast/Import.cs
@@ -1,12 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class Import : Expression
     {
-        public readonly Expression Source;
-        public readonly Expression? Attributes;
-
         public Import(Expression source) : this(source, null)
         {
         }
@@ -16,6 +14,9 @@ namespace Esprima.Ast
             Source = source;
             Attributes = attributes;
         }
+
+        public Expression Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression? Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Source, Attributes);
 

--- a/src/Esprima/Ast/ImportAttribute.cs
+++ b/src/Esprima/Ast/ImportAttribute.cs
@@ -1,20 +1,21 @@
+using System.Runtime.CompilerServices;
 using Esprima.Utils;
 
 namespace Esprima.Ast;
 
 public sealed class ImportAttribute : Node
 {
-    /// <summary>
-    /// <see cref="Identifier" /> | <see cref="Literal" />
-    /// </summary>
-    public readonly Expression Key;
-    public readonly Literal Value;
-
     public ImportAttribute(Expression key, Literal value) : base(Nodes.ImportAttribute)
     {
         Key = key;
         Value = value;
     }
+
+    /// <remarks>
+    /// <see cref="Identifier" /> | <see cref="Literal" />
+    /// </remarks>
+    public Expression Key { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public Literal Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Key, Value);
 

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -1,14 +1,13 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ImportDeclaration : Declaration
     {
         private readonly NodeList<ImportDeclarationSpecifier> _specifiers;
+        private readonly NodeList<ImportAttribute> _assertions;
 
-        public readonly Literal Source;
-
-        public readonly NodeList<ImportAttribute> Assertions;
         public ImportDeclaration(
             in NodeList<ImportDeclarationSpecifier> specifiers,
             Literal source,
@@ -17,10 +16,12 @@ namespace Esprima.Ast
         {
             _specifiers = specifiers;
             Source = source;
-            Assertions = assertions;
+            _assertions = assertions;
         }
 
-        public ref readonly NodeList<ImportDeclarationSpecifier> Specifiers => ref _specifiers;
+        public ref readonly NodeList<ImportDeclarationSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _specifiers; }
+        public Literal Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -41,7 +42,7 @@ namespace Esprima.Ast
 
         private IEnumerable<Node> CreateChildNodes()
         {
-            foreach (var node in _specifiers)
+            foreach (var node in Specifiers)
             {
                 yield return node;
             }

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -1,12 +1,14 @@
-﻿namespace Esprima.Ast
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast
 {
     public abstract class ImportDeclarationSpecifier : Declaration
     {
-        public readonly Identifier Local;
-
         protected ImportDeclarationSpecifier(Identifier local, Nodes type) : base(type)
         {
             Local = local;
         }
+
+        public Identifier Local { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     }
 }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -1,18 +1,19 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ImportSpecifier : ImportDeclarationSpecifier
     {
-        /// <summary>
-        /// <see cref="Identifier" /> | StringLiteral <see cref="Literal" />
-        /// </summary>
-        public readonly Expression Imported;
-
         public ImportSpecifier(Identifier local, Expression imported) : base(local, Nodes.ImportSpecifier)
         {
             Imported = imported;
         }
+
+        /// <remarks>
+        /// <see cref="Identifier" /> | StringLiteral (<see cref="Literal" />)
+        /// </remarks>
+        public Expression Imported { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Local, Imported);
 

--- a/src/Esprima/Ast/Jsx/JsxAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxAttribute.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxAttribute : JsxExpression
 {
-    public readonly JsxExpression Name;
-    public readonly Expression? Value;
-
     public JsxAttribute(JsxExpression name, Expression? value) : base(JsxNodeType.Attribute)
     {
         Name = name;
         Value = value;
     }
+
+    public JsxExpression Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Name, Value);
 

--- a/src/Esprima/Ast/Jsx/JsxClosingElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxClosingElement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxClosingElement : JsxExpression
 {
-    public readonly JsxExpression Name;
-
     public JsxClosingElement(JsxExpression name) : base(JsxNodeType.ClosingElement)
     {
         Name = name;
     }
+
+    public JsxExpression Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Name);
 

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -1,11 +1,10 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxElement : JsxExpression
 {
-    public readonly Node OpeningElement;
-    public readonly Node? ClosingElement;
     private readonly NodeList<JsxExpression> _children;
 
     public JsxElement(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement) : base(JsxNodeType.Element)
@@ -15,9 +14,11 @@ public sealed class JsxElement : JsxExpression
         _children = children;
     }
 
-    public ref readonly NodeList<JsxExpression> Children => ref _children;
+    public Node OpeningElement { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public Node? ClosingElement { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public ref readonly NodeList<JsxExpression> Children { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _children; }
 
-    public override NodeCollection ChildNodes => ClosingElement is null ? GenericChildNodeYield.Yield(OpeningElement, _children) : GenericChildNodeYield.Yield(OpeningElement, _children, ClosingElement);
+    public override NodeCollection ChildNodes => ClosingElement is null ? GenericChildNodeYield.Yield(OpeningElement, Children) : GenericChildNodeYield.Yield(OpeningElement, Children, ClosingElement);
 
     protected override object? Accept(IJsxAstVisitor visitor)
     {

--- a/src/Esprima/Ast/Jsx/JsxExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
@@ -8,12 +9,12 @@ namespace Esprima.Ast.Jsx;
 /// </summary>
 public abstract class JsxExpression : Expression
 {
-    public new readonly JsxNodeType Type;
-
     protected JsxExpression(JsxNodeType type) : base(Nodes.Extension)
     {
         Type = type;
     }
+
+    public new JsxNodeType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     protected abstract object? Accept(IJsxAstVisitor visitor);
 

--- a/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxExpressionContainer : JsxExpression
 {
-    public readonly Expression Expression;
-
     public JsxExpressionContainer(Expression expression) : base(JsxNodeType.ExpressionContainer)
     {
         Expression = expression;
     }
+
+    public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Expression);
 

--- a/src/Esprima/Ast/Jsx/JsxIdentifier.cs
+++ b/src/Esprima/Ast/Jsx/JsxIdentifier.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
@@ -6,12 +7,12 @@ namespace Esprima.Ast.Jsx;
 [DebuggerDisplay("{Name,nq}")]
 public sealed class JsxIdentifier : JsxExpression
 {
-    public readonly string Name;
-
     public JsxIdentifier(string name) : base(JsxNodeType.Identifier)
     {
         Name = name;
     }
+
+    public string Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxMemberExpression : JsxExpression
 {
-    public readonly JsxExpression Object;
-    public readonly JsxIdentifier Property;
-
     public JsxMemberExpression(JsxExpression obj, JsxIdentifier property) : base(JsxNodeType.MemberExpression)
     {
         Object = obj;
         Property = property;
     }
+
+    public JsxExpression Object { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public JsxIdentifier Property { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Object, Property);
 

--- a/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
+++ b/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
@@ -6,14 +7,14 @@ namespace Esprima.Ast.Jsx;
 [DebuggerDisplay("{Namespace,nq}.{Name,nq}")]
 public sealed class JsxNamespacedName : JsxExpression
 {
-    public readonly JsxIdentifier Name;
-    public readonly JsxIdentifier Namespace;
-
-    public JsxNamespacedName(JsxIdentifier @namespace,JsxIdentifier name) : base(JsxNodeType.NamespacedName)
+    public JsxNamespacedName(JsxIdentifier @namespace, JsxIdentifier name) : base(JsxNodeType.NamespacedName)
     {
-        Name = name;
         Namespace = @namespace;
+        Name = name;
     }
+
+    public JsxIdentifier Namespace { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public JsxIdentifier Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Name, Namespace);
 

--- a/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
@@ -1,11 +1,10 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxOpeningElement : JsxExpression
 {
-    public readonly JsxExpression Name;
-    public readonly bool SelfClosing;
     private readonly NodeList<JsxExpression> _attributes;
 
     public JsxOpeningElement(JsxExpression name, bool selfClosing, in NodeList<JsxExpression> attributes) : base(JsxNodeType.OpeningElement)
@@ -15,9 +14,11 @@ public sealed class JsxOpeningElement : JsxExpression
         _attributes = attributes;
     }
 
-    public ref readonly NodeList<JsxExpression> Attributes => ref _attributes;
+    public JsxExpression Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public bool SelfClosing { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public ref readonly NodeList<JsxExpression> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
 
-    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Name, _attributes);
+    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Name, Attributes);
 
     protected override object? Accept(IJsxAstVisitor visitor)
     {

--- a/src/Esprima/Ast/Jsx/JsxOpeningFragment.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningFragment.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxOpeningFragment : JsxExpression
 {
-    public readonly bool SelfClosing;
-
     public JsxOpeningFragment(bool selfClosing) : base(JsxNodeType.OpeningFragment)
     {
         SelfClosing = selfClosing;
     }
+
+    public bool SelfClosing { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils.Jsx;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
 
 public sealed class JsxSpreadAttribute : JsxExpression
 {
-    public readonly Expression Argument;
-
     public JsxSpreadAttribute(Expression argument) : base(JsxNodeType.SpreadAttribute)
     {
         Argument = argument;
     }
+
+    public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/Jsx/JsxText.cs
+++ b/src/Esprima/Ast/Jsx/JsxText.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Esprima.Utils.Jsx;
 
 namespace Esprima.Ast.Jsx;
@@ -6,14 +7,14 @@ namespace Esprima.Ast.Jsx;
 [DebuggerDisplay("{Raw,nq}")]
 public sealed class JsxText : JsxExpression
 {
-    public readonly string? Value;
-    public readonly string Raw;
-
     public JsxText(string? value, string raw) : base(JsxNodeType.Text)
     {
         Value = value;
         Raw = raw;
     }
+
+    public string? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public string Raw { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -1,18 +1,19 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class LabeledStatement : Statement
     {
-        public readonly Identifier Label;
-        public readonly Statement Body;
-
         public LabeledStatement(Identifier label, Statement body) : base(Nodes.LabeledStatement)
         {
             Label = label;
             Body = body;
-            body.LabelSet = label;
+            body._labelSet = label;
         }
+
+        public Identifier Label { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Label, Body);
 

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -1,5 +1,6 @@
 ﻿using System.Diagnostics;
 using System.Numerics;
+using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Esprima.Utils;
 
@@ -8,17 +9,6 @@ namespace Esprima.Ast
     [DebuggerDisplay("{Raw,nq}")]
     public class Literal : Expression
     {
-        public string? StringValue => TokenType == TokenType.StringLiteral ? Value as string : null;
-        public readonly double NumericValue;
-        public bool BooleanValue => TokenType == TokenType.BooleanLiteral && NumericValue != 0;
-        public Regex? RegexValue => TokenType == TokenType.RegularExpression ? (Regex?) Value : null;
-        public BigInteger? BigIntValue => TokenType == TokenType.BigIntLiteral ? (BigInteger?) Value : null;
-
-        public readonly RegexValue? Regex;
-        public readonly object? Value;
-        public readonly string Raw;
-        public readonly TokenType TokenType;
-
         internal Literal(TokenType tokenType, object? value, string raw) : base(Nodes.Literal)
         {
             TokenType = tokenType;
@@ -49,6 +39,17 @@ namespace Esprima.Ast
             // value is null if a Regex object couldn't be created out of the pattern or options
             Regex = new RegexValue(pattern, flags);
         }
+
+        public TokenType TokenType { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public object? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public string Raw { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public RegexValue? Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+        public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? Value as string : null; }
+        public bool BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral && NumericValue != 0; }
+        public double NumericValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Regex? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.RegularExpression ? (Regex?) Value : null; }
+        public BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger?) Value : null; }
 
         public sealed override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -1,16 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public abstract class MemberExpression : Expression
     {
-        public readonly Expression Object;
-        public readonly Expression Property;
-
-        // true if an indexer is used and the property to be evaluated
-        public readonly bool Computed;
-        public readonly bool Optional;
-
         protected MemberExpression(Expression obj, Expression property, bool computed, bool optional)
             : base(Nodes.MemberExpression)
         {
@@ -19,6 +13,14 @@ namespace Esprima.Ast
             Computed = computed;
             Optional = optional;
         }
+
+        public Expression Object { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Property { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        /// <summary>
+        /// True if an indexer is used and the property to be evaluated.
+        /// </summary>
+        public bool Computed { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Optional { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Object, Property);
 

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class MetaProperty : Expression
     {
-        public readonly Identifier Meta;
-        public readonly Identifier Property;
-
         public MetaProperty(Identifier meta, Identifier property) : base(Nodes.MetaProperty)
         {
             Meta = meta;
             Property = property;
         }
+
+        public Identifier Meta { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Identifier Property { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Meta, Property);
 

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -1,14 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class MethodDefinition : ClassProperty
     {
-        public new readonly FunctionExpression Value;
-        protected override Expression? GetValue() => Value;
-
-        public readonly bool Static;
-        public readonly NodeList<Decorator> Decorators;
+        private readonly NodeList<Decorator> _decorators;
 
         public MethodDefinition(
             Expression key,
@@ -19,10 +16,16 @@ namespace Esprima.Ast
             in NodeList<Decorator> decorators)
             : base(Nodes.MethodDefinition, kind, key, computed)
         {
-            Static = isStatic;
             Value = value;
-            Decorators = decorators;
+            Static = isStatic;
+            _decorators = decorators;
         }
+
+        public new FunctionExpression Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        protected override Expression? GetValue() => Value;
+
+        public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/Module.cs
+++ b/src/Esprima/Ast/Module.cs
@@ -2,17 +2,11 @@
 {
     public sealed class Module : Program
     {
-        private readonly NodeList<Statement> _body;
-        public override SourceType SourceType => SourceType.Module;
-
-        public Module(in NodeList<Statement> body) : base(Nodes.Program)
+        public Module(in NodeList<Statement> body) : base(Nodes.Program, body)
         {
-            _body = body;
         }
 
-        public override ref readonly NodeList<Statement> Body => ref _body;
-
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public override SourceType SourceType => SourceType.Module;
 
         protected override Program Rewrite(in NodeList<Statement> body)
         {

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -1,11 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class NewExpression : Expression
     {
         private readonly NodeList<Expression> _arguments;
-        public readonly Expression Callee;
 
         public NewExpression(
             Expression callee,
@@ -16,7 +16,8 @@ namespace Esprima.Ast
             _arguments = args;
         }
 
-        public ref readonly NodeList<Expression> Arguments => ref _arguments;
+        public Expression Callee { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _arguments; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
 

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -9,7 +10,8 @@ namespace Esprima.Ast
             Type = type;
         }
 
-        public readonly Nodes Type;
+        public Nodes Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
         public Range Range;
         public Location Location;
 

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -5,6 +5,9 @@ namespace Esprima.Ast
 {
     public abstract class Node
     {
+        internal Range _range;
+        internal Location _location;
+
         protected Node(Nodes type)
         {
             Type = type;
@@ -12,8 +15,21 @@ namespace Esprima.Ast
 
         public Nodes Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public Range Range;
-        public Location Location;
+        public Range Range
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _range;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            init => _range = value;
+        }
+
+        public Location Location
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _location;
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            init => _location = value;
+        }
 
         public abstract NodeCollection ChildNodes { get; }
 

--- a/src/Esprima/Ast/NodeExtensions.cs
+++ b/src/Esprima/Ast/NodeExtensions.cs
@@ -108,7 +108,7 @@ namespace Esprima.Ast
 
         internal static T SetAdditionalInfo<T>(this T node, Statement sourceNode) where T : Statement
         {
-            node.LabelSet = sourceNode.LabelSet;
+            node._labelSet = sourceNode.LabelSet;
             node.SetAdditionalInfo((Node) sourceNode);
             return node;
         }

--- a/src/Esprima/Ast/NodeExtensions.cs
+++ b/src/Esprima/Ast/NodeExtensions.cs
@@ -101,8 +101,8 @@ namespace Esprima.Ast
 
         internal static T SetAdditionalInfo<T>(this T node, Node sourceNode) where T : Node
         {
-            node.Location = sourceNode.Location;
-            node.Range = sourceNode.Range;
+            node._location = sourceNode._location;
+            node._range = sourceNode._range;
             return node;
         }
 

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -11,9 +12,9 @@ namespace Esprima.Ast
             _properties = properties;
         }
 
-        public ref readonly NodeList<Expression> Properties => ref _properties;
+        public ref readonly NodeList<Expression> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -11,9 +12,9 @@ namespace Esprima.Ast
             _properties = properties;
         }
 
-        public ref readonly NodeList<Node> Properties => ref _properties;
+        public ref readonly NodeList<Node> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/PrivateIdentifier.cs
+++ b/src/Esprima/Ast/PrivateIdentifier.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class PrivateIdentifier : Expression
     {
-        public readonly string? Name;
-
         public PrivateIdentifier(string? name) : base(Nodes.PrivateIdentifier)
         {
             Name = name;
         }
+
+        public string? Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -1,16 +1,22 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public abstract class Program : Statement
     {
-        protected Program(Nodes type) : base(type)
+        private readonly NodeList<Statement> _body;
+
+        protected Program(Nodes type, in NodeList<Statement> body) : base(type)
         {
+            _body = body;
         }
+
+        public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
         public abstract SourceType SourceType { get; }
 
-        public abstract ref readonly NodeList<Statement> Body { get; }
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -1,14 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class Property : ClassProperty
     {
-        public new Expression Value;
-        protected override Expression? GetValue() => Value;
-
-        public readonly bool Method;
-        public readonly bool Shorthand;
+        internal Expression _value;
 
         public Property(
             PropertyKind kind,
@@ -19,10 +16,16 @@ namespace Esprima.Ast
             bool shorthand)
             : base(Nodes.Property, kind, key, computed)
         {
-            Value = value;
+            _value = value;
             Method = method;
             Shorthand = shorthand;
         }
+
+        public new Expression Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _value; }
+        protected override Expression? GetValue() => _value;
+
+        public bool Method { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Shorthand { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -1,14 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class PropertyDefinition : ClassProperty
     {
-        public new readonly Expression? Value;
-        protected override Expression? GetValue() => Value;
-
-        public readonly bool Static;
-        public readonly NodeList<Decorator> Decorators;
+        private readonly NodeList<Decorator> _decorators;
 
         public PropertyDefinition(
             Expression key,
@@ -18,10 +15,16 @@ namespace Esprima.Ast
             in NodeList<Decorator> decorators)
             : base(Nodes.PropertyDefinition, PropertyKind.Property, key, computed)
         {
-            Static = isStatic;
             Value = value;
-            Decorators = decorators;
+            Static = isStatic;
+            _decorators = decorators;
         }
+
+        public new Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        protected override Expression? GetValue() => Value;
+
+        public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -1,19 +1,19 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class RestElement : Expression
     {
-        // Identifier in esprima but not forced and
-        // for instance ...i[0] is a SpreadElement
-        // which is reinterpreted to RestElement with a ComputerMemberExpression
-
-        public readonly Expression Argument; // BindingIdentifier | BindingPattern
-
         public RestElement(Expression argument) : base(Nodes.RestElement)
         {
             Argument = argument;
         }
+
+        /// <remarks>
+        /// BindingIdentifier | <see cref="BindingPattern"/>
+        /// </remarks>
+        public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ReturnStatement : Statement
     {
-        public readonly Expression? Argument;
-
         public ReturnStatement(Expression? argument) : base(Nodes.ReturnStatement)
         {
             Argument = argument;
         }
+
+        public Expression? Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/Script.cs
+++ b/src/Esprima/Ast/Script.cs
@@ -1,24 +1,20 @@
-﻿namespace Esprima.Ast
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast
 {
     public sealed class Script : Program
     {
-        private readonly NodeList<Statement> _body;
-
         public Script(
             in NodeList<Statement> body,
             bool strict)
-            : base(Nodes.Program)
+            : base(Nodes.Program, body)
         {
-            _body = body;
             Strict = strict;
         }
 
         public override SourceType SourceType => SourceType.Script;
-        public bool Strict { get; }
 
-        public override ref readonly NodeList<Statement> Body => ref _body;
-
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         protected override Program Rewrite(in NodeList<Statement> body)
         {

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -1,22 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class SequenceExpression : Expression
     {
-        private NodeList<Expression> _expressions;
+        internal NodeList<Expression> _expressions;
 
         public SequenceExpression(in NodeList<Expression> expressions) : base(Nodes.SequenceExpression)
         {
             _expressions = expressions;
         }
 
-        public ref readonly NodeList<Expression> Expressions => ref _expressions;
-
-        internal void UpdateExpressions(in NodeList<Expression> value)
-        {
-            _expressions = value;
-        }
+        public ref readonly NodeList<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _expressions; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Expressions);
 

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class SpreadElement : Expression
     {
-        public readonly Expression Argument;
-
         public SpreadElement(Expression argument) : base(Nodes.SpreadElement)
         {
             Argument = argument;
         }
+
+        public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/Statement.cs
+++ b/src/Esprima/Ast/Statement.cs
@@ -1,11 +1,15 @@
-﻿namespace Esprima.Ast
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast
 {
     public abstract class Statement : StatementListItem
     {
+        internal Identifier? _labelSet;
+
         protected Statement(Nodes type) : base(type)
         {
         }
 
-        public Identifier? LabelSet { get; internal set; }
+        public Identifier? LabelSet { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _labelSet; }
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -1,11 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class SwitchCase : Node
     {
         private readonly NodeList<Statement> _consequent;
-        public readonly Expression? Test;
 
         public SwitchCase(Expression? test, in NodeList<Statement> consequent) : base(Nodes.SwitchCase)
         {
@@ -13,9 +13,10 @@ namespace Esprima.Ast
             _consequent = consequent;
         }
 
-        public ref readonly NodeList<Statement> Consequent => ref _consequent;
+        public Expression? Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<Statement> Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _consequent; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, _consequent);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, Consequent);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -6,17 +7,16 @@ namespace Esprima.Ast
     {
         private readonly NodeList<SwitchCase> _cases;
 
-        public readonly Expression Discriminant;
-
         public SwitchStatement(Expression discriminant, in NodeList<SwitchCase> cases) : base(Nodes.SwitchStatement)
         {
             Discriminant = discriminant;
             _cases = cases;
         }
 
-        public ref readonly NodeList<SwitchCase> Cases => ref _cases;
+        public Expression Discriminant { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public ref readonly NodeList<SwitchCase> Cases { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _cases; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, _cases);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, Cases);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -32,6 +32,5 @@ namespace Esprima.Ast
 
             return new SwitchStatement(discriminant, cases).SetAdditionalInfo(this);
         }
-
     }
 }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class TaggedTemplateExpression : Expression
     {
-        public readonly Expression Tag;
-        public readonly TemplateLiteral Quasi;
-
         public TaggedTemplateExpression(Expression tag, TemplateLiteral quasi) : base(Nodes.TaggedTemplateExpression)
         {
             Tag = tag;
             Quasi = quasi;
         }
+
+        public Expression Tag { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public TemplateLiteral Quasi { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Tag, Quasi);
 

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -1,23 +1,20 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class TemplateElement : Node
     {
-        public readonly TemplateElementValue Value;
-        public readonly bool Tail;
-
         public TemplateElement(TemplateElementValue value, bool tail) : base(Nodes.TemplateElement)
         {
             Value = value;
             Tail = tail;
         }
 
-        public sealed class TemplateElementValue
-        {
-            public string? Cooked;
-            public string Raw = "";
-        }
+        public sealed record TemplateElementValue(string? Cooked, string Raw);
+
+        public TemplateElementValue Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Tail { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
@@ -16,8 +17,8 @@ namespace Esprima.Ast
             _expressions = expressions;
         }
 
-        public ref readonly NodeList<TemplateElement> Quasis => ref _quasis;
-        public ref readonly NodeList<Expression> Expressions => ref _expressions;
+        public ref readonly NodeList<TemplateElement> Quasis { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _quasis; }
+        public ref readonly NodeList<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _expressions; }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -39,12 +40,12 @@ namespace Esprima.Ast
         private IEnumerable<Node> CreateChildNodes()
         {
             var i = 0;
-            while (!_quasis[i].Tail)
+            while (!Quasis[i].Tail)
             {
-                yield return _quasis[i];
-                yield return _expressions[i++];
+                yield return Quasis[i];
+                yield return Expressions[i++];
             }
-            yield return _quasis[i];
+            yield return Quasis[i];
         }
     }
 }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -1,15 +1,16 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class ThrowStatement : Statement
     {
-        public readonly Expression Argument;
-
         public ThrowStatement(Expression argument) : base(Nodes.ThrowStatement)
         {
             Argument = argument;
         }
+
+        public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -1,13 +1,10 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class TryStatement : Statement
     {
-        public readonly BlockStatement Block;
-        public readonly CatchClause? Handler;
-        public readonly BlockStatement? Finalizer;
-
         public TryStatement(
             BlockStatement block,
             CatchClause? handler,
@@ -18,6 +15,10 @@ namespace Esprima.Ast
             Handler = handler;
             Finalizer = finalizer;
         }
+
+        public BlockStatement Block { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public CatchClause? Handler { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public BlockStatement? Finalizer { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Block, Handler, Finalizer);
 

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -1,4 +1,5 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
@@ -18,27 +19,23 @@ namespace Esprima.Ast
 
     public class UnaryExpression : Expression
     {
-        public readonly UnaryOperator Operator;
-        public readonly Expression Argument;
-        public bool Prefix { get; protected set; }
-
-        public UnaryExpression(string? op, Expression arg) : this(Nodes.UnaryExpression, op, arg)
+        public UnaryExpression(string? op, Expression arg) : this(ParseUnaryOperator(op), arg)
         {
         }
 
-        internal UnaryExpression(UnaryOperator op, Expression arg) : this(Nodes.UnaryExpression, op, arg)
+        public UnaryExpression(UnaryOperator op, Expression arg) : this(Nodes.UnaryExpression, op, arg, prefix: true)
         {
         }
 
-        protected UnaryExpression(Nodes type, string? op, Expression arg) : this(type, ParseUnaryOperator(op), arg)
+        protected UnaryExpression(Nodes type, string? op, Expression arg, bool prefix) : this(type, ParseUnaryOperator(op), arg, prefix)
         {
         }
 
-        protected UnaryExpression(Nodes type, UnaryOperator op, Expression arg) : base(type)
+        protected UnaryExpression(Nodes type, UnaryOperator op, Expression arg, bool prefix) : base(type)
         {
             Operator = op;
             Argument = arg;
-            Prefix = true;
+            Prefix = prefix;
         }
 
         private static UnaryOperator ParseUnaryOperator(string? op)
@@ -57,6 +54,10 @@ namespace Esprima.Ast
                 _ => ThrowArgumentOutOfRangeException<UnaryOperator>(nameof(op), "Invalid unary operator: " + op)
             };
         }
+
+        public UnaryOperator Operator { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Prefix { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public sealed override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/Ast/UpdateExpression.cs
+++ b/src/Esprima/Ast/UpdateExpression.cs
@@ -1,17 +1,13 @@
-﻿using Esprima.Utils;
-
-namespace Esprima.Ast
+﻿namespace Esprima.Ast
 {
     public sealed class UpdateExpression : UnaryExpression
     {
-        public UpdateExpression(string? op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg)
+        public UpdateExpression(string? op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg, prefix)
         {
-            Prefix = prefix;
         }
 
-        internal UpdateExpression(UnaryOperator op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg)
+        public UpdateExpression(UnaryOperator op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg, prefix)
         {
-            Prefix = prefix;
         }
 
         protected override UnaryExpression Rewrite(Expression argument)

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -1,11 +1,11 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class VariableDeclaration : Declaration
     {
         private readonly NodeList<VariableDeclarator> _declarations;
-        public readonly VariableDeclarationKind Kind;
 
         public VariableDeclaration(
             in NodeList<VariableDeclarator> declarations,
@@ -16,9 +16,10 @@ namespace Esprima.Ast
             Kind = kind;
         }
 
-        public ref readonly NodeList<VariableDeclarator> Declarations => ref _declarations;
+        public ref readonly NodeList<VariableDeclarator> Declarations { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _declarations; }
+        public VariableDeclarationKind Kind { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_declarations);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Declarations);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -1,18 +1,22 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class VariableDeclarator : Node
     {
-        public readonly Expression Id; // BindingIdentifier | BindingPattern;
-        public readonly Expression? Init;
-
         public VariableDeclarator(Expression id, Expression? init) :
             base(Nodes.VariableDeclarator)
         {
             Id = id;
             Init = init;
         }
+
+        /// <remarks>
+        /// BindingIdentifier | <see cref="BindingPattern"/>
+        /// </remarks>
+        public Expression Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Expression? Init { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Id, Init);
 

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class WhileStatement : Statement
     {
-        public readonly Expression Test;
-        public readonly Statement Body;
-
         public WhileStatement(Expression test, Statement body) : base(Nodes.WhileStatement)
         {
             Test = test;
             Body = body;
         }
+
+        public Expression Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Test, Body);
 

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class WithStatement : Statement
     {
-        public readonly Expression Object;
-        public readonly Statement Body;
-
         public WithStatement(Expression obj, Statement body) : base(Nodes.WithStatement)
         {
             Object = obj;
             Body = body;
         }
+
+        public Expression Object { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Object, Body);
 

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -1,17 +1,18 @@
-﻿using Esprima.Utils;
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
 
 namespace Esprima.Ast
 {
     public sealed class YieldExpression : Expression
     {
-        public readonly Expression? Argument;
-        public readonly bool Delegate;
-
         public YieldExpression(Expression? argument, bool delgate) : base(Nodes.YieldExpression)
         {
             Argument = argument;
             Delegate = delgate;
         }
+
+        public Expression? Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+        public bool Delegate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
         public override NodeCollection ChildNodes => new(Argument);
 

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -350,12 +350,12 @@ namespace Esprima
 
         private protected T Finalize<T>(Marker marker, T node) where T : Node
         {
-            node.Range = new Esprima.Ast.Range(marker.Index, _lastMarker.Index);
+            node._range = new Esprima.Ast.Range(marker.Index, _lastMarker.Index);
 
             var start = new Position(marker.Line, marker.Column);
             var end = new Position(_lastMarker.Line, _lastMarker.Column);
 
-            node.Location = new Location(start, end, _errorHandler.Source);
+            node._location = new Location(start, end, _errorHandler.Source);
 
             _action?.Invoke(node);
 
@@ -1164,8 +1164,8 @@ namespace Esprima
                 case Nodes.SpreadElement:
                     var newArgument = ReinterpretExpressionAsPattern(expr.As<SpreadElement>().Argument);
                     node = new RestElement(newArgument);
-                    node.Range = expr.Range;
-                    node.Location = expr.Location;
+                    node._range = expr._range;
+                    node._location = expr._location;
                     break;
                 case Nodes.ArrayExpression:
                     var elements = new ArrayList<Expression?>();
@@ -1186,8 +1186,8 @@ namespace Esprima
 #nullable disable
                     node = new ArrayPattern(NodeList.From(ref elements));
 #nullable enable
-                    node.Range = expr.Range;
-                    node.Location = expr.Location;
+                    node._range = expr._range;
+                    node._location = expr._location;
 
                     break;
                 case Nodes.ObjectExpression:
@@ -1206,15 +1206,15 @@ namespace Esprima
                     }
 
                     node = new ObjectPattern(NodeList.From(ref properties));
-                    node.Range = expr.Range;
-                    node.Location = expr.Location;
+                    node._range = expr._range;
+                    node._location = expr._location;
 
                     break;
                 case Nodes.AssignmentExpression:
                     var assignmentExpression = expr.As<AssignmentExpression>();
                     node = new AssignmentPattern(assignmentExpression.Left, assignmentExpression.Right);
-                    node.Range = expr.Range;
-                    node.Location = expr.Location;
+                    node._range = expr._range;
+                    node._location = expr._location;
 
                     break;
                 default:
@@ -2244,7 +2244,7 @@ namespace Esprima
                             ThrowUnexpectedToken(_lookahead);
                         }
 
-                        assignment._right = new Identifier("yield") { Location = assignment.Right.Location, Range = assignment.Right.Range };
+                        assignment._right = new Identifier("yield") { _location = assignment.Right._location, _range = assignment.Right._range };
                     }
                 }
                 else if (asyncArrow && param.Type == Nodes.Identifier && param.As<Identifier>().Name == "await")

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1100,7 +1100,7 @@ namespace Esprima
                 ThrowTemplateLiteralEarlyErrors(token);
             }
 
-            var value = new TemplateElement.TemplateElementValue { Raw = token.RawTemplate!, Cooked = (string) token.Value! };
+            var value = new TemplateElement.TemplateElementValue(Raw: token.RawTemplate!, Cooked: (string) token.Value!);
 
             return Finalize(node, new TemplateElement(value, token.Tail));
         }
@@ -1119,7 +1119,7 @@ namespace Esprima
                 ThrowTemplateLiteralEarlyErrors(token);
             }
 
-            var value = new TemplateElement.TemplateElementValue { Raw = token.RawTemplate!, Cooked = (string) token.Value! };
+            var value = new TemplateElement.TemplateElementValue(Raw: token.RawTemplate!, Cooked: (string) token.Value!);
 
             return Finalize(node, new TemplateElement(value, token.Tail));
         }
@@ -1196,7 +1196,7 @@ namespace Esprima
                     {
                         if (property is Property p)
                         {
-                            p.Value = ReinterpretExpressionAsPattern(p.Value);
+                            p._value = ReinterpretExpressionAsPattern(p.Value);
                             properties.Add(p);
                         }
                         else
@@ -1355,7 +1355,7 @@ namespace Esprima
                                         reinterpretedExpressions.Add(ReinterpretExpressionAsPattern(expression!));
                                     }
 
-                                    sequenceExpression.UpdateExpressions(NodeList.From(ref reinterpretedExpressions));
+                                    sequenceExpression._expressions = NodeList.From(ref reinterpretedExpressions);
                                 }
                                 else
                                 {
@@ -2244,7 +2244,7 @@ namespace Esprima
                             ThrowUnexpectedToken(_lookahead);
                         }
 
-                        assignment.Right = new Identifier("yield") { Location = assignment.Right.Location, Range = assignment.Right.Range };
+                        assignment._right = new Identifier("yield") { Location = assignment.Right.Location, Range = assignment.Right.Range };
                     }
                 }
                 else if (asyncArrow && param.Type == Nodes.Identifier && param.As<Identifier>().Name == "await")

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -200,8 +200,8 @@ public class AstToJsonConverter : AstJson.IConverter
             {
                 _writer.Member("range");
                 _writer.StartArray();
-                _writer.Number(node.Range.Start);
-                _writer.Number(node.Range.End);
+                _writer.Number(node._range.Start);
+                _writer.Number(node._range.End);
                 _writer.EndArray();
             }
 
@@ -210,9 +210,9 @@ public class AstToJsonConverter : AstJson.IConverter
                 _writer.Member("loc");
                 _writer.StartObject();
                 _writer.Member("start");
-                Write(node.Location.Start);
+                Write(node._location.Start);
                 _writer.Member("end");
-                Write(node.Location.End);
+                Write(node._location.End);
                 _writer.EndObject();
             }
 
@@ -912,14 +912,14 @@ public class AstToJsonConverter : AstJson.IConverter
 
                 var callee = new ImportCompat
                 {
-                    Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
-                    Range = new Ast.Range(import.Range.Start, import.Range.Start + importToken.Length)
+                    _location = new Location(import._location.Start, new Position(import._location.Start.Line, import._location.Start.Column + importToken.Length)),
+                    _range = new Ast.Range(import._range.Start, import._range.Start + importToken.Length)
                 };
                 var args = new NodeList<Expression>(new Expression[] { import.Source });
                 var callExpression = new CallExpression(callee, args, optional: false)
                 {
-                    Location = import.Location,
-                    Range = import.Range,
+                    _location = import._location,
+                    _range = import._range,
                 };
 
                 return Visit(callExpression);

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -392,7 +392,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("params", functionDeclaration.Params);
                 Member("body", functionDeclaration.Body);
                 Member("generator", functionDeclaration.Generator);
-                Member("expression", functionDeclaration.Expression);
+                Member("expression", ((IFunction) functionDeclaration).Expression);
                 // original Esprima doesn't include this information yet
                 if (!_testCompatibilityMode)
                 {
@@ -592,10 +592,10 @@ public class AstToJsonConverter : AstJson.IConverter
         {
             using (StartNodeObject(arrowFunctionExpression))
             {
-                Member("id", arrowFunctionExpression.Id);
+                Member("id", ((IFunction) arrowFunctionExpression).Id);
                 Member("params", arrowFunctionExpression.Params);
                 Member("body", arrowFunctionExpression.Body);
-                Member("generator", arrowFunctionExpression.Generator);
+                Member("generator", ((IFunction) arrowFunctionExpression).Generator);
                 Member("expression", arrowFunctionExpression.Expression);
                 // original Esprima doesn't include this information yet
                 if (!_testCompatibilityMode)
@@ -749,7 +749,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("params", functionExpression.Params);
                 Member("body", functionExpression.Body);
                 Member("generator", functionExpression.Generator);
-                Member("expression", functionExpression.Expression);
+                Member("expression", ((IFunction) functionExpression).Expression);
                 // original Esprima doesn't include this information yet
                 if (!_testCompatibilityMode)
                 {

--- a/src/Esprima/Utils/AstRewriter.cs
+++ b/src/Esprima/Utils/AstRewriter.cs
@@ -83,7 +83,7 @@ public class AstRewriter : AstVisitor
     {
         var id = VisitAndConvert(functionDeclaration.Id, allowNull: true);
         VisitAndConvert(functionDeclaration.Params, out var parameters);
-        var body = VisitAndConvert((BlockStatement) functionDeclaration.Body);
+        var body = VisitAndConvert(functionDeclaration.Body);
 
         return functionDeclaration.UpdateWith(id, parameters, body);
     }
@@ -250,7 +250,7 @@ public class AstRewriter : AstVisitor
     {
         var id = VisitAndConvert(functionExpression.Id, allowNull: true);
         VisitAndConvert(functionExpression.Params, out var parameters);
-        var body = VisitAndConvert((BlockStatement) functionExpression.Body);
+        var body = VisitAndConvert(functionExpression.Body);
 
         return functionExpression.UpdateWith(id, parameters, body);
     }

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -219,7 +219,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
     {
         return ForceNewObjectByControlType((FunctionDeclaration) base.VisitFunctionDeclaration(functionDeclaration)!,
-            node => new FunctionDeclaration(node.Id, node.Params, (BlockStatement) node.Body, node.Generator, node.Strict, node.Async));
+            node => new FunctionDeclaration(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
     protected internal override object? VisitWithStatement(WithStatement withStatement)
@@ -398,7 +398,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
     {
         return ForceNewObjectByControlType((FunctionExpression) base.VisitFunctionExpression(functionExpression)!,
-            node => new FunctionExpression(node.Id, node.Params, (BlockStatement) node.Body, node.Generator, node.Strict, node.Async));
+            node => new FunctionExpression(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
     protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)


### PR DESCRIPTION
This PR addresses https://github.com/sebastienros/esprima-dotnet/issues/264 and, partially, https://github.com/sebastienros/esprima-dotnet/issues/66

Phew, this was some epic sh*t. It took all my text editing skills... 😄 But according to the benchmark it was worth it:

Before:

|  Method |        Job |              Runtime |    Toolchain |     Mean |    Error |   StdDev | Ratio | Rank | Allocated |
|-------- |----------- |--------------------- |------------- |---------:|---------:|---------:|------:|-----:|----------:|
|   Visit | Job-ZDQNTH |             .NET 6.0 |        net60 | 15.18 ms | 0.031 ms | 0.026 ms |  0.97 |    1 |      16 B |
|   Visit | Job-IEZQPH |        .NET Core 3.1 | netcoreapp31 | 15.24 ms | 0.029 ms | 0.027 ms |  0.98 |    1 |         - |
|   Visit | Job-WZKQTX | .NET Framework 4.6.2 |       net462 | 15.63 ms | 0.014 ms | 0.012 ms |  1.00 |    2 |         - |
|         |            |                      |              |          |          |          |       |      |           |
| Rewrite | Job-ZDQNTH |             .NET 6.0 |        net60 | 37.70 ms | 0.134 ms | 0.125 ms |  0.75 |    1 |      75 B |
| Rewrite | Job-IEZQPH |        .NET Core 3.1 | netcoreapp31 | 40.52 ms | 0.061 ms | 0.054 ms |  0.81 |    2 |         - |
| Rewrite | Job-WZKQTX | .NET Framework 4.6.2 |       net462 | 50.06 ms | 0.298 ms | 0.279 ms |  1.00 |    3 |         - |

After:

|  Method |        Job |              Runtime |    Toolchain |     Mean |    Error |   StdDev | Ratio | Rank | Allocated |
|-------- |----------- |--------------------- |------------- |---------:|---------:|---------:|------:|-----:|----------:|
|   Visit | Job-PALKNJ |             .NET 6.0 |        net60 | 15.26 ms | 0.046 ms | 0.043 ms |  0.98 |    2 |      16 B |
|   Visit | Job-SJJCSG |        .NET Core 3.1 | netcoreapp31 | 14.96 ms | 0.019 ms | 0.017 ms |  0.96 |    1 |         - |
|   Visit | Job-QAMQPG | .NET Framework 4.6.2 |       net462 | 15.55 ms | 0.016 ms | 0.013 ms |  1.00 |    3 |         - |
|         |            |                      |              |          |          |          |       |      |           |
| Rewrite | Job-PALKNJ |             .NET 6.0 |        net60 | 36.63 ms | 0.190 ms | 0.178 ms |  0.72 |    1 |      75 B |
| Rewrite | Job-SJJCSG |        .NET Core 3.1 | netcoreapp31 | 43.10 ms | 0.082 ms | 0.073 ms |  0.85 |    2 |         - |
| Rewrite | Job-QAMQPG | .NET Framework 4.6.2 |       net462 | 50.52 ms | 0.119 ms | 0.111 ms |  1.00 |    3 |         - |

So it looks like aggressive inlining did its job. (I didn't measure parsing because construction of the tree remained the same as I kept the fields for the constructors and other internal parts.) However, to be 100% certain, it'd be great if someone repeated the benchmarks and verified these result.

With these changes, the AST is now almost fully immutable. It's almost because I haven't touched `Node.Location` and `Node.Range`. These are still public fields and I'm somewhat puzzled as to what to do with them. The crux of the problem is that these properties aren't included in the constructors but should be settable also by end users. Including them in the ctors would be a massive BC, so that's absolutely out of question. Our options are the following:
1. We can simply wrap them in properties. E.g.
    ```csharp
    public Range Range { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; [MethodImpl(MethodImplOptions.AggressiveInlining)] init; }
    ```
    However, this is certainly worse performance-wise than we have currently (i.e. simple fields) because `Range` and `Location` are value types, so there would be inevitable copying.
2. We can return by-ref but then the properties can't have a setter. We could provide some `SetRange` and `SetLocation` methods but then it's not immutable again. For init-only set we need a property. Thus, if we want by-ref return we'd need two properties:
    ```csharp
    public ref readonly Range RangeRef { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _range; }
    public Range Range { get => _range; init => _range = value; }
    ```
    This is ugly but the only way I'm aware of to retain perf. and make the API immutable for consumers at the same time.
3. We leave them alone and have a semi-immutable API.

Which one do you prefer?