### PR TITLE
Fix Node.ChildNodes inconsistencies

### DIFF
--- a/src/Esprima/Ast/AccessorProperty.cs
+++ b/src/Esprima/Ast/AccessorProperty.cs
@@ -27,21 +27,6 @@ public sealed class AccessorProperty : Node
 
     public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-    protected internal override object? Accept(AstVisitor visitor)
-    {
-        return visitor.VisitAccessorProperty(this);
-    }
-
-    public AccessorProperty UpdateWith(Expression key, Expression? value, in NodeList<Decorator> decorators)
-    {
-        if (key == Key && value == Value && NodeList.AreSame(decorators, Decorators))
-        {
-            return this;
-        }
-
-        return new AccessorProperty(key, value, Computed, Static, decorators).SetAdditionalInfo(this);
-    }
-
     private IEnumerable<Node> CreateChildNodes()
     {
         yield return Key;
@@ -55,5 +40,20 @@ public sealed class AccessorProperty : Node
         {
             yield return node;
         }
+    }
+
+    protected internal override object? Accept(AstVisitor visitor)
+    {
+        return visitor.VisitAccessorProperty(this);
+    }
+
+    public AccessorProperty UpdateWith(Expression key, Expression? value, in NodeList<Decorator> decorators)
+    {
+        if (key == Key && value == Value && NodeList.AreSame(decorators, Decorators))
+        {
+            return this;
+        }
+
+        return new AccessorProperty(key, value, Computed, Static, decorators).SetAdditionalInfo(this);
     }
 }

--- a/src/Esprima/Ast/AccessorProperty.cs
+++ b/src/Esprima/Ast/AccessorProperty.cs
@@ -27,14 +27,10 @@ public sealed class AccessorProperty : Node
 
     public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-    private IEnumerable<Node> CreateChildNodes()
+    private IEnumerable<Node?> CreateChildNodes()
     {
         yield return Key;
-
-        if (Value is not null)
-        {
-            yield return Value;
-        }
+        yield return Value;
 
         foreach (var node in Decorators)
         {

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -14,7 +14,7 @@ namespace Esprima.Ast
 
         public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(Elements!);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -14,7 +14,7 @@ namespace Esprima.Ast
 
         public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield<Expression>(Elements!);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -15,7 +15,7 @@ namespace Esprima.Ast
         /// </remarks>
         public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => NodeCollection.Empty;
+        public override NodeCollection ChildNodes => new(Expression);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -26,18 +26,10 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
-            if (Id is not null)
-            {
-                yield return Id;
-            }
-
-            if (SuperClass is not null)
-            {
-                yield return SuperClass;
-            }
-
+            yield return Id;
+            yield return SuperClass;
             yield return Body;
 
             foreach (var node in Decorators)

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -26,21 +26,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        protected internal override object? Accept(AstVisitor visitor)
-        {
-            return visitor.VisitClassDeclaration(this);
-        }
-
-        public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
-        {
-            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
-            {
-                return this;
-            }
-
-            return new ClassDeclaration(id, superClass, body, decorators).SetAdditionalInfo(this);
-        }
-
         private IEnumerable<Node> CreateChildNodes()
         {
             if (Id is not null)
@@ -59,6 +44,21 @@ namespace Esprima.Ast
             {
                 yield return node;
             }
+        }
+
+        protected internal override object? Accept(AstVisitor visitor)
+        {
+            return visitor.VisitClassDeclaration(this);
+        }
+
+        public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
+        {
+            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
+            {
+                return this;
+            }
+
+            return new ClassDeclaration(id, superClass, body, decorators).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ClassElement.cs
+++ b/src/Esprima/Ast/ClassElement.cs
@@ -17,7 +17,5 @@ namespace Esprima.Ast
 
         public Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => GetValue(); }
         protected abstract Expression? GetValue();
-
-        public override NodeCollection ChildNodes => new(Key, GetValue());
     }
 }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -29,18 +29,10 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
-            if (Id is not null)
-            {
-                yield return Id;
-            }
-
-            if (SuperClass is not null)
-            {
-                yield return SuperClass;
-            }
-
+            yield return Id;
+            yield return SuperClass;
             yield return Body;
 
             foreach (var node in Decorators)

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -29,21 +29,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        protected internal override object? Accept(AstVisitor visitor)
-        {
-            return visitor.VisitClassExpression(this);
-        }
-
-        public ClassExpression UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
-        {
-            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
-            {
-                return this;
-            }
-
-            return new ClassExpression(id, superClass, body, decorators).SetAdditionalInfo(this);
-        }
-
         private IEnumerable<Node> CreateChildNodes()
         {
             if (Id is not null)
@@ -62,6 +47,21 @@ namespace Esprima.Ast
             {
                 yield return node;
             }
+        }
+
+        protected internal override object? Accept(AstVisitor visitor)
+        {
+            return visitor.VisitClassExpression(this);
+        }
+
+        public ClassExpression UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
+        {
+            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
+            {
+                return this;
+            }
+
+            return new ClassExpression(id, superClass, body, decorators).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -27,13 +27,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
-            if (Exported is not null)
-            {
-                yield return Exported;
-            }
-
+            yield return Exported;
             yield return Source;
 
             foreach (var assertion in Assertions)

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -27,6 +27,21 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
+        private IEnumerable<Node> CreateChildNodes()
+        {
+            if (Exported is not null)
+            {
+                yield return Exported;
+            }
+
+            yield return Source;
+
+            foreach (var assertion in Assertions)
+            {
+                yield return assertion;
+            }
+        }
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitExportAllDeclaration(this);
@@ -40,21 +55,6 @@ namespace Esprima.Ast
             }
 
             return new ExportAllDeclaration(source, exported, assertions).SetAdditionalInfo(this);
-        }
-
-        private IEnumerable<Node> CreateChildNodes()
-        {
-            yield return Source;
-
-            if (Exported is not null)
-            {
-                yield return Exported;
-            }
-
-            foreach (var assertion in Assertions)
-            {
-                yield return assertion;
-            }
         }
     }
 }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -28,22 +28,16 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
-            if (Declaration is not null)
-            {
-                yield return Declaration;
-            }
+            yield return Declaration;
 
             foreach (var node in Specifiers)
             {
                 yield return node;
             }
 
-            if (Source is not null)
-            {
-                yield return Source;
-            }
+            yield return Source;
 
             foreach (var node in Assertions)
             {

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -28,21 +28,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        protected internal override object? Accept(AstVisitor visitor)
-        {
-            return visitor.VisitExportNamedDeclaration(this);
-        }
-
-        public ExportNamedDeclaration UpdateWith(StatementListItem? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> assertions)
-        {
-            if (declaration == Declaration && NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
-            {
-                return this;
-            }
-
-            return new ExportNamedDeclaration(declaration, specifiers, source, assertions).SetAdditionalInfo(this);
-        }
-
         private IEnumerable<Node> CreateChildNodes()
         {
             if (Declaration is not null)
@@ -64,6 +49,21 @@ namespace Esprima.Ast
             {
                 yield return node;
             }
+        }
+
+        protected internal override object? Accept(AstVisitor visitor)
+        {
+            return visitor.VisitExportNamedDeclaration(this);
+        }
+
+        public ExportNamedDeclaration UpdateWith(StatementListItem? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> assertions)
+        {
+            if (declaration == Declaration && NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
+            {
+                return this;
+            }
+
+            return new ExportNamedDeclaration(declaration, specifiers, source, assertions).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/GenericChildNodeYield.cs
+++ b/src/Esprima/Ast/GenericChildNodeYield.cs
@@ -8,31 +8,31 @@ namespace Esprima.Ast
     internal static class GenericChildNodeYield
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeCollection Yield<T>(Node? first, in NodeList<T> second, Node? third) where T : Node
+        public static NodeCollection Yield<T>(Node? first, in NodeList<T> second, Node? third) where T : Node?
         {
             return new NodeCollection(first, second._items, second._count, third);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeCollection Yield<T>(in NodeList<T> first) where T : Node
+        public static NodeCollection Yield<T>(in NodeList<T> first) where T : Node?
         {
             return new NodeCollection(first._items, first._count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeCollection Yield<T1, T2>(in NodeList<T1> first, in NodeList<T2> second) where T1 : Node where T2 : Node
+        public static NodeCollection Yield<T1, T2>(in NodeList<T1> first, in NodeList<T2> second) where T1 : Node? where T2 : Node?
         {
             return new NodeCollection(first._items, first._count, second._items, second._count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeCollection Yield<T>(Node? first, in NodeList<T> second) where T : Node
+        public static NodeCollection Yield<T>(Node? first, in NodeList<T> second) where T : Node?
         {
             return new NodeCollection(first, second._items, second._count);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static NodeCollection Yield<T>(in NodeList<T> first, Node? second) where T : Node
+        public static NodeCollection Yield<T>(in NodeList<T> first, Node? second) where T : Node?
         {
             return new NodeCollection(first._items, first._count, second);
         }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -25,21 +25,6 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        protected internal override object? Accept(AstVisitor visitor)
-        {
-            return visitor.VisitImportDeclaration(this);
-        }
-
-        public ImportDeclaration UpdateWith(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> assertions)
-        {
-            if (NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
-            {
-                return this;
-            }
-
-            return new ImportDeclaration(specifiers, source, assertions).SetAdditionalInfo(this);
-        }
-
         private IEnumerable<Node> CreateChildNodes()
         {
             foreach (var node in Specifiers)
@@ -53,6 +38,21 @@ namespace Esprima.Ast
             {
                 yield return node;
             }
+        }
+
+        protected internal override object? Accept(AstVisitor visitor)
+        {
+            return visitor.VisitImportDeclaration(this);
+        }
+
+        public ImportDeclaration UpdateWith(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> assertions)
+        {
+            if (NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
+            {
+                return this;
+            }
+
+            return new ImportDeclaration(specifiers, source, assertions).SetAdditionalInfo(this);
         }
     }
 }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -25,7 +25,7 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
             foreach (var node in Specifiers)
             {

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -18,7 +18,7 @@ public sealed class JsxElement : JsxExpression
     public Node? ClosingElement { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public ref readonly NodeList<JsxExpression> Children { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _children; }
 
-    public override NodeCollection ChildNodes => ClosingElement is null ? GenericChildNodeYield.Yield(OpeningElement, Children) : GenericChildNodeYield.Yield(OpeningElement, Children, ClosingElement);
+    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(OpeningElement, Children, ClosingElement);
 
     protected override object? Accept(IJsxAstVisitor visitor)
     {

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -27,6 +27,8 @@ namespace Esprima.Ast
         public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
+        public override NodeCollection ChildNodes => new(Key, Value);
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitMethodDefinition(this);

--- a/src/Esprima/Ast/NodeCollection.cs
+++ b/src/Esprima/Ast/NodeCollection.cs
@@ -1,6 +1,4 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
@@ -8,19 +6,19 @@ namespace Esprima.Ast
     /// <summary>
     /// Collection that enumerates nodes and node lists.
     /// </summary>
-    public readonly struct NodeCollection : IReadOnlyList<Node>
+    public readonly struct NodeCollection : IReadOnlyList<Node?>
     {
         internal static readonly NodeCollection Empty = new(0);
 
-        private readonly Node _first;
-        private readonly Node _second;
-        private readonly Node _third;
-        private readonly Node _fourth;
-        private readonly Node[] _list1;
+        private readonly Node? _first;
+        private readonly Node? _second;
+        private readonly Node? _third;
+        private readonly Node? _fourth;
+        private readonly Node?[]? _list1;
         private readonly int _list1Count;
-        private readonly Node[] _list2;
+        private readonly Node?[]? _list2;
         private readonly int _list2Count;
-        private readonly Node _fifth;
+        private readonly Node? _fifth;
         private readonly int _count;
 
         private readonly int _startNodeCount;
@@ -31,31 +29,31 @@ namespace Esprima.Ast
             _count = count;
         }
 
-        internal NodeCollection(Node first)
+        internal NodeCollection(Node? first)
             : this(first, null, null, null, null)
         {
             _count = _startNodeCount = 1;
         }
 
-        internal NodeCollection(Node first, Node second)
+        internal NodeCollection(Node? first, Node? second)
             : this(first, second, null, null, null)
         {
             _count = _startNodeCount = 2;
         }
 
-        internal NodeCollection(Node first, Node second, Node third)
+        internal NodeCollection(Node? first, Node? second, Node? third)
             : this(first, second, third, null, null)
         {
             _count = _startNodeCount = 3;
         }
 
-        internal NodeCollection(Node first, Node second, Node third, Node fourth)
+        internal NodeCollection(Node? first, Node? second, Node? third, Node? fourth)
             : this(first, second, third, fourth, null)
         {
             _count = _startNodeCount = 4;
         }
 
-        internal NodeCollection(Node[] first, int firstCount, Node second)
+        internal NodeCollection(Node?[]? first, int firstCount, Node? second)
             : this(null, null, null, null, second)
         {
             _list1 = first;
@@ -63,7 +61,7 @@ namespace Esprima.Ast
             _count = firstCount + 1;
         }
 
-        internal NodeCollection(Node first, Node[] second, int secondCount)
+        internal NodeCollection(Node? first, Node?[]? second, int secondCount)
             : this(first, null, null, null, null)
         {
             _startNodeCount = 1;
@@ -72,7 +70,7 @@ namespace Esprima.Ast
             _count = 1 + secondCount;
         }
 
-        internal NodeCollection(Node[] first, int firstCount, Node[] second, int secondCount)
+        internal NodeCollection(Node?[]? first, int firstCount, Node?[]? second, int secondCount)
             : this(null, null, null, null, null)
         {
             _list1 = first;
@@ -82,7 +80,7 @@ namespace Esprima.Ast
             _count = firstCount + secondCount;
         }
 
-        internal NodeCollection(Node first, Node[] second, int secondCount, Node third)
+        internal NodeCollection(Node? first, Node?[]? second, int secondCount, Node? third)
             : this(first, null, null, null, third)
         {
             _startNodeCount = 1;
@@ -91,7 +89,7 @@ namespace Esprima.Ast
             _count = 1 + secondCount + 1;
         }
 
-        internal NodeCollection(Node[] first, int firstCount)
+        internal NodeCollection(Node?[]? first, int firstCount)
             : this(null, null, null, null, null)
         {
             _list1 = first;
@@ -100,11 +98,11 @@ namespace Esprima.Ast
         }
 
         private NodeCollection(
-            Node first,
-            Node second,
-            Node third,
-            Node fourth,
-            Node fifth)
+            Node? first,
+            Node? second,
+            Node? third,
+            Node? fourth,
+            Node? fifth)
         {
             _startNodeCount = 0;
             _first = first;
@@ -125,7 +123,7 @@ namespace Esprima.Ast
 
         public int Count => _count;
 
-        public Node this[int index]
+        public Node? this[int index]
         {
             get
             {
@@ -152,13 +150,13 @@ namespace Esprima.Ast
                 index -= _startNodeCount;
                 if (index < _list1Count)
                 {
-                    return _list1[index];
+                    return _list1![index];
                 }
 
                 index -= _list1Count;
                 if (index < _list2Count)
                 {
-                    return _list2[index];
+                    return _list2![index];
                 }
 
                 return _fifth;
@@ -170,7 +168,7 @@ namespace Esprima.Ast
             return new Enumerator(this);
         }
 
-        IEnumerator<Node> IEnumerable<Node>.GetEnumerator()
+        IEnumerator<Node?> IEnumerable<Node?>.GetEnumerator()
         {
             return new Enumerator(this);
         }
@@ -180,11 +178,11 @@ namespace Esprima.Ast
             return GetEnumerator();
         }
 
-        public struct Enumerator : IEnumerator<Node>
+        public struct Enumerator : IEnumerator<Node?>
         {
             private readonly NodeCollection _collection;
             private int _index;
-            private Node _current;
+            private Node? _current;
 
             public Enumerator(in NodeCollection collection)
             {
@@ -210,9 +208,9 @@ namespace Esprima.Ast
                 return false;
             }
 
-            public Node Current => _current;
+            public Node? Current => _current;
 
-            object IEnumerator.Current => Current;
+            object? IEnumerator.Current => Current;
 
             void IEnumerator.Reset()
             {

--- a/src/Esprima/Ast/NodeList.cs
+++ b/src/Esprima/Ast/NodeList.cs
@@ -1,14 +1,12 @@
-﻿#nullable disable
-
-using System.Collections;
+﻿using System.Collections;
 using System.Runtime.CompilerServices;
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
 {
-    public readonly struct NodeList<T> : IReadOnlyList<T> where T : Node
+    public readonly struct NodeList<T> : IReadOnlyList<T> where T : Node?
     {
-        internal readonly T[] _items;
+        internal readonly T[]? _items;
         internal readonly int _count;
 
         internal NodeList(ICollection<T> collection)
@@ -22,7 +20,7 @@ namespace Esprima.Ast
             }
         }
 
-        internal NodeList(T[] items, int count)
+        internal NodeList(T[]? items, int count)
         {
             _items = items;
             _count = count;
@@ -34,9 +32,9 @@ namespace Esprima.Ast
             get => _count;
         }
 
-        public NodeList<Node> AsNodes()
+        public NodeList<Node?> AsNodes()
         {
-            return new NodeList<Node>(_items /* conversion by co-variance! */, _count);
+            return new NodeList<Node?>(_items /* conversion by co-variance! */, _count);
         }
 
         public T this[int index]
@@ -50,7 +48,7 @@ namespace Esprima.Ast
                     ThrowIndexOutOfRangeException();
                 }
 
-                return _items[index];
+                return _items![index];
             }
         }
 
@@ -76,13 +74,13 @@ namespace Esprima.Ast
         /// </remarks>
         public struct Enumerator : IEnumerator<T>
         {
-            private readonly T[] _items; // Usually null when count is zero
+            private readonly T[]? _items; // Usually null when count is zero
             private readonly int _count;
 
             private int _index;
-            private T _current;
+            private T? _current;
 
-            internal Enumerator(T[] items, int count) : this()
+            internal Enumerator(T[]? items, int count) : this()
             {
                 _index = 0;
                 _items = items;
@@ -97,7 +95,7 @@ namespace Esprima.Ast
             {
                 if (_index < _count)
                 {
-                    _current = _items[_index];
+                    _current = _items![_index];
                     _index++;
                     return true;
                 }
@@ -118,9 +116,9 @@ namespace Esprima.Ast
                 _current = default;
             }
 
-            public T Current => _current;
+            public T Current => _current!;
 
-            object IEnumerator.Current
+            object? IEnumerator.Current
             {
                 get
                 {
@@ -137,14 +135,14 @@ namespace Esprima.Ast
 
     public static class NodeList
     {
-        internal static NodeList<T> From<T>(ref ArrayList<T> arrayList) where T : Node
+        internal static NodeList<T> From<T>(ref ArrayList<T> arrayList) where T : Node?
         {
             arrayList.Yield(out var items, out var count);
             arrayList = default;
             return new NodeList<T>(items, count);
         }
 
-        public static NodeList<T> Create<T>(IEnumerable<T> source) where T : Node
+        public static NodeList<T> Create<T>(IEnumerable<T> source) where T : Node?
         {
             switch (source)
             {
@@ -205,7 +203,7 @@ namespace Esprima.Ast
             }
         }
 
-        internal static bool AreSame<T>(in NodeList<T> nodeList1, in NodeList<T> nodeList2) where T : Node
+        internal static bool AreSame<T>(in NodeList<T> nodeList1, in NodeList<T> nodeList2) where T : Node?
         {
             return nodeList1._items == nodeList2._items;
         }

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -27,6 +27,8 @@ namespace Esprima.Ast
         public bool Method { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public bool Shorthand { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
+        public override NodeCollection ChildNodes => new(Key, Value);
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitProperty(this);

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -28,14 +28,10 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
             yield return Key;
-
-            if (Value is not null)
-            {
-                yield return Value;
-            }
+            yield return Value;
 
             foreach (var node in Decorators)
             {

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -26,6 +26,23 @@ namespace Esprima.Ast
         public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
+
+        private IEnumerable<Node> CreateChildNodes()
+        {
+            yield return Key;
+
+            if (Value is not null)
+            {
+                yield return Value;
+            }
+
+            foreach (var node in Decorators)
+            {
+                yield return node;
+            }
+        }
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitPropertyDefinition(this);

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -22,6 +22,17 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
+        private IEnumerable<Node> CreateChildNodes()
+        {
+            TemplateElement quasi;
+            for (var i = 0; !(quasi = Quasis[i]).Tail; i++)
+            {
+                yield return quasi;
+                yield return Expressions[i];
+            }
+            yield return quasi;
+        }
+
         protected internal override object? Accept(AstVisitor visitor)
         {
             return visitor.VisitTemplateLiteral(this);
@@ -35,17 +46,6 @@ namespace Esprima.Ast
             }
 
             return new TemplateLiteral(quasis, expressions).SetAdditionalInfo(this);
-        }
-
-        private IEnumerable<Node> CreateChildNodes()
-        {
-            var i = 0;
-            while (!Quasis[i].Tail)
-            {
-                yield return Quasis[i];
-                yield return Expressions[i++];
-            }
-            yield return Quasis[i];
         }
     }
 }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -22,7 +22,7 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
-        private IEnumerable<Node> CreateChildNodes()
+        private IEnumerable<Node?> CreateChildNodes()
         {
             TemplateElement quasi;
             for (var i = 0; !(quasi = Quasis[i]).Tail; i++)

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -793,9 +793,7 @@ namespace Esprima
 
             Expect("]");
 
-#nullable disable
             return Finalize(node, new ArrayExpression(NodeList.From(ref elements)));
-#nullable enable
         }
 
         // https://tc39.github.io/ecma262/#sec-object-initializer
@@ -1183,9 +1181,7 @@ namespace Esprima
                         }
                     }
 
-#nullable disable
                     node = new ArrayPattern(NodeList.From(ref elements));
-#nullable enable
                     node._range = expr._range;
                     node._location = expr._location;
 
@@ -2686,9 +2682,7 @@ namespace Esprima
 
             Expect("]");
 
-#nullable disable
             return Finalize(node, new ArrayPattern(NodeList.From(ref elements)));
-#nullable enable
         }
 
         private Property ParsePropertyPattern(ref ArrayList<Token> parameters, VariableDeclarationKind? kind)

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -770,6 +770,10 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("value", propertyDefinition.Value);
                 Member("kind", propertyDefinition.Kind);
                 Member("static", propertyDefinition.Static);
+                if (propertyDefinition.Decorators.Count > 0)
+                {
+                    Member("decorators", propertyDefinition.Decorators);
+                }
             }
 
             return propertyDefinition;

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -327,6 +327,12 @@ public class AstVisitor
             Visit(propertyDefinition.Value);
         }
 
+        ref readonly var decorators = ref propertyDefinition.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
+
         return propertyDefinition;
     }
 
@@ -375,6 +381,12 @@ public class AstVisitor
         }
 
         Visit(classExpression.Body);
+
+        ref readonly var decorators = ref classExpression.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
 
         return classExpression;
     }
@@ -506,6 +518,12 @@ public class AstVisitor
         Visit(methodDefinition.Key);
         Visit(methodDefinition.Value);
 
+        ref readonly var decorators = ref methodDefinition.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
+
         return methodDefinition;
     }
 
@@ -531,6 +549,12 @@ public class AstVisitor
         }
 
         Visit(classDeclaration.Body);
+
+        ref readonly var decorators = ref classDeclaration.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
 
         return classDeclaration;
     }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -315,7 +315,8 @@ class aa {
             var script = parser.ParseScript();
 
             var variableDeclarations = script.ChildNodes
-                .SelectMany(z => z.DescendantNodesAndSelf().OfType<VariableDeclaration>())
+                .Where(node => node != null)
+                .SelectMany(z => z!.DescendantNodesAndSelf().OfType<VariableDeclaration>())
                 .ToList();
 
             Assert.Equal(8, variableDeclarations.Count);
@@ -329,6 +330,7 @@ class aa {
             var script = parser.ParseScript();
 
             var variableDeclarations = script.DescendantNodesAndSelf()
+                .Where(node => node != null)
                 .SelectMany(z => z.AncestorNodesAndSelf(script))
                 .ToList();
 
@@ -349,10 +351,10 @@ class aa {
             {
                 var raw = correctOrder[index];
                 var rawFromNode = GetRawItem(templateLiteral.ChildNodes[index]);
-                Assert.Equal(raw,rawFromNode);
+                Assert.Equal(raw, rawFromNode);
             }
 
-            static string? GetRawItem(Node item)
+            static string? GetRawItem(Node? item)
             {
                 if (item is TemplateElement element)
                 {


### PR DESCRIPTION
During the overhaul of AST, I noticed that `Node.ChildNodes` implementations are pretty inconsistent. This PR addresses this (at least, to some extent).

Besides some missing bits, the core of the issue is that the `ChildNodes` enumeration may contain `null` values in the current implementation: optional nodes are returned even if they are not available (see e.g. `ReturnStatement.Argument`) and the `Elements` node list of `ArrayExpression` and `ArrayPattern` may contain `null` values as well. As I see, Jint is already prepared for this but we should inform other consumers about this. Thus, I revised the nullability annotations of `NodeList<T>` and `NodeCollection`.

(TBH, it'd be better if null values were not returned at all but that change would be a major pain which I don't have the time for ATM.)
