### PR TITLE
Fix incorrect range and location of dynamic import expressions

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1561,7 +1561,7 @@ namespace Esprima
                 NextToken();
                 attributes = ParseObjectInitializer();
             }
-            
+
             _context.IsAssignmentTarget = previousIsAssignmentTarget;
 
             if (!this.Match(")") && this._config.Tolerant)
@@ -1571,10 +1571,6 @@ namespace Esprima
             else
             {
                 this.Expect(")");
-                if (this.Match(";"))
-                {
-                    this.NextToken();
-                }
             }
 
             return Finalize(node, new Import(source, attributes));

--- a/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.js
+++ b/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.js
@@ -1,0 +1,1 @@
+var x = import ('url') ;

--- a/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.tree.json
@@ -1,0 +1,112 @@
+{
+  "type": "Program",
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "id": {
+            "type": "Identifier",
+            "name": "x",
+            "range": [
+              4,
+              5
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 4
+              },
+              "end": {
+                "line": 1,
+                "column": 5
+              }
+            }
+          },
+          "init": {
+            "type": "Import",
+            "source": {
+              "type": "Literal",
+              "value": "url",
+              "raw": "'url'",
+              "range": [
+                16,
+                21
+              ],
+              "loc": {
+                "start": {
+                  "line": 1,
+                  "column": 16
+                },
+                "end": {
+                  "line": 1,
+                  "column": 21
+                }
+              }
+            },
+            "range": [
+              8,
+              22
+            ],
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 8
+              },
+              "end": {
+                "line": 1,
+                "column": 22
+              }
+            }
+          },
+          "range": [
+            4,
+            22
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 4
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          }
+        }
+      ],
+      "kind": "var",
+      "range": [
+        0,
+        24
+      ],
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 24
+        }
+      }
+    }
+  ],
+  "sourceType": "script",
+  "strict": false,
+  "range": [
+    0,
+    24
+  ],
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 1,
+      "column": 24
+    }
+  }
+}


### PR DESCRIPTION
As the AST and visitor APIs are taking shape, I've started dogfooding the recent changes in my project. According to my tests everything works nicely except for one thing:

The range and location of dynamic import expressions are off in cases where they are contained in a statement which is terminated by `;`. It looks like a bug because earlier versions (which used `CallExpression` for representing dynamic imports) gave correct results.

I've made an attempt to fix the issue.