### PR TITLE
Sort VisitXXX methods alphabetically

### DIFF
--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -352,241 +352,24 @@ public class AstToJsonConverter : AstJson.IConverter
             }
         }
 
-        protected internal override object? VisitProgram(Program program)
+        protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
         {
-            using (StartNodeObject(program))
+            using (StartNodeObject(arrayExpression))
             {
-                Member("body", program.Body, e => (Node) e);
-                Member("sourceType", program.SourceType);
-
-                // original Esprima doesn't include this information yet
-                if (!_testCompatibilityMode && program is Script s)
-                {
-                    Member("strict", s.Strict);
-                }
+                Member("elements", arrayExpression.Elements);
             }
 
-            return program;
+            return arrayExpression;
         }
 
-        protected internal override object? VisitExtension(Node node)
+        protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
         {
-            throw new NotSupportedException("Unknown node type: " + node.Type);
-        }
-
-        protected internal override object? VisitCatchClause(CatchClause catchClause)
-        {
-            using (StartNodeObject(catchClause))
+            using (StartNodeObject(arrayPattern))
             {
-                Member("param", catchClause.Param);
-                Member("body", catchClause.Body);
+                Member("elements", arrayPattern.Elements);
             }
 
-            return catchClause;
-        }
-
-        protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
-        {
-            using (StartNodeObject(functionDeclaration))
-            {
-                Member("id", functionDeclaration.Id);
-                Member("params", functionDeclaration.Params);
-                Member("body", functionDeclaration.Body);
-                Member("generator", functionDeclaration.Generator);
-                Member("expression", ((IFunction) functionDeclaration).Expression);
-                // original Esprima doesn't include this information yet
-                if (!_testCompatibilityMode)
-                {
-                    Member("strict", functionDeclaration.Strict);
-                }
-                Member("async", functionDeclaration.Async);
-            }
-
-            return functionDeclaration;
-        }
-
-        protected internal override object? VisitWithStatement(WithStatement withStatement)
-        {
-            using (StartNodeObject(withStatement))
-            {
-                Member("object", withStatement.Object);
-                Member("body", withStatement.Body);
-            }
-
-            return withStatement;
-        }
-
-        protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
-        {
-            using (StartNodeObject(whileStatement))
-            {
-                Member("test", whileStatement.Test);
-                Member("body", whileStatement.Body);
-            }
-
-            return whileStatement;
-        }
-
-        protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
-        {
-            using (StartNodeObject(variableDeclaration))
-            {
-                Member("declarations", variableDeclaration.Declarations);
-                Member("kind", variableDeclaration.Kind);
-            }
-
-            return variableDeclaration;
-        }
-
-        protected internal override object? VisitTryStatement(TryStatement tryStatement)
-        {
-            using (StartNodeObject(tryStatement))
-            {
-                Member("block", tryStatement.Block);
-                Member("handler", tryStatement.Handler);
-                Member("finalizer", tryStatement.Finalizer);
-            }
-
-            return tryStatement;
-        }
-
-        protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
-        {
-            using (StartNodeObject(throwStatement))
-            {
-                Member("argument", throwStatement.Argument);
-            }
-
-            return throwStatement;
-        }
-
-        protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
-        {
-            using (StartNodeObject(awaitExpression))
-            {
-                Member("argument", awaitExpression.Argument);
-            }
-
-            return awaitExpression;
-        }
-
-        protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
-        {
-            using (StartNodeObject(switchStatement))
-            {
-                Member("discriminant", switchStatement.Discriminant);
-                Member("cases", switchStatement.Cases);
-            }
-
-            return switchStatement;
-        }
-
-        protected internal override object? VisitSwitchCase(SwitchCase switchCase)
-        {
-            using (StartNodeObject(switchCase))
-            {
-                Member("test", switchCase.Test);
-                Member("consequent", switchCase.Consequent, e => (Node) e);
-            }
-
-            return switchCase;
-        }
-
-        protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
-        {
-            using (StartNodeObject(returnStatement))
-            {
-                Member("argument", returnStatement.Argument);
-            }
-
-            return returnStatement;
-        }
-
-        protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
-        {
-            using (StartNodeObject(labeledStatement))
-            {
-                Member("label", labeledStatement.Label);
-                Member("body", labeledStatement.Body);
-            }
-
-            return labeledStatement;
-        }
-
-        protected internal override object? VisitIfStatement(IfStatement ifStatement)
-        {
-            using (StartNodeObject(ifStatement))
-            {
-                Member("test", ifStatement.Test);
-                Member("consequent", ifStatement.Consequent);
-                Member("alternate", ifStatement.Alternate);
-            }
-
-            return ifStatement;
-        }
-
-        protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
-        {
-            EmptyNodeObject(emptyStatement);
-            return emptyStatement;
-        }
-
-        protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
-        {
-            EmptyNodeObject(debuggerStatement);
-            return debuggerStatement;
-        }
-
-        protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
-        {
-            using (StartNodeObject(expressionStatement))
-            {
-                if (expressionStatement is Directive d)
-                {
-                    Member("directive", d.Directiv);
-                }
-
-                Member("expression", expressionStatement.Expression);
-            }
-
-            return expressionStatement;
-        }
-
-        protected internal override object? VisitForStatement(ForStatement forStatement)
-        {
-            using (StartNodeObject(forStatement))
-            {
-                Member("init", forStatement.Init);
-                Member("test", forStatement.Test);
-                Member("update", forStatement.Update);
-                Member("body", forStatement.Body);
-            }
-
-            return forStatement;
-        }
-
-        protected internal override object? VisitForInStatement(ForInStatement forInStatement)
-        {
-            using (StartNodeObject(forInStatement))
-            {
-                Member("left", forInStatement.Left);
-                Member("right", forInStatement.Right);
-                Member("body", forInStatement.Body);
-                Member("each", false);
-            }
-
-            return forInStatement;
-        }
-
-        protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
-        {
-            using (StartNodeObject(doWhileStatement))
-            {
-                Member("body", doWhileStatement.Body);
-                Member("test", doWhileStatement.Test);
-            }
-
-            return doWhileStatement;
+            return arrayPattern;
         }
 
         protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
@@ -609,189 +392,128 @@ public class AstToJsonConverter : AstJson.IConverter
             return arrowFunctionExpression;
         }
 
-        protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
         {
-            using (StartNodeObject(unaryExpression))
+            using (StartNodeObject(assignmentExpression))
             {
-                Member("operator", unaryExpression.Operator);
-                Member("argument", unaryExpression.Argument);
-                Member("prefix", unaryExpression.Prefix);
+                Member("operator", assignmentExpression.Operator);
+                Member("left", assignmentExpression.Left);
+                Member("right", assignmentExpression.Right);
             }
 
-            return unaryExpression;
+            return assignmentExpression;
         }
 
-        protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+        protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
         {
-            EmptyNodeObject(thisExpression);
-            return thisExpression;
-        }
-
-        protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
-        {
-            using (StartNodeObject(sequenceExpression))
+            using (StartNodeObject(assignmentPattern))
             {
-                Member("expressions", sequenceExpression.Expressions);
+                Member("left", assignmentPattern.Left);
+                Member("right", assignmentPattern.Right);
             }
 
-            return sequenceExpression;
+            return assignmentPattern;
         }
 
-        protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+        protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
         {
-            using (StartNodeObject(objectExpression))
+            using (StartNodeObject(awaitExpression))
             {
-                Member("properties", objectExpression.Properties);
+                Member("argument", awaitExpression.Argument);
             }
 
-            return objectExpression;
+            return awaitExpression;
         }
 
-        protected internal override object? VisitNewExpression(NewExpression newExpression)
+        protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
         {
-            using (StartNodeObject(newExpression))
+            using (StartNodeObject(binaryExpression))
             {
-                Member("callee", newExpression.Callee);
-                Member("arguments", newExpression.Arguments, e => (Node) e);
+                Member("operator", binaryExpression.Operator);
+                Member("left", binaryExpression.Left);
+                Member("right", binaryExpression.Right);
             }
 
-            return newExpression;
+            return binaryExpression;
         }
 
-        protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+        protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
         {
-            using (StartNodeObject(memberExpression))
+            using (StartNodeObject(blockStatement))
             {
-                Member("computed", memberExpression.Computed);
-                Member("object", memberExpression.Object);
-                Member("property", memberExpression.Property);
-                Member("optional", memberExpression.Optional);
+                Member("body", blockStatement.Body, e => (Statement) e);
             }
 
-            return memberExpression;
+            return blockStatement;
         }
 
-        protected internal override object? VisitLiteral(Literal literal)
+        protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
         {
-            using (StartNodeObject(literal))
+            using (StartNodeObject(breakStatement))
             {
-                _writer.Member("value");
-                var value = literal.Value;
+                Member("label", breakStatement.Label);
+            }
 
-                switch (value)
+            return breakStatement;
+        }
+
+        protected internal override object? VisitCallExpression(CallExpression callExpression)
+        {
+            using (StartNodeObject(callExpression))
+            {
+                Member("callee", callExpression.Callee);
+                Member("arguments", callExpression.Arguments, e => e);
+                Member("optional", callExpression.Optional);
+            }
+
+            return callExpression;
+        }
+
+        protected internal override object? VisitCatchClause(CatchClause catchClause)
+        {
+            using (StartNodeObject(catchClause))
+            {
+                Member("param", catchClause.Param);
+                Member("body", catchClause.Body);
+            }
+
+            return catchClause;
+        }
+
+        protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+        {
+            using (StartNodeObject(chainExpression))
+            {
+                Member("expression", chainExpression.Expression);
+            }
+
+            return chainExpression;
+        }
+
+        protected internal override object? VisitClassBody(ClassBody classBody)
+        {
+            using (StartNodeObject(classBody))
+            {
+                Member("body", classBody.Body);
+            }
+
+            return classBody;
+        }
+
+        protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+        {
+            using (StartNodeObject(classDeclaration))
+            {
+                Member("id", classDeclaration.Id);
+                Member("superClass", classDeclaration.SuperClass);
+                Member("body", classDeclaration.Body);
+                if (classDeclaration.Decorators.Count > 0)
                 {
-                    case null:
-                        if (!_testCompatibilityMode && literal.TokenType == TokenType.RegularExpression)
-                        {
-                            // This is how esprima.org actually renders regexes since it relies on Regex.toString
-                            _writer.String(literal.Raw);
-                        }
-                        else
-                        {
-                            _writer.Null();
-                        }
-
-                        break;
-                    case bool b:
-                        _writer.Boolean(b);
-                        break;
-                    case Regex _:
-                        _writer.StartObject();
-                        _writer.EndObject();
-                        break;
-                    case double d:
-                        _writer.Number(d);
-                        break;
-                    default:
-                        _writer.String(Convert.ToString(value, CultureInfo.InvariantCulture));
-                        break;
-                }
-
-                Member("raw", literal.Raw);
-
-                if (literal.Regex != null)
-                {
-                    _writer.Member("regex");
-                    _writer.StartObject();
-                    Member("pattern", literal.Regex.Pattern);
-                    Member("flags", literal.Regex.Flags);
-                    _writer.EndObject();
-                }
-                else if (literal.Value is BigInteger bigInt)
-                {
-                    Member("bigint", bigInt.ToString(CultureInfo.InvariantCulture));
-                }
-            }
-
-            return literal;
-        }
-
-        protected internal override object? VisitIdentifier(Identifier identifier)
-        {
-            using (StartNodeObject(identifier))
-            {
-                Member("name", identifier.Name);
-            }
-
-            return identifier;
-        }
-
-        protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
-        {
-            using (StartNodeObject(privateIdentifier))
-            {
-                Member("name", privateIdentifier.Name);
-            }
-
-            return privateIdentifier;
-        }
-
-        protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
-        {
-            using (StartNodeObject(functionExpression))
-            {
-                Member("id", functionExpression.Id);
-                Member("params", functionExpression.Params);
-                Member("body", functionExpression.Body);
-                Member("generator", functionExpression.Generator);
-                Member("expression", ((IFunction) functionExpression).Expression);
-                // original Esprima doesn't include this information yet
-                if (!_testCompatibilityMode)
-                {
-                    Member("strict", functionExpression.Strict);
-                }
-                Member("async", functionExpression.Async);
-            }
-
-            return functionExpression;
-        }
-
-        protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
-        {
-            using (StartNodeObject(propertyDefinition))
-            {
-                Member("key", propertyDefinition.Key);
-                Member("computed", propertyDefinition.Computed);
-                Member("value", propertyDefinition.Value);
-                Member("kind", propertyDefinition.Kind);
-                Member("static", propertyDefinition.Static);
-                if (propertyDefinition.Decorators.Count > 0)
-                {
-                    Member("decorators", propertyDefinition.Decorators);
+                    Member("decorators", classDeclaration.Decorators);
                 }
             }
 
-            return propertyDefinition;
-        }
-
-        protected internal override object? VisitDecorator(Decorator decorator)
-        {
-            using (StartNodeObject(decorator))
-            {
-                Member("expression", decorator.Expression);
-            }
-
-            return decorator;
+            return classDeclaration;
         }
 
         protected internal override object? VisitClassExpression(ClassExpression classExpression)
@@ -810,24 +532,59 @@ public class AstToJsonConverter : AstJson.IConverter
             return classExpression;
         }
 
-        protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+        protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
         {
-            using (StartNodeObject(chainExpression))
+            using (StartNodeObject(conditionalExpression))
             {
-                Member("expression", chainExpression.Expression);
+                Member("test", conditionalExpression.Test);
+                Member("consequent", conditionalExpression.Consequent);
+                Member("alternate", conditionalExpression.Alternate);
             }
 
-            return chainExpression;
+            return conditionalExpression;
         }
 
-        protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
         {
-            using (StartNodeObject(exportDefaultDeclaration))
+            using (StartNodeObject(continueStatement))
             {
-                Member("declaration", exportDefaultDeclaration.Declaration);
+                Member("label", continueStatement.Label);
             }
 
-            return exportDefaultDeclaration;
+            return continueStatement;
+        }
+
+        protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        {
+            EmptyNodeObject(debuggerStatement);
+            return debuggerStatement;
+        }
+
+        protected internal override object? VisitDecorator(Decorator decorator)
+        {
+            using (StartNodeObject(decorator))
+            {
+                Member("expression", decorator.Expression);
+            }
+
+            return decorator;
+        }
+
+        protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        {
+            using (StartNodeObject(doWhileStatement))
+            {
+                Member("body", doWhileStatement.Body);
+                Member("test", doWhileStatement.Test);
+            }
+
+            return doWhileStatement;
+        }
+
+        protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
+        {
+            EmptyNodeObject(emptyStatement);
+            return emptyStatement;
         }
 
         protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
@@ -848,6 +605,16 @@ public class AstToJsonConverter : AstJson.IConverter
             }
 
             return exportAllDeclaration;
+        }
+
+        protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        {
+            using (StartNodeObject(exportDefaultDeclaration))
+            {
+                Member("declaration", exportDefaultDeclaration.Declaration);
+            }
+
+            return exportDefaultDeclaration;
         }
 
         protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
@@ -878,22 +645,143 @@ public class AstToJsonConverter : AstJson.IConverter
             return exportSpecifier;
         }
 
-        private sealed class ImportCompat : Expression
+        protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
         {
-            public ImportCompat() : base(Nodes.Import) { }
-
-            public override NodeCollection ChildNodes => NodeCollection.Empty;
-
-            protected internal override object? Accept(AstVisitor visitor)
+            using (StartNodeObject(expressionStatement))
             {
-                return ((VisitorBase) visitor).VisitImportCompat(this);
+                if (expressionStatement is Directive d)
+                {
+                    Member("directive", d.Directiv);
+                }
+
+                Member("expression", expressionStatement.Expression);
             }
+
+            return expressionStatement;
+        }
+
+        protected internal override object? VisitExtension(Node node)
+        {
+            throw new NotSupportedException("Unknown node type: " + node.Type);
+        }
+
+        protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+        {
+            using (StartNodeObject(forInStatement))
+            {
+                Member("left", forInStatement.Left);
+                Member("right", forInStatement.Right);
+                Member("body", forInStatement.Body);
+                Member("each", false);
+            }
+
+            return forInStatement;
+        }
+
+        protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+        {
+            using (StartNodeObject(forOfStatement))
+            {
+                Member("await", forOfStatement.Await);
+                Member("left", forOfStatement.Left);
+                Member("right", forOfStatement.Right);
+                Member("body", forOfStatement.Body);
+            }
+
+            return forOfStatement;
+        }
+
+        protected internal override object? VisitForStatement(ForStatement forStatement)
+        {
+            using (StartNodeObject(forStatement))
+            {
+                Member("init", forStatement.Init);
+                Member("test", forStatement.Test);
+                Member("update", forStatement.Update);
+                Member("body", forStatement.Body);
+            }
+
+            return forStatement;
+        }
+
+        protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        {
+            using (StartNodeObject(functionDeclaration))
+            {
+                Member("id", functionDeclaration.Id);
+                Member("params", functionDeclaration.Params);
+                Member("body", functionDeclaration.Body);
+                Member("generator", functionDeclaration.Generator);
+                Member("expression", ((IFunction) functionDeclaration).Expression);
+                // original Esprima doesn't include this information yet
+                if (!_testCompatibilityMode)
+                {
+                    Member("strict", functionDeclaration.Strict);
+                }
+                Member("async", functionDeclaration.Async);
+            }
+
+            return functionDeclaration;
+        }
+
+        protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+        {
+            using (StartNodeObject(functionExpression))
+            {
+                Member("id", functionExpression.Id);
+                Member("params", functionExpression.Params);
+                Member("body", functionExpression.Body);
+                Member("generator", functionExpression.Generator);
+                Member("expression", ((IFunction) functionExpression).Expression);
+                // original Esprima doesn't include this information yet
+                if (!_testCompatibilityMode)
+                {
+                    Member("strict", functionExpression.Strict);
+                }
+                Member("async", functionExpression.Async);
+            }
+
+            return functionExpression;
+        }
+
+        protected internal override object? VisitIdentifier(Identifier identifier)
+        {
+            using (StartNodeObject(identifier))
+            {
+                Member("name", identifier.Name);
+            }
+
+            return identifier;
+        }
+
+        protected internal override object? VisitIfStatement(IfStatement ifStatement)
+        {
+            using (StartNodeObject(ifStatement))
+            {
+                Member("test", ifStatement.Test);
+                Member("consequent", ifStatement.Consequent);
+                Member("alternate", ifStatement.Alternate);
+            }
+
+            return ifStatement;
         }
 
         private object? VisitImportCompat(ImportCompat import)
         {
             EmptyNodeObject(import);
             return import;
+        }
+
+        private sealed class ImportCompat : Expression
+        {
+            protected internal override object? Accept(AstVisitor visitor)
+            {
+                return ((VisitorBase) visitor).VisitImportCompat(this);
+            }
+
+            public ImportCompat() : base(Nodes.Import) { }
+
+            public override NodeCollection ChildNodes => NodeCollection.Empty;
         }
 
         protected internal override object? VisitImport(Import import)
@@ -962,16 +850,6 @@ public class AstToJsonConverter : AstJson.IConverter
             return importDeclaration;
         }
 
-        protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
-        {
-            using (StartNodeObject(importNamespaceSpecifier))
-            {
-                Member("local", importNamespaceSpecifier.Local);
-            }
-
-            return importNamespaceSpecifier;
-        }
-
         protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
         {
             using (StartNodeObject(importDefaultSpecifier))
@@ -980,6 +858,16 @@ public class AstToJsonConverter : AstJson.IConverter
             }
 
             return importDefaultSpecifier;
+        }
+
+        protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        {
+            using (StartNodeObject(importNamespaceSpecifier))
+            {
+                Member("local", importNamespaceSpecifier.Local);
+            }
+
+            return importNamespaceSpecifier;
         }
 
         protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
@@ -991,6 +879,96 @@ public class AstToJsonConverter : AstJson.IConverter
             }
 
             return importSpecifier;
+        }
+
+        protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+        {
+            using (StartNodeObject(labeledStatement))
+            {
+                Member("label", labeledStatement.Label);
+                Member("body", labeledStatement.Body);
+            }
+
+            return labeledStatement;
+        }
+
+        protected internal override object? VisitLiteral(Literal literal)
+        {
+            using (StartNodeObject(literal))
+            {
+                _writer.Member("value");
+                var value = literal.Value;
+
+                switch (value)
+                {
+                    case null:
+                        if (!_testCompatibilityMode && literal.TokenType == TokenType.RegularExpression)
+                        {
+                            // This is how esprima.org actually renders regexes since it relies on Regex.toString
+                            _writer.String(literal.Raw);
+                        }
+                        else
+                        {
+                            _writer.Null();
+                        }
+
+                        break;
+                    case bool b:
+                        _writer.Boolean(b);
+                        break;
+                    case Regex _:
+                        _writer.StartObject();
+                        _writer.EndObject();
+                        break;
+                    case double d:
+                        _writer.Number(d);
+                        break;
+                    default:
+                        _writer.String(Convert.ToString(value, CultureInfo.InvariantCulture));
+                        break;
+                }
+
+                Member("raw", literal.Raw);
+
+                if (literal.Regex != null)
+                {
+                    _writer.Member("regex");
+                    _writer.StartObject();
+                    Member("pattern", literal.Regex.Pattern);
+                    Member("flags", literal.Regex.Flags);
+                    _writer.EndObject();
+                }
+                else if (literal.Value is BigInteger bigInt)
+                {
+                    Member("bigint", bigInt.ToString(CultureInfo.InvariantCulture));
+                }
+            }
+
+            return literal;
+        }
+
+        protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+        {
+            using (StartNodeObject(memberExpression))
+            {
+                Member("computed", memberExpression.Computed);
+                Member("object", memberExpression.Object);
+                Member("property", memberExpression.Property);
+                Member("optional", memberExpression.Optional);
+            }
+
+            return memberExpression;
+        }
+
+        protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+        {
+            using (StartNodeObject(metaProperty))
+            {
+                Member("meta", metaProperty.Meta);
+                Member("property", metaProperty.Property);
+            }
+
+            return metaProperty;
         }
 
         protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
@@ -1011,82 +989,25 @@ public class AstToJsonConverter : AstJson.IConverter
             return methodDefinition;
         }
 
-        protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+        protected internal override object? VisitNewExpression(NewExpression newExpression)
         {
-            using (StartNodeObject(forOfStatement))
+            using (StartNodeObject(newExpression))
             {
-                Member("await", forOfStatement.Await);
-                Member("left", forOfStatement.Left);
-                Member("right", forOfStatement.Right);
-                Member("body", forOfStatement.Body);
+                Member("callee", newExpression.Callee);
+                Member("arguments", newExpression.Arguments, e => (Node) e);
             }
 
-            return forOfStatement;
+            return newExpression;
         }
 
-        protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
         {
-            using (StartNodeObject(classDeclaration))
+            using (StartNodeObject(objectExpression))
             {
-                Member("id", classDeclaration.Id);
-                Member("superClass", classDeclaration.SuperClass);
-                Member("body", classDeclaration.Body);
-                if (classDeclaration.Decorators.Count > 0)
-                {
-                    Member("decorators", classDeclaration.Decorators);
-                }
+                Member("properties", objectExpression.Properties);
             }
 
-            return classDeclaration;
-        }
-
-        protected internal override object? VisitClassBody(ClassBody classBody)
-        {
-            using (StartNodeObject(classBody))
-            {
-                Member("body", classBody.Body);
-            }
-
-            return classBody;
-        }
-
-        protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
-        {
-            using (StartNodeObject(yieldExpression))
-            {
-                Member("argument", yieldExpression.Argument);
-                Member("delegate", yieldExpression.Delegate);
-            }
-
-            return yieldExpression;
-        }
-
-        protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
-        {
-            using (StartNodeObject(taggedTemplateExpression))
-            {
-                Member("tag", taggedTemplateExpression.Tag);
-                Member("quasi", taggedTemplateExpression.Quasi);
-            }
-
-            return taggedTemplateExpression;
-        }
-
-        protected internal override object? VisitSuper(Super super)
-        {
-            EmptyNodeObject(super);
-            return super;
-        }
-
-        protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
-        {
-            using (StartNodeObject(metaProperty))
-            {
-                Member("meta", metaProperty.Meta);
-                Member("property", metaProperty.Property);
-            }
-
-            return metaProperty;
+            return objectExpression;
         }
 
         protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
@@ -1099,82 +1020,31 @@ public class AstToJsonConverter : AstJson.IConverter
             return objectPattern;
         }
 
-        protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+        protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
         {
-            using (StartNodeObject(spreadElement))
+            using (StartNodeObject(privateIdentifier))
             {
-                Member("argument", spreadElement.Argument);
+                Member("name", privateIdentifier.Name);
             }
 
-            return spreadElement;
+            return privateIdentifier;
         }
 
-        protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected internal override object? VisitProgram(Program program)
         {
-            using (StartNodeObject(assignmentPattern))
+            using (StartNodeObject(program))
             {
-                Member("left", assignmentPattern.Left);
-                Member("right", assignmentPattern.Right);
+                Member("body", program.Body, e => (Node) e);
+                Member("sourceType", program.SourceType);
+
+                // original Esprima doesn't include this information yet
+                if (!_testCompatibilityMode && program is Script s)
+                {
+                    Member("strict", s.Strict);
+                }
             }
 
-            return assignmentPattern;
-        }
-
-        protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
-        {
-            using (StartNodeObject(arrayPattern))
-            {
-                Member("elements", arrayPattern.Elements);
-            }
-
-            return arrayPattern;
-        }
-
-        protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
-        {
-            using (StartNodeObject(variableDeclarator))
-            {
-                Member("id", variableDeclarator.Id);
-                Member("init", variableDeclarator.Init);
-            }
-
-            return variableDeclarator;
-        }
-
-        protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
-        {
-            using (StartNodeObject(templateLiteral))
-            {
-                Member("quasis", templateLiteral.Quasis);
-                Member("expressions", templateLiteral.Expressions);
-            }
-
-            return templateLiteral;
-        }
-
-        protected internal override object? VisitTemplateElement(TemplateElement templateElement)
-        {
-            using (StartNodeObject(templateElement))
-            {
-                _writer.Member("value");
-                _writer.StartObject();
-                Member("raw", templateElement.Value.Raw);
-                Member("cooked", templateElement.Value.Cooked);
-                _writer.EndObject();
-                Member("tail", templateElement.Tail);
-            }
-
-            return templateElement;
-        }
-
-        protected internal override object? VisitRestElement(RestElement restElement)
-        {
-            using (StartNodeObject(restElement))
-            {
-                Member("argument", restElement.Argument);
-            }
-
-            return restElement;
+            return program;
         }
 
         protected internal override object? VisitProperty(Property property)
@@ -1192,92 +1062,62 @@ public class AstToJsonConverter : AstJson.IConverter
             return property;
         }
 
-        protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
         {
-            using (StartNodeObject(conditionalExpression))
+            using (StartNodeObject(propertyDefinition))
             {
-                Member("test", conditionalExpression.Test);
-                Member("consequent", conditionalExpression.Consequent);
-                Member("alternate", conditionalExpression.Alternate);
+                Member("key", propertyDefinition.Key);
+                Member("computed", propertyDefinition.Computed);
+                Member("value", propertyDefinition.Value);
+                Member("kind", propertyDefinition.Kind);
+                Member("static", propertyDefinition.Static);
+                if (propertyDefinition.Decorators.Count > 0)
+                {
+                    Member("decorators", propertyDefinition.Decorators);
+                }
             }
 
-            return conditionalExpression;
+            return propertyDefinition;
         }
 
-        protected internal override object? VisitCallExpression(CallExpression callExpression)
+        protected internal override object? VisitRestElement(RestElement restElement)
         {
-            using (StartNodeObject(callExpression))
+            using (StartNodeObject(restElement))
             {
-                Member("callee", callExpression.Callee);
-                Member("arguments", callExpression.Arguments, e => e);
-                Member("optional", callExpression.Optional);
+                Member("argument", restElement.Argument);
             }
 
-            return callExpression;
+            return restElement;
         }
 
-        protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
         {
-            using (StartNodeObject(binaryExpression))
+            using (StartNodeObject(returnStatement))
             {
-                Member("operator", binaryExpression.Operator);
-                Member("left", binaryExpression.Left);
-                Member("right", binaryExpression.Right);
+                Member("argument", returnStatement.Argument);
             }
 
-            return binaryExpression;
+            return returnStatement;
         }
 
-        protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+        protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
         {
-            using (StartNodeObject(arrayExpression))
+            using (StartNodeObject(sequenceExpression))
             {
-                Member("elements", arrayExpression.Elements);
+                Member("expressions", sequenceExpression.Expressions);
             }
 
-            return arrayExpression;
+            return sequenceExpression;
         }
 
-        protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
         {
-            using (StartNodeObject(assignmentExpression))
+            using (StartNodeObject(spreadElement))
             {
-                Member("operator", assignmentExpression.Operator);
-                Member("left", assignmentExpression.Left);
-                Member("right", assignmentExpression.Right);
+                Member("argument", spreadElement.Argument);
             }
 
-            return assignmentExpression;
-        }
-
-        protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
-        {
-            using (StartNodeObject(continueStatement))
-            {
-                Member("label", continueStatement.Label);
-            }
-
-            return continueStatement;
-        }
-
-        protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
-        {
-            using (StartNodeObject(breakStatement))
-            {
-                Member("label", breakStatement.Label);
-            }
-
-            return breakStatement;
-        }
-
-        protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
-        {
-            using (StartNodeObject(blockStatement))
-            {
-                Member("body", blockStatement.Body, e => (Statement) e);
-            }
-
-            return blockStatement;
+            return spreadElement;
         }
 
         protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
@@ -1288,6 +1128,166 @@ public class AstToJsonConverter : AstJson.IConverter
             }
 
             return staticBlock;
+        }
+
+        protected internal override object? VisitSuper(Super super)
+        {
+            EmptyNodeObject(super);
+            return super;
+        }
+
+        protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+        {
+            using (StartNodeObject(switchCase))
+            {
+                Member("test", switchCase.Test);
+                Member("consequent", switchCase.Consequent, e => (Node) e);
+            }
+
+            return switchCase;
+        }
+
+        protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+        {
+            using (StartNodeObject(switchStatement))
+            {
+                Member("discriminant", switchStatement.Discriminant);
+                Member("cases", switchStatement.Cases);
+            }
+
+            return switchStatement;
+        }
+
+        protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        {
+            using (StartNodeObject(taggedTemplateExpression))
+            {
+                Member("tag", taggedTemplateExpression.Tag);
+                Member("quasi", taggedTemplateExpression.Quasi);
+            }
+
+            return taggedTemplateExpression;
+        }
+
+        protected internal override object? VisitTemplateElement(TemplateElement templateElement)
+        {
+            using (StartNodeObject(templateElement))
+            {
+                _writer.Member("value");
+                _writer.StartObject();
+                Member("raw", templateElement.Value.Raw);
+                Member("cooked", templateElement.Value.Cooked);
+                _writer.EndObject();
+                Member("tail", templateElement.Tail);
+            }
+
+            return templateElement;
+        }
+
+        protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        {
+            using (StartNodeObject(templateLiteral))
+            {
+                Member("quasis", templateLiteral.Quasis);
+                Member("expressions", templateLiteral.Expressions);
+            }
+
+            return templateLiteral;
+        }
+
+        protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+        {
+            EmptyNodeObject(thisExpression);
+            return thisExpression;
+        }
+
+        protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+        {
+            using (StartNodeObject(throwStatement))
+            {
+                Member("argument", throwStatement.Argument);
+            }
+
+            return throwStatement;
+        }
+
+        protected internal override object? VisitTryStatement(TryStatement tryStatement)
+        {
+            using (StartNodeObject(tryStatement))
+            {
+                Member("block", tryStatement.Block);
+                Member("handler", tryStatement.Handler);
+                Member("finalizer", tryStatement.Finalizer);
+            }
+
+            return tryStatement;
+        }
+
+        protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+        {
+            using (StartNodeObject(unaryExpression))
+            {
+                Member("operator", unaryExpression.Operator);
+                Member("argument", unaryExpression.Argument);
+                Member("prefix", unaryExpression.Prefix);
+            }
+
+            return unaryExpression;
+        }
+
+        protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        {
+            using (StartNodeObject(variableDeclaration))
+            {
+                Member("declarations", variableDeclaration.Declarations);
+                Member("kind", variableDeclaration.Kind);
+            }
+
+            return variableDeclaration;
+        }
+
+        protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        {
+            using (StartNodeObject(variableDeclarator))
+            {
+                Member("id", variableDeclarator.Id);
+                Member("init", variableDeclarator.Init);
+            }
+
+            return variableDeclarator;
+        }
+
+        protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+        {
+            using (StartNodeObject(whileStatement))
+            {
+                Member("test", whileStatement.Test);
+                Member("body", whileStatement.Body);
+            }
+
+            return whileStatement;
+        }
+
+        protected internal override object? VisitWithStatement(WithStatement withStatement)
+        {
+            using (StartNodeObject(withStatement))
+            {
+                Member("object", withStatement.Object);
+                Member("body", withStatement.Body);
+            }
+
+            return withStatement;
+        }
+
+        protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+        {
+            using (StartNodeObject(yieldExpression))
+            {
+                Member("argument", yieldExpression.Argument);
+                Member("delegate", yieldExpression.Delegate);
+            }
+
+            return yieldExpression;
         }
     }
 

--- a/src/Esprima/Utils/AstRewriter.cs
+++ b/src/Esprima/Utils/AstRewriter.cs
@@ -64,141 +64,18 @@ public class AstRewriter : AstVisitor
         return false;
     }
 
-    protected internal override object? VisitProgram(Program program)
+    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
     {
-        VisitAndConvert(program.Body, out var body);
+        VisitAndConvert(arrayExpression.Elements, out var elements, allowNullElement: true);
 
-        return program.UpdateWith(body);
+        return arrayExpression.UpdateWith(elements);
     }
 
-    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
     {
-        var param = VisitAndConvert(catchClause.Param, allowNull: true);
-        var body = VisitAndConvert(catchClause.Body);
+        VisitAndConvert(arrayPattern.Elements, out var elements, allowNullElement: true);
 
-        return catchClause.UpdateWith(param, body);
-    }
-
-    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
-    {
-        var id = VisitAndConvert(functionDeclaration.Id, allowNull: true);
-        VisitAndConvert(functionDeclaration.Params, out var parameters);
-        var body = VisitAndConvert(functionDeclaration.Body);
-
-        return functionDeclaration.UpdateWith(id, parameters, body);
-    }
-
-    protected internal override object? VisitWithStatement(WithStatement withStatement)
-    {
-        var obj = VisitAndConvert(withStatement.Object);
-        var body = VisitAndConvert(withStatement.Body);
-
-        return withStatement.UpdateWith(obj, body);
-    }
-
-    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
-    {
-        var test = VisitAndConvert(whileStatement.Test);
-        var body = VisitAndConvert(whileStatement.Body);
-
-        return whileStatement.UpdateWith(test, body);
-    }
-
-    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
-    {
-        VisitAndConvert(variableDeclaration.Declarations, out var declarations);
-
-        return variableDeclaration.UpdateWith(declarations);
-    }
-
-    protected internal override object? VisitTryStatement(TryStatement tryStatement)
-    {
-        var block = VisitAndConvert(tryStatement.Block);
-        var handler = VisitAndConvert(tryStatement.Handler, allowNull: true);
-        var finalizer = VisitAndConvert(tryStatement.Finalizer, allowNull: true);
-
-        return tryStatement.UpdateWith(block, handler, finalizer);
-    }
-
-    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
-    {
-        var argument = VisitAndConvert(throwStatement.Argument);
-
-        return throwStatement.UpdateWith(argument);
-    }
-
-    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
-    {
-        var discriminant = VisitAndConvert(switchStatement.Discriminant);
-        VisitAndConvert(switchStatement.Cases, out var cases);
-
-        return switchStatement.UpdateWith(discriminant, cases);
-    }
-
-    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
-    {
-        var test = VisitAndConvert(switchCase.Test, allowNull: true);
-        VisitAndConvert(switchCase.Consequent, out var consequent);
-
-        return switchCase.UpdateWith(test, consequent);
-    }
-
-    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
-    {
-        var argument = VisitAndConvert(returnStatement.Argument, allowNull: true);
-
-        return returnStatement.UpdateWith(argument);
-    }
-
-    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
-    {
-        var label = VisitAndConvert(labeledStatement.Label);
-        var body = VisitAndConvert(labeledStatement.Body);
-
-        return labeledStatement.UpdateWith(label, body);
-    }
-
-    protected internal override object? VisitIfStatement(IfStatement ifStatement)
-    {
-        var test = VisitAndConvert(ifStatement.Test);
-        var consequent = VisitAndConvert(ifStatement.Consequent);
-        var alternate = VisitAndConvert(ifStatement.Alternate, allowNull: true);
-
-        return ifStatement.UpdateWith(test, consequent, alternate);
-    }
-
-    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
-    {
-        var expression = VisitAndConvert(expressionStatement.Expression);
-
-        return expressionStatement.UpdateWith(expression);
-    }
-
-    protected internal override object? VisitForStatement(ForStatement forStatement)
-    {
-        var init = VisitAndConvert(forStatement.Init, allowNull: true);
-        var test = VisitAndConvert(forStatement.Test, allowNull: true);
-        var update = VisitAndConvert(forStatement.Update, allowNull: true);
-        var body = VisitAndConvert(forStatement.Body);
-
-        return forStatement.UpdateWith(init, test, update, body);
-    }
-
-    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
-    {
-        var left = VisitAndConvert(forInStatement.Left);
-        var right = VisitAndConvert(forInStatement.Right);
-        var body = VisitAndConvert(forInStatement.Body);
-
-        return forInStatement.UpdateWith(left, right, body);
-    }
-
-    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
-    {
-        var body = VisitAndConvert(doWhileStatement.Body);
-        var test = VisitAndConvert(doWhileStatement.Test);
-
-        return doWhileStatement.UpdateWith(body, test);
+        return arrayPattern.UpdateWith(elements);
     }
 
     protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
@@ -209,59 +86,65 @@ public class AstRewriter : AstVisitor
         return arrowFunctionExpression.UpdateWith(parameters, body);
     }
 
-    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
     {
-        var argument = VisitAndConvert(unaryExpression.Argument);
+        var left = VisitAndConvert(assignmentExpression.Left);
+        var right = VisitAndConvert(assignmentExpression.Right);
 
-        return unaryExpression.UpdateWith(argument);
+        return assignmentExpression.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
     {
-        VisitAndConvert(sequenceExpression.Expressions, out var expressions);
+        var left = VisitAndConvert(assignmentPattern.Left);
+        var right = VisitAndConvert(assignmentPattern.Right);
 
-        return sequenceExpression.UpdateWith(expressions);
+        return assignmentPattern.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
     {
-        VisitAndConvert(objectExpression.Properties, out var properties);
+        var argument = VisitAndConvert(awaitExpression.Argument);
 
-        return objectExpression.UpdateWith(properties);
+        return awaitExpression.UpdateWith(argument);
     }
 
-    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
     {
-        var callee = VisitAndConvert(newExpression.Callee);
-        VisitAndConvert(newExpression.Arguments, out var arguments);
+        var left = VisitAndConvert(binaryExpression.Left);
+        var right = VisitAndConvert(binaryExpression.Right);
 
-        return newExpression.UpdateWith(callee, arguments);
+        return binaryExpression.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
     {
-        var obj = VisitAndConvert(memberExpression.Object);
-        var property = VisitAndConvert(memberExpression.Property);
+        VisitAndConvert(blockStatement.Body, out var body);
 
-        return memberExpression.UpdateWith(obj, property);
+        return blockStatement.UpdateWith(body);
     }
 
-    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
     {
-        var id = VisitAndConvert(functionExpression.Id, allowNull: true);
-        VisitAndConvert(functionExpression.Params, out var parameters);
-        var body = VisitAndConvert(functionExpression.Body);
+        var label = VisitAndConvert(breakStatement.Label, allowNull: true);
 
-        return functionExpression.UpdateWith(id, parameters, body);
+        return breakStatement.UpdateWith(label);
     }
 
-    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    protected internal override object? VisitCallExpression(CallExpression callExpression)
     {
-        var key = VisitAndConvert(propertyDefinition.Key);
-        var value = VisitAndConvert(propertyDefinition.Value, allowNull: true);
-        VisitAndConvert(propertyDefinition.Decorators, out var decorators);
+        var callee = VisitAndConvert(callExpression.Callee);
+        VisitAndConvert(callExpression.Arguments, out var arguments);
 
-        return propertyDefinition.UpdateWith(key, value, decorators);
+        return callExpression.UpdateWith(callee, arguments);
+    }
+
+    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    {
+        var param = VisitAndConvert(catchClause.Param, allowNull: true);
+        var body = VisitAndConvert(catchClause.Body);
+
+        return catchClause.UpdateWith(param, body);
     }
 
     protected internal override object? VisitChainExpression(ChainExpression chainExpression)
@@ -271,11 +154,21 @@ public class AstRewriter : AstVisitor
         return chainExpression.UpdateWith(expression);
     }
 
-    protected internal override object? VisitDecorator(Decorator decorator)
+    protected internal override object? VisitClassBody(ClassBody classBody)
     {
-        var expression = VisitAndConvert(decorator.Expression);
+        VisitAndConvert(classBody.Body, out var body);
 
-        return decorator.UpdateWith(expression);
+        return classBody.UpdateWith(body);
+    }
+
+    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    {
+        var id = VisitAndConvert(classDeclaration.Id, allowNull: true);
+        var superClass = VisitAndConvert(classDeclaration.SuperClass, allowNull: true);
+        var body = VisitAndConvert(classDeclaration.Body);
+        VisitAndConvert(classDeclaration.Decorators, out var decorators);
+
+        return classDeclaration.UpdateWith(id, superClass, body, decorators);
     }
 
     protected internal override object? VisitClassExpression(ClassExpression classExpression)
@@ -288,11 +181,35 @@ public class AstRewriter : AstVisitor
         return classExpression.UpdateWith(id, superClass, body, decorators);
     }
 
-    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
     {
-        var declaration = VisitAndConvert(exportDefaultDeclaration.Declaration);
+        var test = VisitAndConvert(conditionalExpression.Test);
+        var consequent = VisitAndConvert(conditionalExpression.Consequent);
+        var alternate = VisitAndConvert(conditionalExpression.Alternate);
 
-        return exportDefaultDeclaration.UpdateWith(declaration);
+        return conditionalExpression.UpdateWith(test, consequent, alternate);
+    }
+
+    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+    {
+        var label = VisitAndConvert(continueStatement.Label, allowNull: true);
+
+        return continueStatement.UpdateWith(label);
+    }
+
+    protected internal override object? VisitDecorator(Decorator decorator)
+    {
+        var expression = VisitAndConvert(decorator.Expression);
+
+        return decorator.UpdateWith(expression);
+    }
+
+    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    {
+        var body = VisitAndConvert(doWhileStatement.Body);
+        var test = VisitAndConvert(doWhileStatement.Test);
+
+        return doWhileStatement.UpdateWith(body, test);
     }
 
     protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
@@ -302,6 +219,13 @@ public class AstRewriter : AstVisitor
         VisitAndConvert(exportAllDeclaration.Assertions, out var assertions);
 
         return exportAllDeclaration.UpdateWith(exported, source, assertions);
+    }
+
+    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    {
+        var declaration = VisitAndConvert(exportDefaultDeclaration.Declaration);
+
+        return exportDefaultDeclaration.UpdateWith(declaration);
     }
 
     protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
@@ -320,6 +244,68 @@ public class AstRewriter : AstVisitor
         var exported = VisitAndConvert(exportSpecifier.Exported);
 
         return exportSpecifier.UpdateWith(local, exported);
+    }
+
+    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    {
+        var expression = VisitAndConvert(expressionStatement.Expression);
+
+        return expressionStatement.UpdateWith(expression);
+    }
+
+    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+    {
+        var left = VisitAndConvert(forInStatement.Left);
+        var right = VisitAndConvert(forInStatement.Right);
+        var body = VisitAndConvert(forInStatement.Body);
+
+        return forInStatement.UpdateWith(left, right, body);
+    }
+
+    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    {
+        var left = VisitAndConvert(forOfStatement.Left);
+        var right = VisitAndConvert(forOfStatement.Right);
+        var body = VisitAndConvert(forOfStatement.Body);
+
+        return forOfStatement.UpdateWith(left, right, body);
+    }
+
+    protected internal override object? VisitForStatement(ForStatement forStatement)
+    {
+        var init = VisitAndConvert(forStatement.Init, allowNull: true);
+        var test = VisitAndConvert(forStatement.Test, allowNull: true);
+        var update = VisitAndConvert(forStatement.Update, allowNull: true);
+        var body = VisitAndConvert(forStatement.Body);
+
+        return forStatement.UpdateWith(init, test, update, body);
+    }
+
+    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    {
+        var id = VisitAndConvert(functionDeclaration.Id, allowNull: true);
+        VisitAndConvert(functionDeclaration.Params, out var parameters);
+        var body = VisitAndConvert(functionDeclaration.Body);
+
+        return functionDeclaration.UpdateWith(id, parameters, body);
+    }
+
+    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    {
+        var id = VisitAndConvert(functionExpression.Id, allowNull: true);
+        VisitAndConvert(functionExpression.Params, out var parameters);
+        var body = VisitAndConvert(functionExpression.Body);
+
+        return functionExpression.UpdateWith(id, parameters, body);
+    }
+
+    protected internal override object? VisitIfStatement(IfStatement ifStatement)
+    {
+        var test = VisitAndConvert(ifStatement.Test);
+        var consequent = VisitAndConvert(ifStatement.Consequent);
+        var alternate = VisitAndConvert(ifStatement.Alternate, allowNull: true);
+
+        return ifStatement.UpdateWith(test, consequent, alternate);
     }
 
     protected internal override object? VisitImport(Import import)
@@ -349,18 +335,18 @@ public class AstRewriter : AstVisitor
         return importDeclaration.UpdateWith(specifiers, source, assertions);
     }
 
-    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
-    {
-        var local = VisitAndConvert(importNamespaceSpecifier.Local);
-
-        return importNamespaceSpecifier.UpdateWith(local);
-    }
-
     protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
     {
         var local = VisitAndConvert(importDefaultSpecifier.Local);
 
         return importDefaultSpecifier.UpdateWith(local);
+    }
+
+    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    {
+        var local = VisitAndConvert(importNamespaceSpecifier.Local);
+
+        return importNamespaceSpecifier.UpdateWith(local);
     }
 
     protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
@@ -369,6 +355,30 @@ public class AstRewriter : AstVisitor
         var local = VisitAndConvert(importSpecifier.Local);
 
         return importSpecifier.UpdateWith(imported, local);
+    }
+
+    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    {
+        var label = VisitAndConvert(labeledStatement.Label);
+        var body = VisitAndConvert(labeledStatement.Body);
+
+        return labeledStatement.UpdateWith(label, body);
+    }
+
+    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    {
+        var obj = VisitAndConvert(memberExpression.Object);
+        var property = VisitAndConvert(memberExpression.Property);
+
+        return memberExpression.UpdateWith(obj, property);
+    }
+
+    protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+    {
+        var meta = VisitAndConvert(metaProperty.Meta);
+        var property = VisitAndConvert(metaProperty.Property);
+
+        return metaProperty.UpdateWith(meta, property);
     }
 
     protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
@@ -380,53 +390,19 @@ public class AstRewriter : AstVisitor
         return methodDefinition.UpdateWith(key, value, decorators);
     }
 
-    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal override object? VisitNewExpression(NewExpression newExpression)
     {
-        var left = VisitAndConvert(forOfStatement.Left);
-        var right = VisitAndConvert(forOfStatement.Right);
-        var body = VisitAndConvert(forOfStatement.Body);
+        var callee = VisitAndConvert(newExpression.Callee);
+        VisitAndConvert(newExpression.Arguments, out var arguments);
 
-        return forOfStatement.UpdateWith(left, right, body);
+        return newExpression.UpdateWith(callee, arguments);
     }
 
-    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
     {
-        var id = VisitAndConvert(classDeclaration.Id, allowNull: true);
-        var superClass = VisitAndConvert(classDeclaration.SuperClass, allowNull: true);
-        var body = VisitAndConvert(classDeclaration.Body);
-        VisitAndConvert(classDeclaration.Decorators, out var decorators);
+        VisitAndConvert(objectExpression.Properties, out var properties);
 
-        return classDeclaration.UpdateWith(id, superClass, body, decorators);
-    }
-
-    protected internal override object? VisitClassBody(ClassBody classBody)
-    {
-        VisitAndConvert(classBody.Body, out var body);
-
-        return classBody.UpdateWith(body);
-    }
-
-    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
-    {
-        var argument = VisitAndConvert(yieldExpression.Argument, allowNull: true);
-
-        return yieldExpression.UpdateWith(argument);
-    }
-
-    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
-    {
-        var tag = VisitAndConvert(taggedTemplateExpression.Tag);
-        var quasi = VisitAndConvert(taggedTemplateExpression.Quasi);
-
-        return taggedTemplateExpression.UpdateWith(tag, quasi);
-    }
-
-    protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
-    {
-        var meta = VisitAndConvert(metaProperty.Meta);
-        var property = VisitAndConvert(metaProperty.Property);
-
-        return metaProperty.UpdateWith(meta, property);
+        return objectExpression.UpdateWith(properties);
     }
 
     protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
@@ -436,49 +412,11 @@ public class AstRewriter : AstVisitor
         return objectPattern.UpdateWith(properties);
     }
 
-    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal override object? VisitProgram(Program program)
     {
-        var argument = VisitAndConvert(spreadElement.Argument);
+        VisitAndConvert(program.Body, out var body);
 
-        return spreadElement.UpdateWith(argument);
-    }
-
-    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
-    {
-        var left = VisitAndConvert(assignmentPattern.Left);
-        var right = VisitAndConvert(assignmentPattern.Right);
-
-        return assignmentPattern.UpdateWith(left, right);
-    }
-
-    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
-    {
-        VisitAndConvert(arrayPattern.Elements, out var elements, allowNullElement: true);
-
-        return arrayPattern.UpdateWith(elements);
-    }
-
-    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
-    {
-        var id = VisitAndConvert(variableDeclarator.Id);
-        var init = VisitAndConvert(variableDeclarator.Init, allowNull: true);
-
-        return variableDeclarator.UpdateWith(id, init);
-    }
-
-    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
-    {
-        VisitAndConvert(templateLiteral.Quasis, out var quasis);
-        VisitAndConvert(templateLiteral.Expressions, out var expressions);
-
-        return templateLiteral.UpdateWith(quasis, expressions);
-    }
-
-    protected internal override object? VisitRestElement(RestElement restElement)
-    {
-        var argument = VisitAndConvert(restElement.Argument);
-
-        return restElement.UpdateWith(argument);
+        return program.UpdateWith(body);
     }
 
     protected internal override object? VisitProperty(Property property)
@@ -489,72 +427,41 @@ public class AstRewriter : AstVisitor
         return property.UpdateWith(key, value);
     }
 
-    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
     {
-        var argument = VisitAndConvert(awaitExpression.Argument);
+        var key = VisitAndConvert(propertyDefinition.Key);
+        var value = VisitAndConvert(propertyDefinition.Value, allowNull: true);
+        VisitAndConvert(propertyDefinition.Decorators, out var decorators);
 
-        return awaitExpression.UpdateWith(argument);
+        return propertyDefinition.UpdateWith(key, value, decorators);
     }
 
-    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal override object? VisitRestElement(RestElement restElement)
     {
-        var test = VisitAndConvert(conditionalExpression.Test);
-        var consequent = VisitAndConvert(conditionalExpression.Consequent);
-        var alternate = VisitAndConvert(conditionalExpression.Alternate);
+        var argument = VisitAndConvert(restElement.Argument);
 
-        return conditionalExpression.UpdateWith(test, consequent, alternate);
+        return restElement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitCallExpression(CallExpression callExpression)
+    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
     {
-        var callee = VisitAndConvert(callExpression.Callee);
-        VisitAndConvert(callExpression.Arguments, out var arguments);
+        var argument = VisitAndConvert(returnStatement.Argument, allowNull: true);
 
-        return callExpression.UpdateWith(callee, arguments);
+        return returnStatement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
     {
-        var left = VisitAndConvert(binaryExpression.Left);
-        var right = VisitAndConvert(binaryExpression.Right);
+        VisitAndConvert(sequenceExpression.Expressions, out var expressions);
 
-        return binaryExpression.UpdateWith(left, right);
+        return sequenceExpression.UpdateWith(expressions);
     }
 
-    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
     {
-        VisitAndConvert(arrayExpression.Elements, out var elements, allowNullElement: true);
+        var argument = VisitAndConvert(spreadElement.Argument);
 
-        return arrayExpression.UpdateWith(elements);
-    }
-
-    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
-    {
-        var left = VisitAndConvert(assignmentExpression.Left);
-        var right = VisitAndConvert(assignmentExpression.Right);
-
-        return assignmentExpression.UpdateWith(left, right);
-    }
-
-    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
-    {
-        var label = VisitAndConvert(continueStatement.Label, allowNull: true);
-
-        return continueStatement.UpdateWith(label);
-    }
-
-    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
-    {
-        var label = VisitAndConvert(breakStatement.Label, allowNull: true);
-
-        return breakStatement.UpdateWith(label);
-    }
-
-    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
-    {
-        VisitAndConvert(blockStatement.Body, out var body);
-
-        return blockStatement.UpdateWith(body);
+        return spreadElement.UpdateWith(argument);
     }
 
     protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
@@ -562,5 +469,98 @@ public class AstRewriter : AstVisitor
         VisitAndConvert(staticBlock.Body, out var body);
 
         return staticBlock.UpdateWith(body);
+    }
+
+    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+    {
+        var test = VisitAndConvert(switchCase.Test, allowNull: true);
+        VisitAndConvert(switchCase.Consequent, out var consequent);
+
+        return switchCase.UpdateWith(test, consequent);
+    }
+
+    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+    {
+        var discriminant = VisitAndConvert(switchStatement.Discriminant);
+        VisitAndConvert(switchStatement.Cases, out var cases);
+
+        return switchStatement.UpdateWith(discriminant, cases);
+    }
+
+    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    {
+        var tag = VisitAndConvert(taggedTemplateExpression.Tag);
+        var quasi = VisitAndConvert(taggedTemplateExpression.Quasi);
+
+        return taggedTemplateExpression.UpdateWith(tag, quasi);
+    }
+
+    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    {
+        VisitAndConvert(templateLiteral.Quasis, out var quasis);
+        VisitAndConvert(templateLiteral.Expressions, out var expressions);
+
+        return templateLiteral.UpdateWith(quasis, expressions);
+    }
+
+    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+    {
+        var argument = VisitAndConvert(throwStatement.Argument);
+
+        return throwStatement.UpdateWith(argument);
+    }
+
+    protected internal override object? VisitTryStatement(TryStatement tryStatement)
+    {
+        var block = VisitAndConvert(tryStatement.Block);
+        var handler = VisitAndConvert(tryStatement.Handler, allowNull: true);
+        var finalizer = VisitAndConvert(tryStatement.Finalizer, allowNull: true);
+
+        return tryStatement.UpdateWith(block, handler, finalizer);
+    }
+
+    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    {
+        var argument = VisitAndConvert(unaryExpression.Argument);
+
+        return unaryExpression.UpdateWith(argument);
+    }
+
+    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    {
+        VisitAndConvert(variableDeclaration.Declarations, out var declarations);
+
+        return variableDeclaration.UpdateWith(declarations);
+    }
+
+    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    {
+        var id = VisitAndConvert(variableDeclarator.Id);
+        var init = VisitAndConvert(variableDeclarator.Init, allowNull: true);
+
+        return variableDeclarator.UpdateWith(id, init);
+    }
+
+    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+    {
+        var test = VisitAndConvert(whileStatement.Test);
+        var body = VisitAndConvert(whileStatement.Body);
+
+        return whileStatement.UpdateWith(test, body);
+    }
+
+    protected internal override object? VisitWithStatement(WithStatement withStatement)
+    {
+        var obj = VisitAndConvert(withStatement.Object);
+        var body = VisitAndConvert(withStatement.Body);
+
+        return withStatement.UpdateWith(obj, body);
+    }
+
+    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+    {
+        var argument = VisitAndConvert(yieldExpression.Argument, allowNull: true);
+
+        return yieldExpression.UpdateWith(argument);
     }
 }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -13,209 +13,34 @@ public class AstVisitor
         return node.Accept(this);
     }
 
-    protected internal virtual object? VisitProgram(Program program)
+    protected internal virtual object? VisitArrayExpression(ArrayExpression arrayExpression)
     {
-        ref readonly var statements = ref program.Body;
-        for (var i = 0; i < statements.Count; i++)
+        ref readonly var elements = ref arrayExpression.Elements;
+        for (var i = 0; i < elements.Count; i++)
         {
-            Visit(statements[i]);
+            var expr = elements[i];
+            if (expr is not null)
+            {
+                Visit(expr);
+            }
         }
 
-        return program;
+        return arrayExpression;
     }
 
-    protected internal virtual object? VisitCatchClause(CatchClause catchClause)
+    protected internal virtual object? VisitArrayPattern(ArrayPattern arrayPattern)
     {
-        if (catchClause.Param is not null)
+        ref readonly var elements = ref arrayPattern.Elements;
+        for (var i = 0; i < elements.Count; i++)
         {
-            Visit(catchClause.Param);
+            var expr = elements[i];
+            if (expr is not null)
+            {
+                Visit(expr);
+            }
         }
 
-        Visit(catchClause.Body);
-
-        return catchClause;
-    }
-
-    protected internal virtual object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
-    {
-        if (functionDeclaration.Id is not null)
-        {
-            Visit(functionDeclaration.Id);
-        }
-
-        ref readonly var parameters = ref functionDeclaration.Params;
-        for (var i = 0; i < parameters.Count; i++)
-        {
-            Visit(parameters[i]);
-        }
-
-        Visit(functionDeclaration.Body);
-
-        return functionDeclaration;
-    }
-
-    protected internal virtual object? VisitWithStatement(WithStatement withStatement)
-    {
-        Visit(withStatement.Object);
-        Visit(withStatement.Body);
-
-        return withStatement;
-    }
-
-    protected internal virtual object? VisitWhileStatement(WhileStatement whileStatement)
-    {
-        Visit(whileStatement.Test);
-        Visit(whileStatement.Body);
-
-        return whileStatement;
-    }
-
-    protected internal virtual object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
-    {
-        ref readonly var declarations = ref variableDeclaration.Declarations;
-        for (var i = 0; i < declarations.Count; i++)
-        {
-            Visit(declarations[i]);
-        }
-
-        return variableDeclaration;
-    }
-
-    protected internal virtual object? VisitTryStatement(TryStatement tryStatement)
-    {
-        Visit(tryStatement.Block);
-        if (tryStatement.Handler is not null)
-        {
-            Visit(tryStatement.Handler);
-        }
-
-        if (tryStatement.Finalizer is not null)
-        {
-            Visit(tryStatement.Finalizer);
-        }
-
-        return tryStatement;
-    }
-
-    protected internal virtual object? VisitThrowStatement(ThrowStatement throwStatement)
-    {
-        Visit(throwStatement.Argument);
-
-        return throwStatement;
-    }
-
-    protected internal virtual object? VisitSwitchStatement(SwitchStatement switchStatement)
-    {
-        Visit(switchStatement.Discriminant);
-        ref readonly var cases = ref switchStatement.Cases;
-        for (var i = 0; i < cases.Count; i++)
-        {
-            Visit(cases[i]);
-        }
-
-        return switchStatement;
-    }
-
-    protected internal virtual object? VisitSwitchCase(SwitchCase switchCase)
-    {
-        if (switchCase.Test is not null)
-        {
-            Visit(switchCase.Test);
-        }
-
-        ref readonly var consequent = ref switchCase.Consequent;
-        for (var i = 0; i < consequent.Count; i++)
-        {
-            Visit(consequent[i]);
-        }
-
-        return switchCase;
-    }
-
-    protected internal virtual object? VisitReturnStatement(ReturnStatement returnStatement)
-    {
-        if (returnStatement.Argument is not null)
-        {
-            Visit(returnStatement.Argument);
-        }
-
-        return returnStatement;
-    }
-
-    protected internal virtual object? VisitLabeledStatement(LabeledStatement labeledStatement)
-    {
-        Visit(labeledStatement.Label);
-        Visit(labeledStatement.Body);
-
-        return labeledStatement;
-    }
-
-    protected internal virtual object? VisitIfStatement(IfStatement ifStatement)
-    {
-        Visit(ifStatement.Test);
-        Visit(ifStatement.Consequent);
-        if (ifStatement.Alternate is not null)
-        {
-            Visit(ifStatement.Alternate);
-        }
-
-        return ifStatement;
-    }
-
-    protected internal virtual object? VisitEmptyStatement(EmptyStatement emptyStatement)
-    {
-        return emptyStatement;
-    }
-
-    protected internal virtual object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
-    {
-        return debuggerStatement;
-    }
-
-    protected internal virtual object? VisitExpressionStatement(ExpressionStatement expressionStatement)
-    {
-        Visit(expressionStatement.Expression);
-
-        return expressionStatement;
-    }
-
-    protected internal virtual object? VisitForStatement(ForStatement forStatement)
-    {
-        if (forStatement.Init is not null)
-        {
-            Visit(forStatement.Init);
-        }
-
-        if (forStatement.Test is not null)
-        {
-            Visit(forStatement.Test);
-        }
-
-        if (forStatement.Update is not null)
-        {
-            Visit(forStatement.Update);
-        }
-
-        Visit(forStatement.Body);
-
-        return forStatement;
-    }
-
-    protected internal virtual object? VisitForInStatement(ForInStatement forInStatement)
-    {
-        Visit(forInStatement.Left);
-        Visit(forInStatement.Right);
-        Visit(forInStatement.Body);
-
-        return forInStatement;
-    }
-
-    protected internal virtual object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
-    {
-        Visit(doWhileStatement.Body);
-        Visit(doWhileStatement.Test);
-
-        return doWhileStatement;
+        return arrayPattern;
     }
 
     protected internal virtual object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
@@ -231,109 +56,88 @@ public class AstVisitor
         return arrowFunctionExpression;
     }
 
-    protected internal virtual object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal virtual object? VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
     {
-        Visit(unaryExpression.Argument);
+        // Seems that ArrowParameterPlaceHolder nodes never appear in the final tree and only used during the construction of a tree.
+        // Though we provide the VisitArrowParameterPlaceHolder method for inheritors in case they still needed it.
 
-        return unaryExpression;
+        throw UnsupportedNodeType(arrowParameterPlaceHolder.GetType());
     }
 
-    protected internal virtual object? VisitThisExpression(ThisExpression thisExpression)
+    protected internal virtual object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
     {
-        return thisExpression;
+        Visit(assignmentExpression.Left);
+        Visit(assignmentExpression.Right);
+
+        return assignmentExpression;
     }
 
-    protected internal virtual object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal virtual object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
     {
-        ref readonly var expressions = ref sequenceExpression.Expressions;
-        for (var i = 0; i < expressions.Count; i++)
+        Visit(assignmentPattern.Left);
+        Visit(assignmentPattern.Right);
+
+        return assignmentPattern;
+    }
+
+    protected internal virtual object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    {
+        Visit(awaitExpression.Argument);
+
+        return awaitExpression;
+    }
+
+    protected internal virtual object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    {
+        Visit(binaryExpression.Left);
+        Visit(binaryExpression.Right);
+
+        return binaryExpression;
+    }
+
+    protected internal virtual object? VisitBlockStatement(BlockStatement blockStatement)
+    {
+        ref readonly var body = ref blockStatement.Body;
+        for (var i = 0; i < body.Count; i++)
         {
-            Visit(expressions[i]);
+            Visit(body[i]);
         }
 
-        return sequenceExpression;
+        return blockStatement;
     }
 
-    protected internal virtual object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal virtual object? VisitBreakStatement(BreakStatement breakStatement)
     {
-        ref readonly var properties = ref objectExpression.Properties;
-        for (var i = 0; i < properties.Count; i++)
+        if (breakStatement.Label is not null)
         {
-            Visit(properties[i]);
+            Visit(breakStatement.Label);
         }
 
-        return objectExpression;
+        return breakStatement;
     }
 
-    protected internal virtual object? VisitNewExpression(NewExpression newExpression)
+    protected internal virtual object? VisitCallExpression(CallExpression callExpression)
     {
-        Visit(newExpression.Callee);
-        ref readonly var arguments = ref newExpression.Arguments;
+        Visit(callExpression.Callee);
+        ref readonly var arguments = ref callExpression.Arguments;
         for (var i = 0; i < arguments.Count; i++)
         {
             Visit(arguments[i]);
         }
 
-        return newExpression;
+        return callExpression;
     }
 
-    protected internal virtual object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal virtual object? VisitCatchClause(CatchClause catchClause)
     {
-        Visit(memberExpression.Object);
-        Visit(memberExpression.Property);
-
-        return memberExpression;
-    }
-
-    protected internal virtual object? VisitLiteral(Literal literal)
-    {
-        return literal;
-    }
-
-    protected internal virtual object? VisitIdentifier(Identifier identifier)
-    {
-        return identifier;
-    }
-
-    protected internal virtual object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
-    {
-        return privateIdentifier;
-    }
-
-    protected internal virtual object? VisitFunctionExpression(FunctionExpression functionExpression)
-    {
-        if (functionExpression.Id is not null)
+        if (catchClause.Param is not null)
         {
-            Visit(functionExpression.Id);
+            Visit(catchClause.Param);
         }
 
-        ref readonly var parameters = ref functionExpression.Params;
-        for (var i = 0; i < parameters.Count; i++)
-        {
-            Visit(parameters[i]);
-        }
+        Visit(catchClause.Body);
 
-        Visit(functionExpression.Body);
-
-        return functionExpression;
-    }
-
-    protected internal virtual object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
-    {
-        Visit(propertyDefinition.Key);
-
-        if (propertyDefinition.Value is not null)
-        {
-            Visit(propertyDefinition.Value);
-        }
-
-        ref readonly var decorators = ref propertyDefinition.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
-        {
-            Visit(decorators[i]);
-        }
-
-        return propertyDefinition;
+        return catchClause;
     }
 
     protected internal virtual object? VisitChainExpression(ChainExpression chainExpression)
@@ -343,11 +147,38 @@ public class AstVisitor
         return chainExpression;
     }
 
-    protected internal virtual object? VisitDecorator(Decorator decorator)
+    protected internal virtual object? VisitClassBody(ClassBody classBody)
     {
-        Visit(decorator.Expression);
+        ref readonly var body = ref classBody.Body;
+        for (var i = 0; i < body.Count; i++)
+        {
+            Visit(body[i]);
+        }
 
-        return decorator;
+        return classBody;
+    }
+
+    protected internal virtual object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    {
+        if (classDeclaration.Id is not null)
+        {
+            Visit(classDeclaration.Id);
+        }
+
+        if (classDeclaration.SuperClass is not null)
+        {
+            Visit(classDeclaration.SuperClass);
+        }
+
+        Visit(classDeclaration.Body);
+
+        ref readonly var decorators = ref classDeclaration.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
+
+        return classDeclaration;
     }
 
     protected internal virtual object? VisitClassExpression(ClassExpression classExpression)
@@ -373,11 +204,48 @@ public class AstVisitor
         return classExpression;
     }
 
-    protected internal virtual object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal virtual object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
     {
-        Visit(exportDefaultDeclaration.Declaration);
+        Visit(conditionalExpression.Test);
+        Visit(conditionalExpression.Consequent);
+        Visit(conditionalExpression.Alternate);
 
-        return exportDefaultDeclaration;
+        return conditionalExpression;
+    }
+
+    protected internal virtual object? VisitContinueStatement(ContinueStatement continueStatement)
+    {
+        if (continueStatement.Label is not null)
+        {
+            Visit(continueStatement.Label);
+        }
+
+        return continueStatement;
+    }
+
+    protected internal virtual object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+    {
+        return debuggerStatement;
+    }
+
+    protected internal virtual object? VisitDecorator(Decorator decorator)
+    {
+        Visit(decorator.Expression);
+
+        return decorator;
+    }
+
+    protected internal virtual object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    {
+        Visit(doWhileStatement.Body);
+        Visit(doWhileStatement.Test);
+
+        return doWhileStatement;
+    }
+
+    protected internal virtual object? VisitEmptyStatement(EmptyStatement emptyStatement)
+    {
+        return emptyStatement;
     }
 
     protected internal virtual object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
@@ -396,6 +264,13 @@ public class AstVisitor
         }
 
         return exportAllDeclaration;
+    }
+
+    protected internal virtual object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    {
+        Visit(exportDefaultDeclaration.Declaration);
+
+        return exportDefaultDeclaration;
     }
 
     protected internal virtual object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
@@ -433,6 +308,116 @@ public class AstVisitor
         return exportSpecifier;
     }
 
+    protected internal virtual object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    {
+        Visit(expressionStatement.Expression);
+
+        return expressionStatement;
+    }
+
+    protected internal virtual object? VisitExtension(Node node)
+    {
+        // Node type Extension is used to represent extensions to the standard AST (for example, see JSX parsing).
+        // Nodes of this type never appear in the tree returned by the core parser (JavaScriptParser),
+        // thus the visitor doesn't deal with this type by default. Inheritors either need to override this method,
+        // or inherit from another visitor which was built to handle extension nodes (e.g. JsxAstVisitor in the case of JSX).
+
+        throw UnsupportedNodeType(node.GetType());
+    }
+
+    protected internal virtual object? VisitForInStatement(ForInStatement forInStatement)
+    {
+        Visit(forInStatement.Left);
+        Visit(forInStatement.Right);
+        Visit(forInStatement.Body);
+
+        return forInStatement;
+    }
+
+    protected internal virtual object? VisitForOfStatement(ForOfStatement forOfStatement)
+    {
+        Visit(forOfStatement.Left);
+        Visit(forOfStatement.Right);
+        Visit(forOfStatement.Body);
+
+        return forOfStatement;
+    }
+
+    protected internal virtual object? VisitForStatement(ForStatement forStatement)
+    {
+        if (forStatement.Init is not null)
+        {
+            Visit(forStatement.Init);
+        }
+
+        if (forStatement.Test is not null)
+        {
+            Visit(forStatement.Test);
+        }
+
+        if (forStatement.Update is not null)
+        {
+            Visit(forStatement.Update);
+        }
+
+        Visit(forStatement.Body);
+
+        return forStatement;
+    }
+
+    protected internal virtual object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    {
+        if (functionDeclaration.Id is not null)
+        {
+            Visit(functionDeclaration.Id);
+        }
+
+        ref readonly var parameters = ref functionDeclaration.Params;
+        for (var i = 0; i < parameters.Count; i++)
+        {
+            Visit(parameters[i]);
+        }
+
+        Visit(functionDeclaration.Body);
+
+        return functionDeclaration;
+    }
+
+    protected internal virtual object? VisitFunctionExpression(FunctionExpression functionExpression)
+    {
+        if (functionExpression.Id is not null)
+        {
+            Visit(functionExpression.Id);
+        }
+
+        ref readonly var parameters = ref functionExpression.Params;
+        for (var i = 0; i < parameters.Count; i++)
+        {
+            Visit(parameters[i]);
+        }
+
+        Visit(functionExpression.Body);
+
+        return functionExpression;
+    }
+
+    protected internal virtual object? VisitIdentifier(Identifier identifier)
+    {
+        return identifier;
+    }
+
+    protected internal virtual object? VisitIfStatement(IfStatement ifStatement)
+    {
+        Visit(ifStatement.Test);
+        Visit(ifStatement.Consequent);
+        if (ifStatement.Alternate is not null)
+        {
+            Visit(ifStatement.Alternate);
+        }
+
+        return ifStatement;
+    }
+
     protected internal virtual object? VisitImport(Import import)
     {
         Visit(import.Source);
@@ -453,7 +438,6 @@ public class AstVisitor
         return importAttribute;
     }
 
-
     protected internal virtual object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         ref readonly var specifiers = ref importDeclaration.Specifiers;
@@ -473,18 +457,18 @@ public class AstVisitor
         return importDeclaration;
     }
 
-    protected internal virtual object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
-    {
-        Visit(importNamespaceSpecifier.Local);
-
-        return importNamespaceSpecifier;
-    }
-
     protected internal virtual object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
     {
         Visit(importDefaultSpecifier.Local);
 
         return importDefaultSpecifier;
+    }
+
+    protected internal virtual object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    {
+        Visit(importNamespaceSpecifier.Local);
+
+        return importNamespaceSpecifier;
     }
 
     protected internal virtual object? VisitImportSpecifier(ImportSpecifier importSpecifier)
@@ -493,6 +477,35 @@ public class AstVisitor
         Visit(importSpecifier.Local);
 
         return importSpecifier;
+    }
+
+    protected internal virtual object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    {
+        Visit(labeledStatement.Label);
+        Visit(labeledStatement.Body);
+
+        return labeledStatement;
+    }
+
+    protected internal virtual object? VisitLiteral(Literal literal)
+    {
+        return literal;
+    }
+
+    protected internal virtual object? VisitMemberExpression(MemberExpression memberExpression)
+    {
+        Visit(memberExpression.Object);
+        Visit(memberExpression.Property);
+
+        return memberExpression;
+    }
+
+    protected internal virtual object? VisitMetaProperty(MetaProperty metaProperty)
+    {
+        Visit(metaProperty.Meta);
+        Visit(metaProperty.Property);
+
+        return metaProperty;
     }
 
     protected internal virtual object? VisitMethodDefinition(MethodDefinition methodDefinition)
@@ -509,86 +522,27 @@ public class AstVisitor
         return methodDefinition;
     }
 
-    protected internal virtual object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal virtual object? VisitNewExpression(NewExpression newExpression)
     {
-        Visit(forOfStatement.Left);
-        Visit(forOfStatement.Right);
-        Visit(forOfStatement.Body);
-
-        return forOfStatement;
-    }
-
-    protected internal virtual object? VisitClassDeclaration(ClassDeclaration classDeclaration)
-    {
-        if (classDeclaration.Id is not null)
+        Visit(newExpression.Callee);
+        ref readonly var arguments = ref newExpression.Arguments;
+        for (var i = 0; i < arguments.Count; i++)
         {
-            Visit(classDeclaration.Id);
+            Visit(arguments[i]);
         }
 
-        if (classDeclaration.SuperClass is not null)
+        return newExpression;
+    }
+
+    protected internal virtual object? VisitObjectExpression(ObjectExpression objectExpression)
+    {
+        ref readonly var properties = ref objectExpression.Properties;
+        for (var i = 0; i < properties.Count; i++)
         {
-            Visit(classDeclaration.SuperClass);
+            Visit(properties[i]);
         }
 
-        Visit(classDeclaration.Body);
-
-        ref readonly var decorators = ref classDeclaration.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
-        {
-            Visit(decorators[i]);
-        }
-
-        return classDeclaration;
-    }
-
-    protected internal virtual object? VisitClassBody(ClassBody classBody)
-    {
-        ref readonly var body = ref classBody.Body;
-        for (var i = 0; i < body.Count; i++)
-        {
-            Visit(body[i]);
-        }
-
-        return classBody;
-    }
-
-    protected internal virtual object? VisitYieldExpression(YieldExpression yieldExpression)
-    {
-        if (yieldExpression.Argument is not null)
-        {
-            Visit(yieldExpression.Argument);
-        }
-
-        return yieldExpression;
-    }
-
-    protected internal virtual object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
-    {
-        Visit(taggedTemplateExpression.Tag);
-        Visit(taggedTemplateExpression.Quasi);
-
-        return taggedTemplateExpression;
-    }
-
-    protected internal virtual object? VisitSuper(Super super)
-    {
-        return super;
-    }
-
-    protected internal virtual object? VisitMetaProperty(MetaProperty metaProperty)
-    {
-        Visit(metaProperty.Meta);
-        Visit(metaProperty.Property);
-
-        return metaProperty;
-    }
-
-    protected internal virtual object? VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
-    {
-        // Seems that ArrowParameterPlaceHolder nodes never appear in the final tree and only used during the construction of a tree.
-        // Though we provide the VisitArrowParameterPlaceHolder method for inheritors in case they still needed it.
-
-        throw UnsupportedNodeType(arrowParameterPlaceHolder.GetType());
+        return objectExpression;
     }
 
     protected internal virtual object? VisitObjectPattern(ObjectPattern objectPattern)
@@ -602,6 +556,76 @@ public class AstVisitor
         return objectPattern;
     }
 
+    protected internal virtual object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+    {
+        return privateIdentifier;
+    }
+
+    protected internal virtual object? VisitProgram(Program program)
+    {
+        ref readonly var statements = ref program.Body;
+        for (var i = 0; i < statements.Count; i++)
+        {
+            Visit(statements[i]);
+        }
+
+        return program;
+    }
+
+    protected internal virtual object? VisitProperty(Property property)
+    {
+        Visit(property.Key);
+        Visit(property.Value);
+
+        return property;
+    }
+
+    protected internal virtual object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    {
+        Visit(propertyDefinition.Key);
+
+        if (propertyDefinition.Value is not null)
+        {
+            Visit(propertyDefinition.Value);
+        }
+
+        ref readonly var decorators = ref propertyDefinition.Decorators;
+        for (var i = 0; i < decorators.Count; i++)
+        {
+            Visit(decorators[i]);
+        }
+
+        return propertyDefinition;
+    }
+
+    protected internal virtual object? VisitRestElement(RestElement restElement)
+    {
+        Visit(restElement.Argument);
+
+        return restElement;
+    }
+
+    protected internal virtual object? VisitReturnStatement(ReturnStatement returnStatement)
+    {
+        if (returnStatement.Argument is not null)
+        {
+            Visit(returnStatement.Argument);
+        }
+
+        return returnStatement;
+    }
+
+    protected internal virtual object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    {
+        ref readonly var expressions = ref sequenceExpression.Expressions;
+        for (var i = 0; i < expressions.Count; i++)
+        {
+            Visit(expressions[i]);
+        }
+
+        return sequenceExpression;
+    }
+
     protected internal virtual object? VisitSpreadElement(SpreadElement spreadElement)
     {
         Visit(spreadElement.Argument);
@@ -609,38 +633,61 @@ public class AstVisitor
         return spreadElement;
     }
 
-    protected internal virtual object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal virtual object? VisitStaticBlock(StaticBlock staticBlock)
     {
-        Visit(assignmentPattern.Left);
-        Visit(assignmentPattern.Right);
-
-        return assignmentPattern;
-    }
-
-    protected internal virtual object? VisitArrayPattern(ArrayPattern arrayPattern)
-    {
-        ref readonly var elements = ref arrayPattern.Elements;
-        for (var i = 0; i < elements.Count; i++)
+        ref readonly var body = ref staticBlock.Body;
+        for (var i = 0; i < body.Count; i++)
         {
-            var expr = elements[i];
-            if (expr is not null)
-            {
-                Visit(expr);
-            }
+            Visit(body[i]);
         }
 
-        return arrayPattern;
+        return staticBlock;
     }
 
-    protected internal virtual object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    protected internal virtual object? VisitSuper(Super super)
     {
-        Visit(variableDeclarator.Id);
-        if (variableDeclarator.Init is not null)
+        return super;
+    }
+
+    protected internal virtual object? VisitSwitchCase(SwitchCase switchCase)
+    {
+        if (switchCase.Test is not null)
         {
-            Visit(variableDeclarator.Init);
+            Visit(switchCase.Test);
         }
 
-        return variableDeclarator;
+        ref readonly var consequent = ref switchCase.Consequent;
+        for (var i = 0; i < consequent.Count; i++)
+        {
+            Visit(consequent[i]);
+        }
+
+        return switchCase;
+    }
+
+    protected internal virtual object? VisitSwitchStatement(SwitchStatement switchStatement)
+    {
+        Visit(switchStatement.Discriminant);
+        ref readonly var cases = ref switchStatement.Cases;
+        for (var i = 0; i < cases.Count; i++)
+        {
+            Visit(cases[i]);
+        }
+
+        return switchStatement;
+    }
+
+    protected internal virtual object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    {
+        Visit(taggedTemplateExpression.Tag);
+        Visit(taggedTemplateExpression.Quasi);
+
+        return taggedTemplateExpression;
+    }
+
+    protected internal virtual object? VisitTemplateElement(TemplateElement templateElement)
+    {
+        return templateElement;
     }
 
     protected internal virtual object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
@@ -659,134 +706,86 @@ public class AstVisitor
         return templateLiteral;
     }
 
-    protected internal virtual object? VisitTemplateElement(TemplateElement templateElement)
+    protected internal virtual object? VisitThisExpression(ThisExpression thisExpression)
     {
-        return templateElement;
+        return thisExpression;
     }
 
-    protected internal virtual object? VisitRestElement(RestElement restElement)
+    protected internal virtual object? VisitThrowStatement(ThrowStatement throwStatement)
     {
-        Visit(restElement.Argument);
+        Visit(throwStatement.Argument);
 
-        return restElement;
+        return throwStatement;
     }
 
-    protected internal virtual object? VisitProperty(Property property)
+    protected internal virtual object? VisitTryStatement(TryStatement tryStatement)
     {
-        Visit(property.Key);
-        Visit(property.Value);
-
-        return property;
-    }
-
-    protected internal virtual object? VisitAwaitExpression(AwaitExpression awaitExpression)
-    {
-        Visit(awaitExpression.Argument);
-
-        return awaitExpression;
-    }
-
-    protected internal virtual object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
-    {
-        Visit(conditionalExpression.Test);
-        Visit(conditionalExpression.Consequent);
-        Visit(conditionalExpression.Alternate);
-
-        return conditionalExpression;
-    }
-
-    protected internal virtual object? VisitCallExpression(CallExpression callExpression)
-    {
-        Visit(callExpression.Callee);
-        ref readonly var arguments = ref callExpression.Arguments;
-        for (var i = 0; i < arguments.Count; i++)
+        Visit(tryStatement.Block);
+        if (tryStatement.Handler is not null)
         {
-            Visit(arguments[i]);
+            Visit(tryStatement.Handler);
         }
 
-        return callExpression;
-    }
-
-    protected internal virtual object? VisitBinaryExpression(BinaryExpression binaryExpression)
-    {
-        Visit(binaryExpression.Left);
-        Visit(binaryExpression.Right);
-
-        return binaryExpression;
-    }
-
-    protected internal virtual object? VisitArrayExpression(ArrayExpression arrayExpression)
-    {
-        ref readonly var elements = ref arrayExpression.Elements;
-        for (var i = 0; i < elements.Count; i++)
+        if (tryStatement.Finalizer is not null)
         {
-            var expr = elements[i];
-            if (expr is not null)
-            {
-                Visit(expr);
-            }
+            Visit(tryStatement.Finalizer);
         }
 
-        return arrayExpression;
+        return tryStatement;
     }
 
-    protected internal virtual object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+    protected internal virtual object? VisitUnaryExpression(UnaryExpression unaryExpression)
     {
-        Visit(assignmentExpression.Left);
-        Visit(assignmentExpression.Right);
+        Visit(unaryExpression.Argument);
 
-        return assignmentExpression;
+        return unaryExpression;
     }
 
-    protected internal virtual object? VisitContinueStatement(ContinueStatement continueStatement)
+    protected internal virtual object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
     {
-        if (continueStatement.Label is not null)
+        ref readonly var declarations = ref variableDeclaration.Declarations;
+        for (var i = 0; i < declarations.Count; i++)
         {
-            Visit(continueStatement.Label);
+            Visit(declarations[i]);
         }
 
-        return continueStatement;
+        return variableDeclaration;
     }
 
-    protected internal virtual object? VisitBreakStatement(BreakStatement breakStatement)
+    protected internal virtual object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
     {
-        if (breakStatement.Label is not null)
+        Visit(variableDeclarator.Id);
+        if (variableDeclarator.Init is not null)
         {
-            Visit(breakStatement.Label);
+            Visit(variableDeclarator.Init);
         }
 
-        return breakStatement;
+        return variableDeclarator;
     }
 
-    protected internal virtual object? VisitBlockStatement(BlockStatement blockStatement)
+    protected internal virtual object? VisitWhileStatement(WhileStatement whileStatement)
     {
-        ref readonly var body = ref blockStatement.Body;
-        for (var i = 0; i < body.Count; i++)
+        Visit(whileStatement.Test);
+        Visit(whileStatement.Body);
+
+        return whileStatement;
+    }
+
+    protected internal virtual object? VisitWithStatement(WithStatement withStatement)
+    {
+        Visit(withStatement.Object);
+        Visit(withStatement.Body);
+
+        return withStatement;
+    }
+
+    protected internal virtual object? VisitYieldExpression(YieldExpression yieldExpression)
+    {
+        if (yieldExpression.Argument is not null)
         {
-            Visit(body[i]);
+            Visit(yieldExpression.Argument);
         }
 
-        return blockStatement;
-    }
-
-    protected internal virtual object? VisitStaticBlock(StaticBlock staticBlock)
-    {
-        ref readonly var body = ref staticBlock.Body;
-        for (var i = 0; i < body.Count; i++)
-        {
-            Visit(body[i]);
-        }
-
-        return staticBlock;
-    }
-
-    protected internal virtual object? VisitExtension(Node node)
-    {
-        // Node type Extension is used to represent extensions to the standard AST (for example, see JSX parsing).
-        // Nodes of this type never appear in the tree returned by the core parser (JavaScriptParser),
-        // thus the visitor doesn't deal with this type by default. Inheritors either need to override this method,
-        // or inherit from another visitor which was built to handle extension nodes (e.g. JsxAstVisitor in the case of JSX).
-
-        throw UnsupportedNodeType(node.GetType());
+        return yieldExpression;
     }
 }

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -8,148 +8,148 @@ namespace Esprima.Utils;
 /// </summary>
 public class AstVisitorEventSource : AstVisitor
 {
-    public event EventHandler<Node>? VisitingNode;
-    public event EventHandler<Node>? VisitedNode;
-    public event EventHandler<Program>? VisitingProgram;
-    public event EventHandler<Program>? VisitedProgram;
+    public event EventHandler<ArrayExpression>? VisitingArrayExpression;
+    public event EventHandler<ArrayExpression>? VisitedArrayExpression;
+    public event EventHandler<ArrayPattern>? VisitedArrayPattern;
+    public event EventHandler<ArrayPattern>? VisitingArrayPattern;
+    public event EventHandler<ArrowFunctionExpression>? VisitedArrowFunctionExpression;
+    public event EventHandler<ArrowFunctionExpression>? VisitingArrowFunctionExpression;
+    public event EventHandler<AssignmentExpression>? VisitedAssignmentExpression;
+    public event EventHandler<AssignmentExpression>? VisitingAssignmentExpression;
+    public event EventHandler<AssignmentPattern>? VisitedAssignmentPattern;
+    public event EventHandler<AssignmentPattern>? VisitingAssignmentPattern;
+    public event EventHandler<AwaitExpression>? VisitingAwaitExpression;
+    public event EventHandler<AwaitExpression>? VisitedAwaitExpression;
+    public event EventHandler<BinaryExpression>? VisitingBinaryExpression;
+    public event EventHandler<BinaryExpression>? VisitedBinaryExpression;
+    public event EventHandler<BlockStatement>? VisitingBlockStatement;
+    public event EventHandler<BlockStatement>? VisitedBlockStatement;
+    public event EventHandler<BreakStatement>? VisitingBreakStatement;
+    public event EventHandler<BreakStatement>? VisitedBreakStatement;
+    public event EventHandler<CallExpression>? VisitingCallExpression;
+    public event EventHandler<CallExpression>? VisitedCallExpression;
     public event EventHandler<CatchClause>? VisitingCatchClause;
     public event EventHandler<CatchClause>? VisitedCatchClause;
-    public event EventHandler<FunctionDeclaration>? VisitingFunctionDeclaration;
-    public event EventHandler<FunctionDeclaration>? VisitedFunctionDeclaration;
-    public event EventHandler<WithStatement>? VisitingWithStatement;
-    public event EventHandler<WithStatement>? VisitedWithStatement;
-    public event EventHandler<WhileStatement>? VisitingWhileStatement;
-    public event EventHandler<WhileStatement>? VisitedWhileStatement;
-    public event EventHandler<VariableDeclaration>? VisitingVariableDeclaration;
-    public event EventHandler<VariableDeclaration>? VisitedVariableDeclaration;
-    public event EventHandler<TryStatement>? VisitingTryStatement;
-    public event EventHandler<TryStatement>? VisitedTryStatement;
-    public event EventHandler<ThrowStatement>? VisitingThrowStatement;
-    public event EventHandler<ThrowStatement>? VisitedThrowStatement;
-    public event EventHandler<SwitchStatement>? VisitingSwitchStatement;
-    public event EventHandler<SwitchStatement>? VisitedSwitchStatement;
-    public event EventHandler<SwitchCase>? VisitingSwitchCase;
-    public event EventHandler<SwitchCase>? VisitedSwitchCase;
-    public event EventHandler<ReturnStatement>? VisitingReturnStatement;
-    public event EventHandler<ReturnStatement>? VisitedReturnStatement;
-    public event EventHandler<LabeledStatement>? VisitingLabeledStatement;
-    public event EventHandler<LabeledStatement>? VisitedLabeledStatement;
-    public event EventHandler<IfStatement>? VisitingIfStatement;
-    public event EventHandler<IfStatement>? VisitedIfStatement;
-    public event EventHandler<EmptyStatement>? VisitingEmptyStatement;
-    public event EventHandler<EmptyStatement>? VisitedEmptyStatement;
-    public event EventHandler<DebuggerStatement>? VisitingDebuggerStatement;
-    public event EventHandler<DebuggerStatement>? VisitedDebuggerStatement;
-    public event EventHandler<ExpressionStatement>? VisitingExpressionStatement;
-    public event EventHandler<ExpressionStatement>? VisitedExpressionStatement;
-    public event EventHandler<ForStatement>? VisitingForStatement;
-    public event EventHandler<ForStatement>? VisitedForStatement;
-    public event EventHandler<ForInStatement>? VisitingForInStatement;
-    public event EventHandler<ForInStatement>? VisitedForInStatement;
-    public event EventHandler<DoWhileStatement>? VisitingDoWhileStatement;
-    public event EventHandler<DoWhileStatement>? VisitedDoWhileStatement;
-    public event EventHandler<ArrowFunctionExpression>? VisitingArrowFunctionExpression;
-    public event EventHandler<ArrowFunctionExpression>? VisitedArrowFunctionExpression;
-    public event EventHandler<UnaryExpression>? VisitingUnaryExpression;
-    public event EventHandler<UnaryExpression>? VisitedUnaryExpression;
-    public event EventHandler<ThisExpression>? VisitingThisExpression;
-    public event EventHandler<ThisExpression>? VisitedThisExpression;
-    public event EventHandler<SequenceExpression>? VisitingSequenceExpression;
-    public event EventHandler<SequenceExpression>? VisitedSequenceExpression;
-    public event EventHandler<ObjectExpression>? VisitingObjectExpression;
-    public event EventHandler<ObjectExpression>? VisitedObjectExpression;
-    public event EventHandler<NewExpression>? VisitingNewExpression;
-    public event EventHandler<NewExpression>? VisitedNewExpression;
-    public event EventHandler<MemberExpression>? VisitingMemberExpression;
-    public event EventHandler<MemberExpression>? VisitedMemberExpression;
-    public event EventHandler<Literal>? VisitingLiteral;
-    public event EventHandler<Literal>? VisitedLiteral;
-    public event EventHandler<Identifier>? VisitingIdentifier;
-    public event EventHandler<Identifier>? VisitedIdentifier;
-    public event EventHandler<PrivateIdentifier>? VisitingPrivateIdentifier;
-    public event EventHandler<PrivateIdentifier>? VisitedPrivateIdentifier;
-    public event EventHandler<FunctionExpression>? VisitingFunctionExpression;
-    public event EventHandler<FunctionExpression>? VisitedFunctionExpression;
-    public event EventHandler<PropertyDefinition>? VisitingPropertyDefinition;
-    public event EventHandler<PropertyDefinition>? VisitedPropertyDefinition;
     public event EventHandler<ChainExpression>? VisitingChainExpression;
     public event EventHandler<ChainExpression>? VisitedChainExpression;
+    public event EventHandler<ClassBody>? VisitingClassBody;
+    public event EventHandler<ClassBody>? VisitedClassBody;
+    public event EventHandler<ClassDeclaration>? VisitingClassDeclaration;
+    public event EventHandler<ClassDeclaration>? VisitedClassDeclaration;
     public event EventHandler<ClassExpression>? VisitingClassExpression;
     public event EventHandler<ClassExpression>? VisitedClassExpression;
-    public event EventHandler<ExportDefaultDeclaration>? VisitingExportDefaultDeclaration;
-    public event EventHandler<ExportDefaultDeclaration>? VisitedExportDefaultDeclaration;
+    public event EventHandler<ConditionalExpression>? VisitingConditionalExpression;
+    public event EventHandler<ConditionalExpression>? VisitedConditionalExpression;
+    public event EventHandler<ContinueStatement>? VisitingContinueStatement;
+    public event EventHandler<ContinueStatement>? VisitedContinueStatement;
+    public event EventHandler<DebuggerStatement>? VisitingDebuggerStatement;
+    public event EventHandler<DebuggerStatement>? VisitedDebuggerStatement;
+    public event EventHandler<Decorator>? VisitingDecorator;
+    public event EventHandler<Decorator>? VisitedDecorator;
+    public event EventHandler<DoWhileStatement>? VisitingDoWhileStatement;
+    public event EventHandler<DoWhileStatement>? VisitedDoWhileStatement;
+    public event EventHandler<EmptyStatement>? VisitingEmptyStatement;
+    public event EventHandler<EmptyStatement>? VisitedEmptyStatement;
     public event EventHandler<ExportAllDeclaration>? VisitingExportAllDeclaration;
     public event EventHandler<ExportAllDeclaration>? VisitedExportAllDeclaration;
+    public event EventHandler<ExportDefaultDeclaration>? VisitingExportDefaultDeclaration;
+    public event EventHandler<ExportDefaultDeclaration>? VisitedExportDefaultDeclaration;
     public event EventHandler<ExportNamedDeclaration>? VisitingExportNamedDeclaration;
     public event EventHandler<ExportNamedDeclaration>? VisitedExportNamedDeclaration;
     public event EventHandler<ExportSpecifier>? VisitingExportSpecifier;
     public event EventHandler<ExportSpecifier>? VisitedExportSpecifier;
+    public event EventHandler<ExpressionStatement>? VisitingExpressionStatement;
+    public event EventHandler<ExpressionStatement>? VisitedExpressionStatement;
+    public event EventHandler<ForInStatement>? VisitingForInStatement;
+    public event EventHandler<ForInStatement>? VisitedForInStatement;
+    public event EventHandler<ForOfStatement>? VisitingForOfStatement;
+    public event EventHandler<ForOfStatement>? VisitedForOfStatement;
+    public event EventHandler<ForStatement>? VisitingForStatement;
+    public event EventHandler<ForStatement>? VisitedForStatement;
+    public event EventHandler<FunctionDeclaration>? VisitingFunctionDeclaration;
+    public event EventHandler<FunctionDeclaration>? VisitedFunctionDeclaration;
+    public event EventHandler<FunctionExpression>? VisitingFunctionExpression;
+    public event EventHandler<FunctionExpression>? VisitedFunctionExpression;
+    public event EventHandler<Identifier>? VisitingIdentifier;
+    public event EventHandler<Identifier>? VisitedIdentifier;
+    public event EventHandler<IfStatement>? VisitingIfStatement;
+    public event EventHandler<IfStatement>? VisitedIfStatement;
     public event EventHandler<Import>? VisitingImport;
     public event EventHandler<Import>? VisitedImport;
     public event EventHandler<ImportDeclaration>? VisitingImportDeclaration;
     public event EventHandler<ImportDeclaration>? VisitedImportDeclaration;
-    public event EventHandler<ImportNamespaceSpecifier>? VisitingImportNamespaceSpecifier;
-    public event EventHandler<ImportNamespaceSpecifier>? VisitedImportNamespaceSpecifier;
     public event EventHandler<ImportDefaultSpecifier>? VisitingImportDefaultSpecifier;
     public event EventHandler<ImportDefaultSpecifier>? VisitedImportDefaultSpecifier;
+    public event EventHandler<ImportNamespaceSpecifier>? VisitingImportNamespaceSpecifier;
+    public event EventHandler<ImportNamespaceSpecifier>? VisitedImportNamespaceSpecifier;
     public event EventHandler<ImportSpecifier>? VisitingImportSpecifier;
     public event EventHandler<ImportSpecifier>? VisitedImportSpecifier;
-    public event EventHandler<MethodDefinition>? VisitingMethodDefinition;
-    public event EventHandler<MethodDefinition>? VisitedMethodDefinition;
-    public event EventHandler<ForOfStatement>? VisitingForOfStatement;
-    public event EventHandler<ForOfStatement>? VisitedForOfStatement;
-    public event EventHandler<ClassDeclaration>? VisitingClassDeclaration;
-    public event EventHandler<ClassDeclaration>? VisitedClassDeclaration;
-    public event EventHandler<ClassBody>? VisitingClassBody;
-    public event EventHandler<ClassBody>? VisitedClassBody;
-    public event EventHandler<YieldExpression>? VisitingYieldExpression;
-    public event EventHandler<YieldExpression>? VisitedYieldExpression;
-    public event EventHandler<TaggedTemplateExpression>? VisitingTaggedTemplateExpression;
-    public event EventHandler<TaggedTemplateExpression>? VisitedTaggedTemplateExpression;
-    public event EventHandler<Super>? VisitingSuper;
-    public event EventHandler<Super>? VisitedSuper;
+    public event EventHandler<LabeledStatement>? VisitingLabeledStatement;
+    public event EventHandler<LabeledStatement>? VisitedLabeledStatement;
+    public event EventHandler<Literal>? VisitingLiteral;
+    public event EventHandler<Literal>? VisitedLiteral;
+    public event EventHandler<MemberExpression>? VisitingMemberExpression;
+    public event EventHandler<MemberExpression>? VisitedMemberExpression;
     public event EventHandler<MetaProperty>? VisitingMetaProperty;
     public event EventHandler<MetaProperty>? VisitedMetaProperty;
+    public event EventHandler<MethodDefinition>? VisitingMethodDefinition;
+    public event EventHandler<MethodDefinition>? VisitedMethodDefinition;
+    public event EventHandler<NewExpression>? VisitingNewExpression;
+    public event EventHandler<NewExpression>? VisitedNewExpression;
+    public event EventHandler<Node>? VisitingNode;
+    public event EventHandler<Node>? VisitedNode;
+    public event EventHandler<ObjectExpression>? VisitingObjectExpression;
+    public event EventHandler<ObjectExpression>? VisitedObjectExpression;
     public event EventHandler<ObjectPattern>? VisitingObjectPattern;
     public event EventHandler<ObjectPattern>? VisitedObjectPattern;
-    public event EventHandler<SpreadElement>? VisitingSpreadElement;
-    public event EventHandler<SpreadElement>? VisitedSpreadElement;
-    public event EventHandler<AssignmentPattern>? VisitingAssignmentPattern;
-    public event EventHandler<AssignmentPattern>? VisitedAssignmentPattern;
-    public event EventHandler<ArrayPattern>? VisitingArrayPattern;
-    public event EventHandler<ArrayPattern>? VisitedArrayPattern;
-    public event EventHandler<VariableDeclarator>? VisitingVariableDeclarator;
-    public event EventHandler<VariableDeclarator>? VisitedVariableDeclarator;
-    public event EventHandler<TemplateLiteral>? VisitingTemplateLiteral;
-    public event EventHandler<TemplateLiteral>? VisitedTemplateLiteral;
-    public event EventHandler<TemplateElement>? VisitingTemplateElement;
-    public event EventHandler<TemplateElement>? VisitedTemplateElement;
-    public event EventHandler<RestElement>? VisitingRestElement;
-    public event EventHandler<RestElement>? VisitedRestElement;
+    public event EventHandler<PrivateIdentifier>? VisitingPrivateIdentifier;
+    public event EventHandler<PrivateIdentifier>? VisitedPrivateIdentifier;
+    public event EventHandler<Program>? VisitingProgram;
+    public event EventHandler<Program>? VisitedProgram;
     public event EventHandler<Property>? VisitingProperty;
     public event EventHandler<Property>? VisitedProperty;
-    public event EventHandler<AwaitExpression>? VisitingAwaitExpression;
-    public event EventHandler<AwaitExpression>? VisitedAwaitExpression;
-    public event EventHandler<ConditionalExpression>? VisitingConditionalExpression;
-    public event EventHandler<ConditionalExpression>? VisitedConditionalExpression;
-    public event EventHandler<CallExpression>? VisitingCallExpression;
-    public event EventHandler<CallExpression>? VisitedCallExpression;
-    public event EventHandler<BinaryExpression>? VisitingBinaryExpression;
-    public event EventHandler<BinaryExpression>? VisitedBinaryExpression;
-    public event EventHandler<ArrayExpression>? VisitingArrayExpression;
-    public event EventHandler<ArrayExpression>? VisitedArrayExpression;
-    public event EventHandler<AssignmentExpression>? VisitingAssignmentExpression;
-    public event EventHandler<AssignmentExpression>? VisitedAssignmentExpression;
-    public event EventHandler<ContinueStatement>? VisitingContinueStatement;
-    public event EventHandler<ContinueStatement>? VisitedContinueStatement;
-    public event EventHandler<BreakStatement>? VisitingBreakStatement;
-    public event EventHandler<BreakStatement>? VisitedBreakStatement;
-    public event EventHandler<BlockStatement>? VisitingBlockStatement;
-    public event EventHandler<BlockStatement>? VisitedBlockStatement;
-    public event EventHandler<Decorator>? VisitingDecorator;
-    public event EventHandler<Decorator>? VisitedDecorator;
+    public event EventHandler<PropertyDefinition>? VisitingPropertyDefinition;
+    public event EventHandler<PropertyDefinition>? VisitedPropertyDefinition;
+    public event EventHandler<RestElement>? VisitingRestElement;
+    public event EventHandler<RestElement>? VisitedRestElement;
+    public event EventHandler<ReturnStatement>? VisitingReturnStatement;
+    public event EventHandler<ReturnStatement>? VisitedReturnStatement;
+    public event EventHandler<SequenceExpression>? VisitingSequenceExpression;
+    public event EventHandler<SequenceExpression>? VisitedSequenceExpression;
+    public event EventHandler<SpreadElement>? VisitingSpreadElement;
+    public event EventHandler<SpreadElement>? VisitedSpreadElement;
     public event EventHandler<StaticBlock>? VisitingStaticBlock;
     public event EventHandler<StaticBlock>? VisitedStaticBlock;
+    public event EventHandler<Super>? VisitingSuper;
+    public event EventHandler<Super>? VisitedSuper;
+    public event EventHandler<SwitchCase>? VisitingSwitchCase;
+    public event EventHandler<SwitchCase>? VisitedSwitchCase;
+    public event EventHandler<SwitchStatement>? VisitingSwitchStatement;
+    public event EventHandler<SwitchStatement>? VisitedSwitchStatement;
+    public event EventHandler<TaggedTemplateExpression>? VisitingTaggedTemplateExpression;
+    public event EventHandler<TaggedTemplateExpression>? VisitedTaggedTemplateExpression;
+    public event EventHandler<TemplateElement>? VisitingTemplateElement;
+    public event EventHandler<TemplateElement>? VisitedTemplateElement;
+    public event EventHandler<TemplateLiteral>? VisitingTemplateLiteral;
+    public event EventHandler<TemplateLiteral>? VisitedTemplateLiteral;
+    public event EventHandler<ThisExpression>? VisitingThisExpression;
+    public event EventHandler<ThisExpression>? VisitedThisExpression;
+    public event EventHandler<ThrowStatement>? VisitingThrowStatement;
+    public event EventHandler<ThrowStatement>? VisitedThrowStatement;
+    public event EventHandler<TryStatement>? VisitingTryStatement;
+    public event EventHandler<TryStatement>? VisitedTryStatement;
+    public event EventHandler<UnaryExpression>? VisitingUnaryExpression;
+    public event EventHandler<UnaryExpression>? VisitedUnaryExpression;
+    public event EventHandler<VariableDeclaration>? VisitingVariableDeclaration;
+    public event EventHandler<VariableDeclaration>? VisitedVariableDeclaration;
+    public event EventHandler<VariableDeclarator>? VisitingVariableDeclarator;
+    public event EventHandler<VariableDeclarator>? VisitedVariableDeclarator;
+    public event EventHandler<WhileStatement>? VisitingWhileStatement;
+    public event EventHandler<WhileStatement>? VisitedWhileStatement;
+    public event EventHandler<WithStatement>? VisitingWithStatement;
+    public event EventHandler<WithStatement>? VisitedWithStatement;
+    public event EventHandler<YieldExpression>? VisitingYieldExpression;
+    public event EventHandler<YieldExpression>? VisitedYieldExpression;
 
     public override object? Visit(Node node)
     {
@@ -159,155 +159,19 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitProgram(Program program)
+    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
     {
-        VisitingProgram?.Invoke(this, program);
-        var result = base.VisitProgram(program);
-        VisitedProgram?.Invoke(this, program);
+        VisitingArrayExpression?.Invoke(this, arrayExpression);
+        var result = base.VisitArrayExpression(arrayExpression);
+        VisitedArrayExpression?.Invoke(this, arrayExpression);
         return result;
     }
 
-    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
     {
-        VisitingCatchClause?.Invoke(this, catchClause);
-        var result = base.VisitCatchClause(catchClause);
-        VisitedCatchClause?.Invoke(this, catchClause);
-        return result;
-    }
-
-    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
-    {
-        VisitingFunctionDeclaration?.Invoke(this, functionDeclaration);
-        var result = base.VisitFunctionDeclaration(functionDeclaration);
-        VisitedFunctionDeclaration?.Invoke(this, functionDeclaration);
-        return result;
-    }
-
-    protected internal override object? VisitWithStatement(WithStatement withStatement)
-    {
-        VisitingWithStatement?.Invoke(this, withStatement);
-        var result = base.VisitWithStatement(withStatement);
-        VisitedWithStatement?.Invoke(this, withStatement);
-        return result;
-    }
-
-    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
-    {
-        VisitingWhileStatement?.Invoke(this, whileStatement);
-        var result = base.VisitWhileStatement(whileStatement);
-        VisitedWhileStatement?.Invoke(this, whileStatement);
-        return result;
-    }
-
-    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
-    {
-        VisitingVariableDeclaration?.Invoke(this, variableDeclaration);
-        var result = base.VisitVariableDeclaration(variableDeclaration);
-        VisitedVariableDeclaration?.Invoke(this, variableDeclaration);
-        return result;
-    }
-
-    protected internal override object? VisitTryStatement(TryStatement tryStatement)
-    {
-        VisitingTryStatement?.Invoke(this, tryStatement);
-        var result = base.VisitTryStatement(tryStatement);
-        VisitedTryStatement?.Invoke(this, tryStatement);
-        return result;
-    }
-
-    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
-    {
-        VisitingThrowStatement?.Invoke(this, throwStatement);
-        var result = base.VisitThrowStatement(throwStatement);
-        VisitedThrowStatement?.Invoke(this, throwStatement);
-        return result;
-    }
-
-    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
-    {
-        VisitingSwitchStatement?.Invoke(this, switchStatement);
-        var result = base.VisitSwitchStatement(switchStatement);
-        VisitedSwitchStatement?.Invoke(this, switchStatement);
-        return result;
-    }
-
-    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
-    {
-        VisitingSwitchCase?.Invoke(this, switchCase);
-        var result = base.VisitSwitchCase(switchCase);
-        VisitedSwitchCase?.Invoke(this, switchCase);
-        return result;
-    }
-
-    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
-    {
-        VisitingReturnStatement?.Invoke(this, returnStatement);
-        var result = base.VisitReturnStatement(returnStatement);
-        VisitedReturnStatement?.Invoke(this, returnStatement);
-        return result;
-    }
-
-    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
-    {
-        VisitingLabeledStatement?.Invoke(this, labeledStatement);
-        var result = base.VisitLabeledStatement(labeledStatement);
-        VisitedLabeledStatement?.Invoke(this, labeledStatement);
-        return result;
-    }
-
-    protected internal override object? VisitIfStatement(IfStatement ifStatement)
-    {
-        VisitingIfStatement?.Invoke(this, ifStatement);
-        var result = base.VisitIfStatement(ifStatement);
-        VisitedIfStatement?.Invoke(this, ifStatement);
-        return result;
-    }
-
-    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
-    {
-        VisitingEmptyStatement?.Invoke(this, emptyStatement);
-        var result = base.VisitEmptyStatement(emptyStatement);
-        VisitedEmptyStatement?.Invoke(this, emptyStatement);
-        return result;
-    }
-
-    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
-    {
-        VisitingDebuggerStatement?.Invoke(this, debuggerStatement);
-        var result = base.VisitDebuggerStatement(debuggerStatement);
-        VisitedDebuggerStatement?.Invoke(this, debuggerStatement);
-        return result;
-    }
-
-    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
-    {
-        VisitingExpressionStatement?.Invoke(this, expressionStatement);
-        var result = base.VisitExpressionStatement(expressionStatement);
-        VisitedExpressionStatement?.Invoke(this, expressionStatement);
-        return result;
-    }
-
-    protected internal override object? VisitForStatement(ForStatement forStatement)
-    {
-        VisitingForStatement?.Invoke(this, forStatement);
-        var result = base.VisitForStatement(forStatement);
-        VisitedForStatement?.Invoke(this, forStatement);
-        return result;
-    }
-
-    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
-    {
-        VisitingForInStatement?.Invoke(this, forInStatement);
-        var result = base.VisitForInStatement(forInStatement);
-        VisitedForInStatement?.Invoke(this, forInStatement);
-        return result;
-    }
-
-    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
-    {
-        VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
-        var result = base.VisitDoWhileStatement(doWhileStatement);
-        VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
+        VisitingArrayPattern?.Invoke(this, arrayPattern);
+        var result = base.VisitArrayPattern(arrayPattern);
+        VisitedArrayPattern?.Invoke(this, arrayPattern);
         return result;
     }
 
@@ -319,91 +183,67 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
     {
-        VisitingUnaryExpression?.Invoke(this, unaryExpression);
-        var result = base.VisitUnaryExpression(unaryExpression);
-        VisitedUnaryExpression?.Invoke(this, unaryExpression);
+        VisitingAssignmentExpression?.Invoke(this, assignmentExpression);
+        var result = base.VisitAssignmentExpression(assignmentExpression);
+        VisitedAssignmentExpression?.Invoke(this, assignmentExpression);
         return result;
     }
 
-    protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
     {
-        VisitingThisExpression?.Invoke(this, thisExpression);
-        var result = base.VisitThisExpression(thisExpression);
-        VisitedThisExpression?.Invoke(this, thisExpression);
+        VisitingAssignmentPattern?.Invoke(this, assignmentPattern);
+        var result = base.VisitAssignmentPattern(assignmentPattern);
+        VisitedAssignmentPattern?.Invoke(this, assignmentPattern);
         return result;
     }
 
-    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
     {
-        VisitingSequenceExpression?.Invoke(this, sequenceExpression);
-        var result = base.VisitSequenceExpression(sequenceExpression);
-        VisitedSequenceExpression?.Invoke(this, sequenceExpression);
+        VisitingAwaitExpression?.Invoke(this, awaitExpression);
+        var result = base.VisitAwaitExpression(awaitExpression);
+        VisitedAwaitExpression?.Invoke(this, awaitExpression);
         return result;
     }
 
-    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
     {
-        VisitingObjectExpression?.Invoke(this, objectExpression);
-        var result = base.VisitObjectExpression(objectExpression);
-        VisitedObjectExpression?.Invoke(this, objectExpression);
+        VisitingBinaryExpression?.Invoke(this, binaryExpression);
+        var result = base.VisitBinaryExpression(binaryExpression);
+        VisitedBinaryExpression?.Invoke(this, binaryExpression);
         return result;
     }
 
-    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
     {
-        VisitingNewExpression?.Invoke(this, newExpression);
-        var result = base.VisitNewExpression(newExpression);
-        VisitedNewExpression?.Invoke(this, newExpression);
+        VisitingBlockStatement?.Invoke(this, blockStatement);
+        var result = base.VisitBlockStatement(blockStatement);
+        VisitedBlockStatement?.Invoke(this, blockStatement);
         return result;
     }
 
-    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
     {
-        VisitingMemberExpression?.Invoke(this, memberExpression);
-        var result = base.VisitMemberExpression(memberExpression);
-        VisitedMemberExpression?.Invoke(this, memberExpression);
+        VisitingBreakStatement?.Invoke(this, breakStatement);
+        var result = base.VisitBreakStatement(breakStatement);
+        VisitedBreakStatement?.Invoke(this, breakStatement);
         return result;
     }
 
-    protected internal override object? VisitLiteral(Literal literal)
+    protected internal override object? VisitCallExpression(CallExpression callExpression)
     {
-        VisitingLiteral?.Invoke(this, literal);
-        var result = base.VisitLiteral(literal);
-        VisitedLiteral?.Invoke(this, literal);
+        VisitingCallExpression?.Invoke(this, callExpression);
+        var result = base.VisitCallExpression(callExpression);
+        VisitedCallExpression?.Invoke(this, callExpression);
         return result;
     }
 
-    protected internal override object? VisitIdentifier(Identifier identifier)
+    protected internal override object? VisitCatchClause(CatchClause catchClause)
     {
-        VisitingIdentifier?.Invoke(this, identifier);
-        var result = base.VisitIdentifier(identifier);
-        VisitedIdentifier?.Invoke(this, identifier);
-        return result;
-    }
-
-    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
-    {
-        VisitingPrivateIdentifier?.Invoke(this, privateIdentifier);
-        var result = base.VisitPrivateIdentifier(privateIdentifier);
-        VisitedPrivateIdentifier?.Invoke(this, privateIdentifier);
-        return result;
-    }
-
-    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
-    {
-        VisitingFunctionExpression?.Invoke(this, functionExpression);
-        var result = base.VisitFunctionExpression(functionExpression);
-        VisitedFunctionExpression?.Invoke(this, functionExpression);
-        return result;
-    }
-
-    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
-    {
-        VisitingPropertyDefinition?.Invoke(this, propertyDefinition);
-        var result = base.VisitPropertyDefinition(propertyDefinition);
-        VisitedPropertyDefinition?.Invoke(this, propertyDefinition);
+        VisitingCatchClause?.Invoke(this, catchClause);
+        var result = base.VisitCatchClause(catchClause);
+        VisitedCatchClause?.Invoke(this, catchClause);
         return result;
     }
 
@@ -415,11 +255,19 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitDecorator(Decorator decorator)
+    protected internal override object? VisitClassBody(ClassBody classBody)
     {
-        VisitingDecorator?.Invoke(this, decorator);
-        var result = base.VisitDecorator(decorator);
-        VisitedDecorator?.Invoke(this, decorator);
+        VisitingClassBody?.Invoke(this, classBody);
+        var result = base.VisitClassBody(classBody);
+        VisitedClassBody?.Invoke(this, classBody);
+        return result;
+    }
+
+    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    {
+        VisitingClassDeclaration?.Invoke(this, classDeclaration);
+        var result = base.VisitClassDeclaration(classDeclaration);
+        VisitedClassDeclaration?.Invoke(this, classDeclaration);
         return result;
     }
 
@@ -431,11 +279,51 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
     {
-        VisitingExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
-        var result = base.VisitExportDefaultDeclaration(exportDefaultDeclaration);
-        VisitedExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
+        VisitingConditionalExpression?.Invoke(this, conditionalExpression);
+        var result = base.VisitConditionalExpression(conditionalExpression);
+        VisitedConditionalExpression?.Invoke(this, conditionalExpression);
+        return result;
+    }
+
+    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+    {
+        VisitingContinueStatement?.Invoke(this, continueStatement);
+        var result = base.VisitContinueStatement(continueStatement);
+        VisitedContinueStatement?.Invoke(this, continueStatement);
+        return result;
+    }
+
+    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+    {
+        VisitingDebuggerStatement?.Invoke(this, debuggerStatement);
+        var result = base.VisitDebuggerStatement(debuggerStatement);
+        VisitedDebuggerStatement?.Invoke(this, debuggerStatement);
+        return result;
+    }
+
+    protected internal override object? VisitDecorator(Decorator decorator)
+    {
+        VisitingDecorator?.Invoke(this, decorator);
+        var result = base.VisitDecorator(decorator);
+        VisitedDecorator?.Invoke(this, decorator);
+        return result;
+    }
+
+    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    {
+        VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
+        var result = base.VisitDoWhileStatement(doWhileStatement);
+        VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
+        return result;
+    }
+
+    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
+    {
+        VisitingEmptyStatement?.Invoke(this, emptyStatement);
+        var result = base.VisitEmptyStatement(emptyStatement);
+        VisitedEmptyStatement?.Invoke(this, emptyStatement);
         return result;
     }
 
@@ -444,6 +332,14 @@ public class AstVisitorEventSource : AstVisitor
         VisitingExportAllDeclaration?.Invoke(this, exportAllDeclaration);
         var result = base.VisitExportAllDeclaration(exportAllDeclaration);
         VisitedExportAllDeclaration?.Invoke(this, exportAllDeclaration);
+        return result;
+    }
+
+    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    {
+        VisitingExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
+        var result = base.VisitExportDefaultDeclaration(exportDefaultDeclaration);
+        VisitedExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
         return result;
     }
 
@@ -463,6 +359,70 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
+    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    {
+        VisitingExpressionStatement?.Invoke(this, expressionStatement);
+        var result = base.VisitExpressionStatement(expressionStatement);
+        VisitedExpressionStatement?.Invoke(this, expressionStatement);
+        return result;
+    }
+
+    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+    {
+        VisitingForInStatement?.Invoke(this, forInStatement);
+        var result = base.VisitForInStatement(forInStatement);
+        VisitedForInStatement?.Invoke(this, forInStatement);
+        return result;
+    }
+
+    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    {
+        VisitingForOfStatement?.Invoke(this, forOfStatement);
+        var result = base.VisitForOfStatement(forOfStatement);
+        VisitedForOfStatement?.Invoke(this, forOfStatement);
+        return result;
+    }
+
+    protected internal override object? VisitForStatement(ForStatement forStatement)
+    {
+        VisitingForStatement?.Invoke(this, forStatement);
+        var result = base.VisitForStatement(forStatement);
+        VisitedForStatement?.Invoke(this, forStatement);
+        return result;
+    }
+
+    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    {
+        VisitingFunctionDeclaration?.Invoke(this, functionDeclaration);
+        var result = base.VisitFunctionDeclaration(functionDeclaration);
+        VisitedFunctionDeclaration?.Invoke(this, functionDeclaration);
+        return result;
+    }
+
+    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    {
+        VisitingFunctionExpression?.Invoke(this, functionExpression);
+        var result = base.VisitFunctionExpression(functionExpression);
+        VisitedFunctionExpression?.Invoke(this, functionExpression);
+        return result;
+    }
+
+    protected internal override object? VisitIdentifier(Identifier identifier)
+    {
+        VisitingIdentifier?.Invoke(this, identifier);
+        var result = base.VisitIdentifier(identifier);
+        VisitedIdentifier?.Invoke(this, identifier);
+        return result;
+    }
+
+    protected internal override object? VisitIfStatement(IfStatement ifStatement)
+    {
+        VisitingIfStatement?.Invoke(this, ifStatement);
+        var result = base.VisitIfStatement(ifStatement);
+        VisitedIfStatement?.Invoke(this, ifStatement);
+        return result;
+    }
+
     protected internal override object? VisitImport(Import import)
     {
         VisitingImport?.Invoke(this, import);
@@ -479,19 +439,19 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
-    {
-        VisitingImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
-        var result = base.VisitImportNamespaceSpecifier(importNamespaceSpecifier);
-        VisitedImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
-        return result;
-    }
-
     protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
     {
         VisitingImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
         var result = base.VisitImportDefaultSpecifier(importDefaultSpecifier);
         VisitedImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
+        return result;
+    }
+
+    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    {
+        VisitingImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
+        var result = base.VisitImportNamespaceSpecifier(importNamespaceSpecifier);
+        VisitedImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
         return result;
     }
 
@@ -503,59 +463,27 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
     {
-        VisitingMethodDefinition?.Invoke(this, methodDefinition);
-        var result = base.VisitMethodDefinition(methodDefinition);
-        VisitedMethodDefinition?.Invoke(this, methodDefinition);
+        VisitingLabeledStatement?.Invoke(this, labeledStatement);
+        var result = base.VisitLabeledStatement(labeledStatement);
+        VisitedLabeledStatement?.Invoke(this, labeledStatement);
         return result;
     }
 
-    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal override object? VisitLiteral(Literal literal)
     {
-        VisitingForOfStatement?.Invoke(this, forOfStatement);
-        var result = base.VisitForOfStatement(forOfStatement);
-        VisitedForOfStatement?.Invoke(this, forOfStatement);
+        VisitingLiteral?.Invoke(this, literal);
+        var result = base.VisitLiteral(literal);
+        VisitedLiteral?.Invoke(this, literal);
         return result;
     }
 
-    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
     {
-        VisitingClassDeclaration?.Invoke(this, classDeclaration);
-        var result = base.VisitClassDeclaration(classDeclaration);
-        VisitedClassDeclaration?.Invoke(this, classDeclaration);
-        return result;
-    }
-
-    protected internal override object? VisitClassBody(ClassBody classBody)
-    {
-        VisitingClassBody?.Invoke(this, classBody);
-        var result = base.VisitClassBody(classBody);
-        VisitedClassBody?.Invoke(this, classBody);
-        return result;
-    }
-
-    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
-    {
-        VisitingYieldExpression?.Invoke(this, yieldExpression);
-        var result = base.VisitYieldExpression(yieldExpression);
-        VisitedYieldExpression?.Invoke(this, yieldExpression);
-        return result;
-    }
-
-    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
-    {
-        VisitingTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
-        var result = base.VisitTaggedTemplateExpression(taggedTemplateExpression);
-        VisitedTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
-        return result;
-    }
-
-    protected internal override object? VisitSuper(Super super)
-    {
-        VisitingSuper?.Invoke(this, super);
-        var result = base.VisitSuper(super);
-        VisitedSuper?.Invoke(this, super);
+        VisitingMemberExpression?.Invoke(this, memberExpression);
+        var result = base.VisitMemberExpression(memberExpression);
+        VisitedMemberExpression?.Invoke(this, memberExpression);
         return result;
     }
 
@@ -567,6 +495,30 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
+    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    {
+        VisitingMethodDefinition?.Invoke(this, methodDefinition);
+        var result = base.VisitMethodDefinition(methodDefinition);
+        VisitedMethodDefinition?.Invoke(this, methodDefinition);
+        return result;
+    }
+
+    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    {
+        VisitingNewExpression?.Invoke(this, newExpression);
+        var result = base.VisitNewExpression(newExpression);
+        VisitedNewExpression?.Invoke(this, newExpression);
+        return result;
+    }
+
+    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    {
+        VisitingObjectExpression?.Invoke(this, objectExpression);
+        var result = base.VisitObjectExpression(objectExpression);
+        VisitedObjectExpression?.Invoke(this, objectExpression);
+        return result;
+    }
+
     protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
     {
         VisitingObjectPattern?.Invoke(this, objectPattern);
@@ -575,59 +527,19 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
     {
-        VisitingSpreadElement?.Invoke(this, spreadElement);
-        var result = base.VisitSpreadElement(spreadElement);
-        VisitedSpreadElement?.Invoke(this, spreadElement);
+        VisitingPrivateIdentifier?.Invoke(this, privateIdentifier);
+        var result = base.VisitPrivateIdentifier(privateIdentifier);
+        VisitedPrivateIdentifier?.Invoke(this, privateIdentifier);
         return result;
     }
 
-    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal override object? VisitProgram(Program program)
     {
-        VisitingAssignmentPattern?.Invoke(this, assignmentPattern);
-        var result = base.VisitAssignmentPattern(assignmentPattern);
-        VisitedAssignmentPattern?.Invoke(this, assignmentPattern);
-        return result;
-    }
-
-    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
-    {
-        VisitingArrayPattern?.Invoke(this, arrayPattern);
-        var result = base.VisitArrayPattern(arrayPattern);
-        VisitedArrayPattern?.Invoke(this, arrayPattern);
-        return result;
-    }
-
-    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
-    {
-        VisitingVariableDeclarator?.Invoke(this, variableDeclarator);
-        var result = base.VisitVariableDeclarator(variableDeclarator);
-        VisitedVariableDeclarator?.Invoke(this, variableDeclarator);
-        return result;
-    }
-
-    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
-    {
-        VisitingTemplateLiteral?.Invoke(this, templateLiteral);
-        var result = base.VisitTemplateLiteral(templateLiteral);
-        VisitedTemplateLiteral?.Invoke(this, templateLiteral);
-        return result;
-    }
-
-    protected internal override object? VisitTemplateElement(TemplateElement templateElement)
-    {
-        VisitingTemplateElement?.Invoke(this, templateElement);
-        var result = base.VisitTemplateElement(templateElement);
-        VisitedTemplateElement?.Invoke(this, templateElement);
-        return result;
-    }
-
-    protected internal override object? VisitRestElement(RestElement restElement)
-    {
-        VisitingRestElement?.Invoke(this, restElement);
-        var result = base.VisitRestElement(restElement);
-        VisitedRestElement?.Invoke(this, restElement);
+        VisitingProgram?.Invoke(this, program);
+        var result = base.VisitProgram(program);
+        VisitedProgram?.Invoke(this, program);
         return result;
     }
 
@@ -639,75 +551,43 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
     {
-        VisitingAwaitExpression?.Invoke(this, awaitExpression);
-        var result = base.VisitAwaitExpression(awaitExpression);
-        VisitedAwaitExpression?.Invoke(this, awaitExpression);
+        VisitingPropertyDefinition?.Invoke(this, propertyDefinition);
+        var result = base.VisitPropertyDefinition(propertyDefinition);
+        VisitedPropertyDefinition?.Invoke(this, propertyDefinition);
         return result;
     }
 
-    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal override object? VisitRestElement(RestElement restElement)
     {
-        VisitingConditionalExpression?.Invoke(this, conditionalExpression);
-        var result = base.VisitConditionalExpression(conditionalExpression);
-        VisitedConditionalExpression?.Invoke(this, conditionalExpression);
+        VisitingRestElement?.Invoke(this, restElement);
+        var result = base.VisitRestElement(restElement);
+        VisitedRestElement?.Invoke(this, restElement);
         return result;
     }
 
-    protected internal override object? VisitCallExpression(CallExpression callExpression)
+    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
     {
-        VisitingCallExpression?.Invoke(this, callExpression);
-        var result = base.VisitCallExpression(callExpression);
-        VisitedCallExpression?.Invoke(this, callExpression);
+        VisitingReturnStatement?.Invoke(this, returnStatement);
+        var result = base.VisitReturnStatement(returnStatement);
+        VisitedReturnStatement?.Invoke(this, returnStatement);
         return result;
     }
 
-    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
     {
-        VisitingBinaryExpression?.Invoke(this, binaryExpression);
-        var result = base.VisitBinaryExpression(binaryExpression);
-        VisitedBinaryExpression?.Invoke(this, binaryExpression);
+        VisitingSequenceExpression?.Invoke(this, sequenceExpression);
+        var result = base.VisitSequenceExpression(sequenceExpression);
+        VisitedSequenceExpression?.Invoke(this, sequenceExpression);
         return result;
     }
 
-    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
     {
-        VisitingArrayExpression?.Invoke(this, arrayExpression);
-        var result = base.VisitArrayExpression(arrayExpression);
-        VisitedArrayExpression?.Invoke(this, arrayExpression);
-        return result;
-    }
-
-    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
-    {
-        VisitingAssignmentExpression?.Invoke(this, assignmentExpression);
-        var result = base.VisitAssignmentExpression(assignmentExpression);
-        VisitedAssignmentExpression?.Invoke(this, assignmentExpression);
-        return result;
-    }
-
-    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
-    {
-        VisitingContinueStatement?.Invoke(this, continueStatement);
-        var result = base.VisitContinueStatement(continueStatement);
-        VisitedContinueStatement?.Invoke(this, continueStatement);
-        return result;
-    }
-
-    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
-    {
-        VisitingBreakStatement?.Invoke(this, breakStatement);
-        var result = base.VisitBreakStatement(breakStatement);
-        VisitedBreakStatement?.Invoke(this, breakStatement);
-        return result;
-    }
-
-    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
-    {
-        VisitingBlockStatement?.Invoke(this, blockStatement);
-        var result = base.VisitBlockStatement(blockStatement);
-        VisitedBlockStatement?.Invoke(this, blockStatement);
+        VisitingSpreadElement?.Invoke(this, spreadElement);
+        var result = base.VisitSpreadElement(spreadElement);
+        VisitedSpreadElement?.Invoke(this, spreadElement);
         return result;
     }
 
@@ -716,6 +596,126 @@ public class AstVisitorEventSource : AstVisitor
         VisitingStaticBlock?.Invoke(this, staticBlock);
         var result = base.VisitStaticBlock(staticBlock);
         VisitedStaticBlock?.Invoke(this, staticBlock);
+        return result;
+    }
+
+    protected internal override object? VisitSuper(Super super)
+    {
+        VisitingSuper?.Invoke(this, super);
+        var result = base.VisitSuper(super);
+        VisitedSuper?.Invoke(this, super);
+        return result;
+    }
+
+    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+    {
+        VisitingSwitchCase?.Invoke(this, switchCase);
+        var result = base.VisitSwitchCase(switchCase);
+        VisitedSwitchCase?.Invoke(this, switchCase);
+        return result;
+    }
+
+    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+    {
+        VisitingSwitchStatement?.Invoke(this, switchStatement);
+        var result = base.VisitSwitchStatement(switchStatement);
+        VisitedSwitchStatement?.Invoke(this, switchStatement);
+        return result;
+    }
+
+    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    {
+        VisitingTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
+        var result = base.VisitTaggedTemplateExpression(taggedTemplateExpression);
+        VisitedTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
+        return result;
+    }
+
+    protected internal override object? VisitTemplateElement(TemplateElement templateElement)
+    {
+        VisitingTemplateElement?.Invoke(this, templateElement);
+        var result = base.VisitTemplateElement(templateElement);
+        VisitedTemplateElement?.Invoke(this, templateElement);
+        return result;
+    }
+
+    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    {
+        VisitingTemplateLiteral?.Invoke(this, templateLiteral);
+        var result = base.VisitTemplateLiteral(templateLiteral);
+        VisitedTemplateLiteral?.Invoke(this, templateLiteral);
+        return result;
+    }
+
+    protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+    {
+        VisitingThisExpression?.Invoke(this, thisExpression);
+        var result = base.VisitThisExpression(thisExpression);
+        VisitedThisExpression?.Invoke(this, thisExpression);
+        return result;
+    }
+
+    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+    {
+        VisitingThrowStatement?.Invoke(this, throwStatement);
+        var result = base.VisitThrowStatement(throwStatement);
+        VisitedThrowStatement?.Invoke(this, throwStatement);
+        return result;
+    }
+
+    protected internal override object? VisitTryStatement(TryStatement tryStatement)
+    {
+        VisitingTryStatement?.Invoke(this, tryStatement);
+        var result = base.VisitTryStatement(tryStatement);
+        VisitedTryStatement?.Invoke(this, tryStatement);
+        return result;
+    }
+
+    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    {
+        VisitingUnaryExpression?.Invoke(this, unaryExpression);
+        var result = base.VisitUnaryExpression(unaryExpression);
+        VisitedUnaryExpression?.Invoke(this, unaryExpression);
+        return result;
+    }
+
+    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    {
+        VisitingVariableDeclaration?.Invoke(this, variableDeclaration);
+        var result = base.VisitVariableDeclaration(variableDeclaration);
+        VisitedVariableDeclaration?.Invoke(this, variableDeclaration);
+        return result;
+    }
+
+    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    {
+        VisitingVariableDeclarator?.Invoke(this, variableDeclarator);
+        var result = base.VisitVariableDeclarator(variableDeclarator);
+        VisitedVariableDeclarator?.Invoke(this, variableDeclarator);
+        return result;
+    }
+
+    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+    {
+        VisitingWhileStatement?.Invoke(this, whileStatement);
+        var result = base.VisitWhileStatement(whileStatement);
+        VisitedWhileStatement?.Invoke(this, whileStatement);
+        return result;
+    }
+
+    protected internal override object? VisitWithStatement(WithStatement withStatement)
+    {
+        VisitingWithStatement?.Invoke(this, withStatement);
+        var result = base.VisitWithStatement(withStatement);
+        VisitedWithStatement?.Invoke(this, withStatement);
+        return result;
+    }
+
+    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+    {
+        VisitingYieldExpression?.Invoke(this, yieldExpression);
+        var result = base.VisitYieldExpression(yieldExpression);
+        VisitedYieldExpression?.Invoke(this, yieldExpression);
         return result;
     }
 }

--- a/src/Esprima/Utils/Jsx/IJsxAstVisitor.cs
+++ b/src/Esprima/Utils/Jsx/IJsxAstVisitor.cs
@@ -4,17 +4,17 @@ namespace Esprima.Utils.Jsx;
 
 public interface IJsxAstVisitor
 {
-    object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression);
-    object? VisitJsxText(JsxText jsxText);
-    object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment);
-    object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment);
-    object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier);
-    object? VisitJsxElement(JsxElement jsxElement);
-    object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement);
-    object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement);
-    object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression);
-    object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName);
-    object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute);
     object? VisitJsxAttribute(JsxAttribute jsxAttribute);
+    object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement);
+    object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment);
+    object? VisitJsxElement(JsxElement jsxElement);
+    object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression);
     object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer);
+    object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier);
+    object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression);
+    object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName);
+    object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement);
+    object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment);
+    object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute);
+    object? VisitJsxText(JsxText jsxText);
 }

--- a/src/Esprima/Utils/Jsx/JsxAstJson.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstJson.cs
@@ -33,28 +33,6 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return base.GetNodeType(node);
         }
 
-        object? IJsxAstVisitor.VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
-        {
-            using (StartNodeObject(jsxSpreadAttribute))
-            {
-                Member("argument", jsxSpreadAttribute.Argument);
-            }
-
-            return jsxSpreadAttribute;
-        }
-
-        object? IJsxAstVisitor.VisitJsxElement(JsxElement jsxElement)
-        {
-            using (StartNodeObject(jsxElement))
-            {
-                Member("openingElement", jsxElement.OpeningElement);
-                Member("children", jsxElement.Children);
-                Member("closingElement", jsxElement.ClosingElement);
-            }
-
-            return jsxElement;
-        }
-
         object? IJsxAstVisitor.VisitJsxAttribute(JsxAttribute jsxAttribute)
         {
             using (StartNodeObject(jsxAttribute))
@@ -64,16 +42,6 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             }
 
             return jsxAttribute;
-        }
-
-        object? IJsxAstVisitor.VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
-        {
-            using (StartNodeObject(jsxIdentifier))
-            {
-                Member("name", jsxIdentifier.Name);
-            }
-
-            return jsxIdentifier;
         }
 
         object? IJsxAstVisitor.VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
@@ -86,17 +54,6 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxClosingElement;
         }
 
-        object? IJsxAstVisitor.VisitJsxText(JsxText jsxText)
-        {
-            using (StartNodeObject(jsxText))
-            {
-                Member("value", jsxText.Value);
-                Member("raw", jsxText.Raw);
-            }
-
-            return jsxText;
-        }
-
         object? IJsxAstVisitor.VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
         {
             using (StartNodeObject(jsxClosingFragment))
@@ -106,48 +63,16 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxClosingFragment;
         }
 
-        object? IJsxAstVisitor.VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+        object? IJsxAstVisitor.VisitJsxElement(JsxElement jsxElement)
         {
-            using (StartNodeObject(jsxOpeningFragment))
+            using (StartNodeObject(jsxElement))
             {
-                Member("selfClosing", jsxOpeningFragment.SelfClosing);
+                Member("openingElement", jsxElement.OpeningElement);
+                Member("children", jsxElement.Children);
+                Member("closingElement", jsxElement.ClosingElement);
             }
 
-            return jsxOpeningFragment;
-        }
-
-        object? IJsxAstVisitor.VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
-        {
-            using (StartNodeObject(jsxOpeningElement))
-            {
-                Member("name", jsxOpeningElement.Name);
-                Member("selfClosing", jsxOpeningElement.SelfClosing);
-                Member("attributes", jsxOpeningElement.Attributes);
-            }
-
-            return jsxOpeningElement;
-        }
-
-        object? IJsxAstVisitor.VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
-        {
-            using (StartNodeObject(jsxNamespacedName))
-            {
-                Member("namespace", jsxNamespacedName.Namespace);
-                Member("name", jsxNamespacedName.Name);
-            }
-
-            return jsxNamespacedName;
-        }
-
-        object? IJsxAstVisitor.VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
-        {
-            using (StartNodeObject(jsxMemberExpression))
-            {
-                Member("object", jsxMemberExpression.Object);
-                Member("property", jsxMemberExpression.Property);
-            }
-
-            return jsxMemberExpression;
+            return jsxElement;
         }
 
         object? IJsxAstVisitor.VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
@@ -167,6 +92,81 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             }
 
             return jsxExpressionContainer;
+        }
+
+        object? IJsxAstVisitor.VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+        {
+            using (StartNodeObject(jsxIdentifier))
+            {
+                Member("name", jsxIdentifier.Name);
+            }
+
+            return jsxIdentifier;
+        }
+
+        object? IJsxAstVisitor.VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+        {
+            using (StartNodeObject(jsxMemberExpression))
+            {
+                Member("object", jsxMemberExpression.Object);
+                Member("property", jsxMemberExpression.Property);
+            }
+
+            return jsxMemberExpression;
+        }
+
+        object? IJsxAstVisitor.VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+        {
+            using (StartNodeObject(jsxNamespacedName))
+            {
+                Member("namespace", jsxNamespacedName.Namespace);
+                Member("name", jsxNamespacedName.Name);
+            }
+
+            return jsxNamespacedName;
+        }
+
+        object? IJsxAstVisitor.VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+        {
+            using (StartNodeObject(jsxOpeningElement))
+            {
+                Member("name", jsxOpeningElement.Name);
+                Member("selfClosing", jsxOpeningElement.SelfClosing);
+                Member("attributes", jsxOpeningElement.Attributes);
+            }
+
+            return jsxOpeningElement;
+        }
+
+        object? IJsxAstVisitor.VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+        {
+            using (StartNodeObject(jsxOpeningFragment))
+            {
+                Member("selfClosing", jsxOpeningFragment.SelfClosing);
+            }
+
+            return jsxOpeningFragment;
+        }
+
+        object? IJsxAstVisitor.VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+        {
+            using (StartNodeObject(jsxSpreadAttribute))
+            {
+                Member("argument", jsxSpreadAttribute.Argument);
+            }
+
+            return jsxSpreadAttribute;
+        }
+
+        object? IJsxAstVisitor.VisitJsxText(JsxText jsxText)
+        {
+            using (StartNodeObject(jsxText))
+            {
+                Member("value", jsxText.Value);
+                Member("raw", jsxText.Raw);
+            }
+
+            return jsxText;
         }
     }
 }

--- a/src/Esprima/Utils/Jsx/JsxAstRewriter.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstRewriter.cs
@@ -29,32 +29,24 @@ public class JsxAstRewriter : AstRewriter, IJsxAstVisitor
         _jsxVisitor = JsxAstVisitor.CreateJsxVisitorFor(this);
     }
 
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
     {
-        var obj = _rewriter.VisitAndConvert(jsxMemberExpression.Object);
-        var property = _rewriter.VisitAndConvert(jsxMemberExpression.Property);
+        var name = _rewriter.VisitAndConvert(jsxAttribute.Name);
+        var value = _rewriter.VisitAndConvert(jsxAttribute.Value, allowNull: true);
 
-        return jsxMemberExpression.UpdateWith(obj, property);
+        return jsxAttribute.UpdateWith(name, value);
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
+    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
     {
-        return _jsxVisitor.VisitJsxText(jsxText);
-    }
+        var name = _rewriter.VisitAndConvert(jsxClosingElement.Name);
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
-    {
-        return _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
+        return jsxClosingElement.UpdateWith(name);
     }
 
     public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
     {
         return _jsxVisitor.VisitJsxClosingFragment(jsxClosingFragment);
-    }
-
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
-    {
-        return _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
     }
 
     public virtual object? VisitJsxElement(JsxElement jsxElement)
@@ -66,24 +58,29 @@ public class JsxAstRewriter : AstRewriter, IJsxAstVisitor
         return jsxElement.UpdateWith(openingElement, children, closingElement);
     }
 
-    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
-    {
-        var name = _rewriter.VisitAndConvert(jsxOpeningElement.Name);
-        _rewriter.VisitAndConvert(jsxOpeningElement.Attributes, out var attributes);
-
-        return jsxOpeningElement.UpdateWith(name, attributes);
-    }
-
-    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
-    {
-        var name = _rewriter.VisitAndConvert(jsxClosingElement.Name);
-
-        return jsxClosingElement.UpdateWith(name);
-    }
-
     public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
     {
         return _jsxVisitor.VisitJsxEmptyExpression(jsxEmptyExpression);
+    }
+
+    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    {
+        var expression = _rewriter.VisitAndConvert(jsxExpressionContainer.Expression);
+
+        return jsxExpressionContainer.UpdateWith(expression);
+    }
+
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    {
+        return _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
+    }
+
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    {
+        var obj = _rewriter.VisitAndConvert(jsxMemberExpression.Object);
+        var property = _rewriter.VisitAndConvert(jsxMemberExpression.Property);
+
+        return jsxMemberExpression.UpdateWith(obj, property);
     }
 
     public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
@@ -94,6 +91,19 @@ public class JsxAstRewriter : AstRewriter, IJsxAstVisitor
         return jsxNamespacedName.UpdateWith(name, @namespace);
     }
 
+    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    {
+        var name = _rewriter.VisitAndConvert(jsxOpeningElement.Name);
+        _rewriter.VisitAndConvert(jsxOpeningElement.Attributes, out var attributes);
+
+        return jsxOpeningElement.UpdateWith(name, attributes);
+    }
+
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    {
+        return _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
+    }
+
     public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
     {
         var argument = _rewriter.VisitAndConvert(jsxSpreadAttribute.Argument);
@@ -101,18 +111,8 @@ public class JsxAstRewriter : AstRewriter, IJsxAstVisitor
         return jsxSpreadAttribute.UpdateWith(argument);
     }
 
-    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public virtual object? VisitJsxText(JsxText jsxText)
     {
-        var name = _rewriter.VisitAndConvert(jsxAttribute.Name);
-        var value = _rewriter.VisitAndConvert(jsxAttribute.Value, allowNull: true);
-
-        return jsxAttribute.UpdateWith(name, value);
-    }
-
-    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
-    {
-        var expression = _rewriter.VisitAndConvert(jsxExpressionContainer.Expression);
-
-        return jsxExpressionContainer.UpdateWith(expression);
+        return _jsxVisitor.VisitJsxText(jsxText);
     }
 }

--- a/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
@@ -26,32 +26,27 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
         _visitor = visitor;
     }
 
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
     {
-        _visitor.Visit(jsxMemberExpression.Object);
-        _visitor.Visit(jsxMemberExpression.Property);
+        _visitor.Visit(jsxAttribute.Name);
+        if (jsxAttribute.Value is not null)
+        {
+            _visitor.Visit(jsxAttribute.Value);
+        }
 
-        return jsxMemberExpression;
+        return jsxAttribute;
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
+    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
     {
-        return jsxText;
-    }
+        _visitor.Visit(jsxClosingElement.Name);
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
-    {
-        return jsxOpeningFragment;
+        return jsxClosingElement;
     }
 
     public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
     {
         return jsxClosingFragment;
-    }
-
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
-    {
-        return jsxIdentifier;
     }
 
     public virtual object? VisitJsxElement(JsxElement jsxElement)
@@ -71,6 +66,39 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
         return jsxElement;
     }
 
+    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+    {
+        return jsxEmptyExpression;
+    }
+
+    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    {
+        _visitor.Visit(jsxExpressionContainer.Expression);
+
+        return jsxExpressionContainer;
+    }
+
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    {
+        return jsxIdentifier;
+    }
+
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    {
+        _visitor.Visit(jsxMemberExpression.Object);
+        _visitor.Visit(jsxMemberExpression.Property);
+
+        return jsxMemberExpression;
+    }
+
+    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    {
+        _visitor.Visit(jsxNamespacedName.Name);
+        _visitor.Visit(jsxNamespacedName.Namespace);
+
+        return jsxNamespacedName;
+    }
+
     public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
     {
         _visitor.Visit(jsxOpeningElement.Name);
@@ -83,24 +111,9 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
         return jsxOpeningElement;
     }
 
-    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
     {
-        _visitor.Visit(jsxClosingElement.Name);
-
-        return jsxClosingElement;
-    }
-
-    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
-    {
-        return jsxEmptyExpression;
-    }
-
-    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
-    {
-        _visitor.Visit(jsxNamespacedName.Name);
-        _visitor.Visit(jsxNamespacedName.Namespace);
-
-        return jsxNamespacedName;
+        return jsxOpeningFragment;
     }
 
     public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
@@ -110,21 +123,8 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
         return jsxSpreadAttribute;
     }
 
-    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public virtual object? VisitJsxText(JsxText jsxText)
     {
-        _visitor.Visit(jsxAttribute.Name);
-        if (jsxAttribute.Value is not null)
-        {
-            _visitor.Visit(jsxAttribute.Value);
-        }
-
-        return jsxAttribute;
-    }
-
-    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
-    {
-        _visitor.Visit(jsxExpressionContainer.Expression);
-
-        return jsxExpressionContainer;
+        return jsxText;
     }
 }

--- a/src/Esprima/Utils/Jsx/JsxAstVisitorEventSource.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstVisitorEventSource.cs
@@ -4,32 +4,32 @@ namespace Esprima.Utils.Jsx;
 
 public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
 {
-    public event EventHandler<JsxSpreadAttribute>? VisitingJsxSpreadAttribute;
-    public event EventHandler<JsxSpreadAttribute>? VisitedJsxSpreadAttribute;
-    public event EventHandler<JsxElement>? VisitingJsxElement;
-    public event EventHandler<JsxElement>? VisitedJsxElement;
     public event EventHandler<JsxAttribute>? VisitingJsxAttribute;
     public event EventHandler<JsxAttribute>? VisitedJsxAttribute;
-    public event EventHandler<JsxIdentifier>? VisitingJsxIdentifier;
-    public event EventHandler<JsxIdentifier>? VisitedJsxIdentifier;
     public event EventHandler<JsxClosingElement>? VisitingJsxClosingElement;
     public event EventHandler<JsxClosingElement>? VisitedJsxClosingElement;
-    public event EventHandler<JsxText>? VisitingJsxText;
-    public event EventHandler<JsxText>? VisitedJsxText;
     public event EventHandler<JsxClosingFragment>? VisitingJsxClosingFragment;
     public event EventHandler<JsxClosingFragment>? VisitedJsxClosingFragment;
-    public event EventHandler<JsxOpeningFragment>? VisitingJsxOpeningFragment;
-    public event EventHandler<JsxOpeningFragment>? VisitedJsxOpeningFragment;
-    public event EventHandler<JsxOpeningElement>? VisitingJsxOpeningElement;
-    public event EventHandler<JsxOpeningElement>? VisitedJsxOpeningElement;
-    public event EventHandler<JsxNamespacedName>? VisitingJsxNamespacedName;
-    public event EventHandler<JsxNamespacedName>? VisitedJsxNamespacedName;
-    public event EventHandler<JsxMemberExpression>? VisitingJsxMemberExpression;
-    public event EventHandler<JsxMemberExpression>? VisitedJsxMemberExpression;
+    public event EventHandler<JsxElement>? VisitingJsxElement;
+    public event EventHandler<JsxElement>? VisitedJsxElement;
     public event EventHandler<JsxEmptyExpression>? VisitingJsxEmptyExpression;
     public event EventHandler<JsxEmptyExpression>? VisitedJsxEmptyExpression;
     public event EventHandler<JsxExpressionContainer>? VisitingJsxExpressionContainer;
     public event EventHandler<JsxExpressionContainer>? VisitedJsxExpressionContainer;
+    public event EventHandler<JsxIdentifier>? VisitingJsxIdentifier;
+    public event EventHandler<JsxIdentifier>? VisitedJsxIdentifier;
+    public event EventHandler<JsxMemberExpression>? VisitingJsxMemberExpression;
+    public event EventHandler<JsxMemberExpression>? VisitedJsxMemberExpression;
+    public event EventHandler<JsxNamespacedName>? VisitingJsxNamespacedName;
+    public event EventHandler<JsxNamespacedName>? VisitedJsxNamespacedName;
+    public event EventHandler<JsxOpeningElement>? VisitingJsxOpeningElement;
+    public event EventHandler<JsxOpeningElement>? VisitedJsxOpeningElement;
+    public event EventHandler<JsxOpeningFragment>? VisitingJsxOpeningFragment;
+    public event EventHandler<JsxOpeningFragment>? VisitedJsxOpeningFragment;
+    public event EventHandler<JsxSpreadAttribute>? VisitingJsxSpreadAttribute;
+    public event EventHandler<JsxSpreadAttribute>? VisitedJsxSpreadAttribute;
+    public event EventHandler<JsxText>? VisitingJsxText;
+    public event EventHandler<JsxText>? VisitedJsxText;
 
     private readonly IJsxAstVisitor _jsxVisitor;
 
@@ -38,35 +38,11 @@ public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
         _jsxVisitor = JsxAstVisitor.CreateJsxVisitorFor(this);
     }
 
-    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
-    {
-        VisitingJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
-        var node = _jsxVisitor.VisitJsxSpreadAttribute(jsxSpreadAttribute);
-        VisitedJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
-        return node;
-    }
-
-    public virtual object? VisitJsxElement(JsxElement jsxElement)
-    {
-        VisitingJsxElement?.Invoke(this, jsxElement);
-        var node = _jsxVisitor.VisitJsxElement(jsxElement);
-        VisitedJsxElement?.Invoke(this, jsxElement);
-        return node;
-    }
-
     public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
     {
         VisitingJsxAttribute?.Invoke(this, jsxAttribute);
         var node = _jsxVisitor.VisitJsxAttribute(jsxAttribute);
         VisitedJsxAttribute?.Invoke(this, jsxAttribute);
-        return node;
-    }
-
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
-    {
-        VisitingJsxIdentifier?.Invoke(this, jsxIdentifier);
-        var node = _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
-        VisitedJsxIdentifier?.Invoke(this, jsxIdentifier);
         return node;
     }
 
@@ -78,14 +54,6 @@ public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
         return node;
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
-    {
-        VisitingJsxText?.Invoke(this, jsxText);
-        var node = _jsxVisitor.VisitJsxText(jsxText);
-        VisitedJsxText?.Invoke(this, jsxText);
-        return node;
-    }
-
     public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
     {
         VisitingJsxClosingFragment?.Invoke(this, jsxClosingFragment);
@@ -94,35 +62,11 @@ public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
         return node;
     }
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    public virtual object? VisitJsxElement(JsxElement jsxElement)
     {
-        VisitingJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
-        var node = _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
-        VisitedJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
-        return node;
-    }
-
-    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
-    {
-        VisitingJsxOpeningElement?.Invoke(this, jsxOpeningElement);
-        var node = _jsxVisitor.VisitJsxOpeningElement(jsxOpeningElement);
-        VisitedJsxOpeningElement?.Invoke(this, jsxOpeningElement);
-        return node;
-    }
-
-    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
-    {
-        VisitingJsxNamespacedName?.Invoke(this, jsxNamespacedName);
-        var node = _jsxVisitor.VisitJsxNamespacedName(jsxNamespacedName);
-        VisitedJsxNamespacedName?.Invoke(this, jsxNamespacedName);
-        return node;
-    }
-
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
-    {
-        VisitingJsxMemberExpression?.Invoke(this, jsxMemberExpression);
-        var node = _jsxVisitor.VisitJsxMemberExpression(jsxMemberExpression);
-        VisitedJsxMemberExpression?.Invoke(this, jsxMemberExpression);
+        VisitingJsxElement?.Invoke(this, jsxElement);
+        var node = _jsxVisitor.VisitJsxElement(jsxElement);
+        VisitedJsxElement?.Invoke(this, jsxElement);
         return node;
     }
 
@@ -139,6 +83,62 @@ public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
         VisitingJsxExpressionContainer?.Invoke(this, jsxExpressionContainer);
         var node = _jsxVisitor.VisitJsxExpressionContainer(jsxExpressionContainer);
         VisitedJsxExpressionContainer?.Invoke(this, jsxExpressionContainer);
+        return node;
+    }
+
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    {
+        VisitingJsxIdentifier?.Invoke(this, jsxIdentifier);
+        var node = _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
+        VisitedJsxIdentifier?.Invoke(this, jsxIdentifier);
+        return node;
+    }
+
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    {
+        VisitingJsxMemberExpression?.Invoke(this, jsxMemberExpression);
+        var node = _jsxVisitor.VisitJsxMemberExpression(jsxMemberExpression);
+        VisitedJsxMemberExpression?.Invoke(this, jsxMemberExpression);
+        return node;
+    }
+
+    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    {
+        VisitingJsxNamespacedName?.Invoke(this, jsxNamespacedName);
+        var node = _jsxVisitor.VisitJsxNamespacedName(jsxNamespacedName);
+        VisitedJsxNamespacedName?.Invoke(this, jsxNamespacedName);
+        return node;
+    }
+
+    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    {
+        VisitingJsxOpeningElement?.Invoke(this, jsxOpeningElement);
+        var node = _jsxVisitor.VisitJsxOpeningElement(jsxOpeningElement);
+        VisitedJsxOpeningElement?.Invoke(this, jsxOpeningElement);
+        return node;
+    }
+
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    {
+        VisitingJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
+        var node = _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
+        VisitedJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
+        return node;
+    }
+
+    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+    {
+        VisitingJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
+        var node = _jsxVisitor.VisitJsxSpreadAttribute(jsxSpreadAttribute);
+        VisitedJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
+        return node;
+    }
+
+    public virtual object? VisitJsxText(JsxText jsxText)
+    {
+        VisitingJsxText?.Invoke(this, jsxText);
+        var node = _jsxVisitor.VisitJsxText(jsxText);
+        VisitedJsxText?.Invoke(this, jsxText);
         return node;
     }
 }


### PR DESCRIPTION
Due to the large number of AST nodes, I suggest maintaining an alphabetic order of `VisitXXX` methods in our visitors. This makes the code easier to navigate and work with.

This is a code quality improvement, no logic or structure modified. Unfortunately, it kind of messes up git history of the files involved but I think this is a right time to set this straight.