### PR TITLE
Change AST to return ReadOnlySpans instead of NodeList

### DIFF
--- a/samples/Esprima.Benchmark/AstTreeWalkBenchmark.cs
+++ b/samples/Esprima.Benchmark/AstTreeWalkBenchmark.cs
@@ -61,8 +61,7 @@ namespace Esprima.Benchmark
                     {
                         if (variableDeclaration.Kind == VariableDeclarationKind.Var)
                         {
-                            ref readonly var nodeList = ref variableDeclaration.Declarations;
-                            foreach (var declaration in nodeList)
+                            foreach (var declaration in variableDeclaration.Declarations)
                             {
                                 _varNameCount++;
                             }
@@ -70,8 +69,7 @@ namespace Esprima.Benchmark
 
                         if (variableDeclaration.Kind != VariableDeclarationKind.Var)
                         {
-                            ref readonly var nodeList = ref variableDeclaration.Declarations;
-                            foreach (var declaration in nodeList)
+                            foreach (var declaration in variableDeclaration.Declarations)
                             {
                                 _lexicalNameCount++;
                             }

--- a/samples/Esprima.Benchmark/VisitorBenchmark.cs
+++ b/samples/Esprima.Benchmark/VisitorBenchmark.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using BenchmarkDotNet.Attributes;
-using BenchmarkDotNet.Jobs;
 using Esprima.Utils;
 
 namespace Esprima.Benchmark

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class ArrayExpression : Expression
     {
-        private readonly NodeList<Expression?> _elements;
+        internal readonly NodeList<Expression?> _elements;
 
         public ArrayExpression(in NodeList<Expression?> elements) : base(Nodes.ArrayExpression)
         {
             _elements = elements;
         }
 
-        public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
+        public ReadOnlySpan<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _elements.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public ArrayExpression UpdateWith(in NodeList<Expression?> elements)
         {
-            if (NodeList.AreSame(elements, Elements))
+            if (NodeList.AreSame(elements, _elements))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class ArrayPattern : BindingPattern
     {
-        private readonly NodeList<Expression?> _elements;
+        internal readonly NodeList<Expression?> _elements;
 
         public ArrayPattern(in NodeList<Expression?> elements) : base(Nodes.ArrayPattern)
         {
             _elements = elements;
         }
 
-        public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
+        public ReadOnlySpan<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _elements.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_elements);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public ArrayPattern UpdateWith(in NodeList<Expression?> elements)
         {
-            if (NodeList.AreSame(elements, Elements))
+            if (NodeList.AreSame(elements, _elements))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class ArrowFunctionExpression : Expression, IFunction
     {
-        private readonly NodeList<Expression> _params;
+        internal readonly NodeList<Expression> _params;
 
         public ArrowFunctionExpression(
             in NodeList<Expression> parameters,
@@ -23,7 +23,8 @@ namespace Esprima.Ast
         }
 
         Identifier? IFunction.Id => null;
-        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
+        public ReadOnlySpan<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _params.AsSpan(); }
+
         /// <remarks>
         /// <see cref="BlockStatement" /> | <see cref="Ast.Expression" />
         /// </remarks>
@@ -33,7 +34,7 @@ namespace Esprima.Ast
         public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params, Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_params, Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -42,7 +43,7 @@ namespace Esprima.Ast
 
         public ArrowFunctionExpression UpdateWith(in NodeList<Expression> parameters, Node body)
         {
-            if (NodeList.AreSame(parameters, Params) && body == Body)
+            if (NodeList.AreSame(parameters, _params) && body == Body)
             {
                 return this;
             }

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -7,7 +7,7 @@ namespace Esprima.Ast
     {
         public static readonly ArrowParameterPlaceHolder Empty = new(new NodeList<Expression>(), false);
 
-        private readonly NodeList<Expression> _params;
+        internal readonly NodeList<Expression> _params;
 
         public ArrowParameterPlaceHolder(
             in NodeList<Expression> parameters,
@@ -19,9 +19,9 @@ namespace Esprima.Ast
         }
 
         public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
+        public ReadOnlySpan<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _params.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_params);
 
         protected internal override object? Accept(AstVisitor visitor)
         {

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class BlockStatement : Statement
     {
-        private readonly NodeList<Statement> _body;
+        internal readonly NodeList<Statement> _body;
 
         public BlockStatement(in NodeList<Statement> body) : base(Nodes.BlockStatement)
         {
             _body = body;
         }
 
-        public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
+        public ReadOnlySpan<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _body.AsSpan(); }
 
-        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
         protected internal sealed override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public BlockStatement UpdateWith(in NodeList<Statement> body)
         {
-            if (NodeList.AreSame(body, Body))
+            if (NodeList.AreSame(body, _body))
             {
                 return this;
             }

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class CallExpression : Expression
     {
-        private readonly NodeList<Expression> _arguments;
+        internal readonly NodeList<Expression> _arguments;
 
         public CallExpression(
             Expression callee,
@@ -18,10 +18,10 @@ namespace Esprima.Ast
         }
 
         public Expression Callee { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _arguments; }
+        public ReadOnlySpan<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _arguments.AsSpan(); }
         public bool Optional { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, _arguments);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -30,7 +30,7 @@ namespace Esprima.Ast
 
         public CallExpression UpdateWith(Expression callee, in NodeList<Expression> arguments)
         {
-            if (callee == Callee && NodeList.AreSame(arguments, Arguments))
+            if (callee == Callee && NodeList.AreSame(arguments, _arguments))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class ClassBody : Node
     {
-        private readonly NodeList<ClassElement> _body;
+        internal readonly NodeList<ClassElement> _body;
 
         public ClassBody(in NodeList<ClassElement> body) : base(Nodes.ClassBody)
         {
@@ -15,9 +15,9 @@ namespace Esprima.Ast
         /// <remarks>
         /// <see cref="MethodDefinition" /> | <see cref="PropertyDefinition" /> | <see cref="StaticBlock" />
         /// </remarks>
-        public ref readonly NodeList<ClassElement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
+        public ReadOnlySpan<ClassElement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _body.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -26,7 +26,7 @@ namespace Esprima.Ast
 
         public ClassBody UpdateWith(in NodeList<ClassElement> body)
         {
-            if (NodeList.AreSame(body, Body))
+            if (NodeList.AreSame(body, _body))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class ClassDeclaration : Declaration, IClass
     {
-        private readonly NodeList<Decorator> _decorators;
+        internal readonly NodeList<Decorator> _decorators;
 
         public ClassDeclaration(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators) :
             base(Nodes.ClassDeclaration)
@@ -22,7 +22,7 @@ namespace Esprima.Ast
         /// </remarks>
         public Expression? SuperClass { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public ClassBody Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
+        public ReadOnlySpan<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _decorators.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -32,7 +32,7 @@ namespace Esprima.Ast
             yield return SuperClass;
             yield return Body;
 
-            foreach (var node in Decorators)
+            foreach (var node in _decorators)
             {
                 yield return node;
             }
@@ -45,7 +45,7 @@ namespace Esprima.Ast
 
         public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
         {
-            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
+            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, _decorators))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class ClassExpression : Expression, IClass
     {
-        private readonly NodeList<Decorator> _decorators;
+        internal readonly NodeList<Decorator> _decorators;
 
         public ClassExpression(
             Identifier? id,
@@ -25,7 +25,7 @@ namespace Esprima.Ast
         /// </remarks>
         public Expression? SuperClass { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public ClassBody Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
+        public ReadOnlySpan<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _decorators.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -35,7 +35,7 @@ namespace Esprima.Ast
             yield return SuperClass;
             yield return Body;
 
-            foreach (var node in Decorators)
+            foreach (var node in _decorators)
             {
                 yield return node;
             }
@@ -48,7 +48,7 @@ namespace Esprima.Ast
 
         public ClassExpression UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)
         {
-            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, Decorators))
+            if (id == Id && superClass == SuperClass && body == Body && NodeList.AreSame(decorators, _decorators))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class ExportAllDeclaration : ExportDeclaration
     {
-        private readonly NodeList<ImportAttribute> _assertions;
+        internal readonly NodeList<ImportAttribute> _assertions;
 
         public ExportAllDeclaration(Literal source) : this(source, null, new NodeList<ImportAttribute>())
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
         /// <see cref="Identifier" /> | StringLiteral (<see cref="Literal" />)
         /// </remarks>
         public Expression? Exported { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
+        public ReadOnlySpan<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _assertions.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -32,7 +32,7 @@ namespace Esprima.Ast
             yield return Exported;
             yield return Source;
 
-            foreach (var assertion in Assertions)
+            foreach (var assertion in _assertions)
             {
                 yield return assertion;
             }
@@ -45,7 +45,7 @@ namespace Esprima.Ast
 
         public ExportAllDeclaration UpdateWith(Expression? exported, Literal source, in NodeList<ImportAttribute> assertions)
         {
-            if (exported == Exported && source == Source && NodeList.AreSame(assertions, Assertions))
+            if (exported == Exported && source == Source && NodeList.AreSame(assertions, _assertions))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -5,8 +5,8 @@ namespace Esprima.Ast
 {
     public sealed class ExportNamedDeclaration : ExportDeclaration
     {
-        private readonly NodeList<ExportSpecifier> _specifiers;
-        private readonly NodeList<ImportAttribute> _assertions;
+        internal readonly NodeList<ExportSpecifier> _specifiers;
+        internal readonly NodeList<ImportAttribute> _assertions;
 
         public ExportNamedDeclaration(
             StatementListItem? declaration,
@@ -22,9 +22,9 @@ namespace Esprima.Ast
         }
 
         public StatementListItem? Declaration { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<ExportSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _specifiers; }
+        public ReadOnlySpan<ExportSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _specifiers.AsSpan(); }
         public Literal? Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
+        public ReadOnlySpan<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _assertions.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -32,14 +32,14 @@ namespace Esprima.Ast
         {
             yield return Declaration;
 
-            foreach (var node in Specifiers)
+            foreach (var node in _specifiers)
             {
                 yield return node;
             }
 
             yield return Source;
 
-            foreach (var node in Assertions)
+            foreach (var node in _assertions)
             {
                 yield return node;
             }
@@ -52,7 +52,7 @@ namespace Esprima.Ast
 
         public ExportNamedDeclaration UpdateWith(StatementListItem? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> assertions)
         {
-            if (declaration == Declaration && NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
+            if (declaration == Declaration && NodeList.AreSame(specifiers, _specifiers) && source == Source && NodeList.AreSame(assertions, _assertions))
             {
                 return this;
             }

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class FunctionDeclaration : Declaration, IFunction
     {
-        private readonly NodeList<Expression> _params;
+        internal readonly NodeList<Expression> _params;
 
         public FunctionDeclaration(
             Identifier? id,
@@ -25,7 +25,7 @@ namespace Esprima.Ast
         }
 
         public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
+        public ReadOnlySpan<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _params.AsSpan(); }
 
         public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         Node IFunction.Body => Body;
@@ -35,7 +35,7 @@ namespace Esprima.Ast
         public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _params, Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -44,7 +44,7 @@ namespace Esprima.Ast
 
         public FunctionDeclaration UpdateWith(Identifier? id, in NodeList<Expression> parameters, BlockStatement body)
         {
-            if (id == Id && NodeList.AreSame(parameters, Params) && body == Body)
+            if (id == Id && NodeList.AreSame(parameters, _params) && body == Body)
             {
                 return this;
             }

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class FunctionExpression : Expression, IFunction
     {
-        private readonly NodeList<Expression> _params;
+        internal readonly NodeList<Expression> _params;
 
         public FunctionExpression(
             Identifier? id,
@@ -25,7 +25,7 @@ namespace Esprima.Ast
         }
 
         public Identifier? Id { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _params; }
+        public ReadOnlySpan<Expression> Params { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _params.AsSpan(); }
 
         public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         Node IFunction.Body => Body;
@@ -35,7 +35,7 @@ namespace Esprima.Ast
         public bool Strict { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public bool Async { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, _params, Body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -44,7 +44,7 @@ namespace Esprima.Ast
 
         public FunctionExpression UpdateWith(Identifier? id, in NodeList<Expression> parameters, BlockStatement body)
         {
-            if (id == Id && NodeList.AreSame(parameters, Params) && body == Body)
+            if (id == Id && NodeList.AreSame(parameters, _params) && body == Body)
             {
                 return this;
             }

--- a/src/Esprima/Ast/IClass.cs
+++ b/src/Esprima/Ast/IClass.cs
@@ -8,7 +8,7 @@
         Identifier? Id { get; }
         Expression? SuperClass { get; }
         ClassBody Body { get; }
-        ref readonly NodeList<Decorator> Decorators { get; }
+        ReadOnlySpan<Decorator> Decorators { get; }
         NodeCollection ChildNodes { get; }
     }
 }

--- a/src/Esprima/Ast/IFunction.cs
+++ b/src/Esprima/Ast/IFunction.cs
@@ -6,7 +6,7 @@
     public interface IFunction
     {
         Identifier? Id { get; }
-        ref readonly NodeList<Expression> Params { get; }
+        ReadOnlySpan<Expression> Params { get; }
         Node Body { get; }
         bool Generator { get; }
         bool Expression { get; }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -5,8 +5,8 @@ namespace Esprima.Ast
 {
     public sealed class ImportDeclaration : Declaration
     {
-        private readonly NodeList<ImportDeclarationSpecifier> _specifiers;
-        private readonly NodeList<ImportAttribute> _assertions;
+        internal readonly NodeList<ImportDeclarationSpecifier> _specifiers;
+        internal readonly NodeList<ImportAttribute> _assertions;
 
         public ImportDeclaration(
             in NodeList<ImportDeclarationSpecifier> specifiers,
@@ -19,22 +19,22 @@ namespace Esprima.Ast
             _assertions = assertions;
         }
 
-        public ref readonly NodeList<ImportDeclarationSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _specifiers; }
+        public ReadOnlySpan<ImportDeclarationSpecifier> Specifiers { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _specifiers.AsSpan(); }
         public Literal Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _assertions; }
+        public ReadOnlySpan<ImportAttribute> Assertions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _assertions.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
         private IEnumerable<Node?> CreateChildNodes()
         {
-            foreach (var node in Specifiers)
+            foreach (var node in _specifiers)
             {
                 yield return node;
             }
 
             yield return Source;
 
-            foreach (var node in Assertions)
+            foreach (var node in _assertions)
             {
                 yield return node;
             }
@@ -47,7 +47,7 @@ namespace Esprima.Ast
 
         public ImportDeclaration UpdateWith(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> assertions)
         {
-            if (NodeList.AreSame(specifiers, Specifiers) && source == Source && NodeList.AreSame(assertions, Assertions))
+            if (NodeList.AreSame(specifiers, _specifiers) && source == Source && NodeList.AreSame(assertions, _assertions))
             {
                 return this;
             }

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast.Jsx;
 
 public sealed class JsxElement : JsxExpression
 {
-    private readonly NodeList<JsxExpression> _children;
+    internal readonly NodeList<JsxExpression> _children;
 
     public JsxElement(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement) : base(JsxNodeType.Element)
     {
@@ -16,9 +16,9 @@ public sealed class JsxElement : JsxExpression
 
     public Node OpeningElement { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public Node? ClosingElement { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-    public ref readonly NodeList<JsxExpression> Children { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _children; }
+    public ReadOnlySpan<JsxExpression> Children { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _children.AsSpan(); }
 
-    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(OpeningElement, Children, ClosingElement);
+    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(OpeningElement, _children, ClosingElement);
 
     protected override object? Accept(IJsxAstVisitor visitor)
     {
@@ -27,7 +27,7 @@ public sealed class JsxElement : JsxExpression
 
     public JsxElement UpdateWith(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement)
     {
-        if (openingElement == OpeningElement && NodeList.AreSame(children, Children) && closingElement == ClosingElement)
+        if (openingElement == OpeningElement && NodeList.AreSame(children, _children) && closingElement == ClosingElement)
         {
             return this;
         }

--- a/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast.Jsx;
 
 public sealed class JsxOpeningElement : JsxExpression
 {
-    private readonly NodeList<JsxExpression> _attributes;
+    internal readonly NodeList<JsxExpression> _attributes;
 
     public JsxOpeningElement(JsxExpression name, bool selfClosing, in NodeList<JsxExpression> attributes) : base(JsxNodeType.OpeningElement)
     {
@@ -16,9 +16,9 @@ public sealed class JsxOpeningElement : JsxExpression
 
     public JsxExpression Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public bool SelfClosing { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-    public ref readonly NodeList<JsxExpression> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
+    public ReadOnlySpan<JsxExpression> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _attributes.AsSpan(); }
 
-    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Name, Attributes);
+    public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Name, _attributes);
 
     protected override object? Accept(IJsxAstVisitor visitor)
     {
@@ -27,7 +27,7 @@ public sealed class JsxOpeningElement : JsxExpression
 
     public JsxOpeningElement UpdateWith(JsxExpression name, in NodeList<JsxExpression> attributes)
     {
-        if (name == Name && NodeList.AreSame(attributes, Attributes))
+        if (name == Name && NodeList.AreSame(attributes, _attributes))
         {
             return this;
         }

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class MethodDefinition : ClassProperty
     {
-        private readonly NodeList<Decorator> _decorators;
+        internal readonly NodeList<Decorator> _decorators;
 
         public MethodDefinition(
             Expression key,
@@ -25,7 +25,7 @@ namespace Esprima.Ast
         protected override Expression? GetValue() => Value;
 
         public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
+        public ReadOnlySpan<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _decorators.AsSpan(); }
 
         public override NodeCollection ChildNodes => new(Key, Value);
 
@@ -36,7 +36,7 @@ namespace Esprima.Ast
 
         public MethodDefinition UpdateWith(Expression key, FunctionExpression value, in NodeList<Decorator> decorators)
         {
-            if (key == Key && value == Value && NodeList.AreSame(decorators, Decorators))
+            if (key == Key && value == Value && NodeList.AreSame(decorators, _decorators))
             {
                 return this;
             }

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class NewExpression : Expression
     {
-        private readonly NodeList<Expression> _arguments;
+        internal readonly NodeList<Expression> _arguments;
 
         public NewExpression(
             Expression callee,
@@ -17,9 +17,9 @@ namespace Esprima.Ast
         }
 
         public Expression Callee { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _arguments; }
+        public ReadOnlySpan<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _arguments.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, _arguments);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -28,7 +28,7 @@ namespace Esprima.Ast
 
         public NewExpression UpdateWith(Expression callee, in NodeList<Expression> arguments)
         {
-            if (callee == Callee && NodeList.AreSame(arguments, Arguments))
+            if (callee == Callee && NodeList.AreSame(arguments, _arguments))
             {
                 return this;
             }

--- a/src/Esprima/Ast/NodeList.cs
+++ b/src/Esprima/Ast/NodeList.cs
@@ -1,5 +1,6 @@
-﻿using System.Collections;
+using System.Collections;
 using System.Runtime.CompilerServices;
+
 using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Ast
@@ -11,12 +12,19 @@ namespace Esprima.Ast
 
         internal NodeList(ICollection<T> collection)
         {
-            collection ??= ThrowArgumentNullException<ICollection<T>>(nameof(collection));
-
             var count = _count = collection.Count;
             if ((_items = count == 0 ? null : new T[count]) != null)
             {
                 collection.CopyTo(_items, 0);
+            }
+        }
+
+        internal NodeList(ReadOnlySpan<T> collection)
+        {
+            var count = _count = collection.Length;
+            if ((_items = count == 0 ? null : new T[count]) != null)
+            {
+                collection.CopyTo(_items);
             }
         }
 
@@ -32,9 +40,10 @@ namespace Esprima.Ast
             get => _count;
         }
 
-        public NodeList<Node?> AsNodes()
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public ReadOnlySpan<T> AsSpan()
         {
-            return new NodeList<Node?>(_items /* conversion by co-variance! */, _count);
+            return new ReadOnlySpan<T>(_items, 0, _count);
         }
 
         public T this[int index]

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class ObjectExpression : Expression
     {
-        private readonly NodeList<Expression> _properties;
+        internal readonly NodeList<Expression> _properties;
 
         public ObjectExpression(in NodeList<Expression> properties) : base(Nodes.ObjectExpression)
         {
             _properties = properties;
         }
 
-        public ref readonly NodeList<Expression> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
+        public ReadOnlySpan<Expression> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _properties.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public ObjectExpression UpdateWith(in NodeList<Expression> properties)
         {
-            if (NodeList.AreSame(properties, Properties))
+            if (NodeList.AreSame(properties, _properties))
             {
                 return this;
             }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class ObjectPattern : BindingPattern
     {
-        private readonly NodeList<Node> _properties;
+        internal readonly NodeList<Node> _properties;
 
         public ObjectPattern(in NodeList<Node> properties) : base(Nodes.ObjectPattern)
         {
             _properties = properties;
         }
 
-        public ref readonly NodeList<Node> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
+        public ReadOnlySpan<Node> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _properties.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_properties);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public ObjectPattern UpdateWith(in NodeList<Node> properties)
         {
-            if (NodeList.AreSame(properties, Properties))
+            if (NodeList.AreSame(properties, _properties))
             {
                 return this;
             }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -5,18 +5,18 @@ namespace Esprima.Ast
 {
     public abstract class Program : Statement
     {
-        private readonly NodeList<Statement> _body;
+        internal readonly NodeList<Statement> _body;
 
         protected Program(in NodeList<Statement> body) : base(Nodes.Program)
         {
             _body = body;
         }
 
-        public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
+        public ReadOnlySpan<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _body.AsSpan(); }
 
         public abstract SourceType SourceType { get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -27,7 +27,7 @@ namespace Esprima.Ast
 
         public Program UpdateWith(in NodeList<Statement> body)
         {
-            if (NodeList.AreSame(body, Body))
+            if (NodeList.AreSame(body, _body))
             {
                 return this;
             }

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class PropertyDefinition : ClassProperty
     {
-        private readonly NodeList<Decorator> _decorators;
+        internal readonly NodeList<Decorator> _decorators;
 
         public PropertyDefinition(
             Expression key,
@@ -24,7 +24,7 @@ namespace Esprima.Ast
         protected override Expression? GetValue() => Value;
 
         public bool Static { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
+        public ReadOnlySpan<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _decorators.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -33,7 +33,7 @@ namespace Esprima.Ast
             yield return Key;
             yield return Value;
 
-            foreach (var node in Decorators)
+            foreach (var node in _decorators)
             {
                 yield return node;
             }
@@ -46,7 +46,7 @@ namespace Esprima.Ast
 
         public PropertyDefinition UpdateWith(Expression key, Expression? value, in NodeList<Decorator> decorators)
         {
-            if (key == Key && value == Value && NodeList.AreSame(decorators, Decorators))
+            if (key == Key && value == Value && NodeList.AreSame(decorators, _decorators))
             {
                 return this;
             }

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -12,9 +12,9 @@ namespace Esprima.Ast
             _expressions = expressions;
         }
 
-        public ref readonly NodeList<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _expressions; }
+        public ReadOnlySpan<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _expressions.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Expressions);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_expressions);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public SequenceExpression UpdateWith(in NodeList<Expression> expressions)
         {
-            if (NodeList.AreSame(expressions, Expressions))
+            if (NodeList.AreSame(expressions, _expressions))
             {
                 return this;
             }

--- a/src/Esprima/Ast/StaticBlock.cs
+++ b/src/Esprima/Ast/StaticBlock.cs
@@ -5,16 +5,16 @@ namespace Esprima.Ast
 {
     public sealed class StaticBlock : ClassElement
     {
-        private readonly NodeList<Statement> _body;
+        internal readonly NodeList<Statement> _body;
 
         public StaticBlock(in NodeList<Statement> body) : base(Nodes.StaticBlock)
         {
             _body = body;
         }
 
-        public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
+        public ReadOnlySpan<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _body.AsSpan(); }
 
-        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_body);
 
         protected internal sealed override object? Accept(AstVisitor visitor)
         {
@@ -23,7 +23,7 @@ namespace Esprima.Ast
 
         public StaticBlock UpdateWith(in NodeList<Statement> body)
         {
-            if (NodeList.AreSame(body, Body))
+            if (NodeList.AreSame(body, _body))
             {
                 return this;
             }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class SwitchCase : Node
     {
-        private readonly NodeList<Statement> _consequent;
+        internal readonly NodeList<Statement> _consequent;
 
         public SwitchCase(Expression? test, in NodeList<Statement> consequent) : base(Nodes.SwitchCase)
         {
@@ -14,9 +14,9 @@ namespace Esprima.Ast
         }
 
         public Expression? Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<Statement> Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _consequent; }
+        public ReadOnlySpan<Statement> Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _consequent.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, Consequent);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, _consequent);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -25,7 +25,7 @@ namespace Esprima.Ast
 
         public SwitchCase UpdateWith(Expression? test, in NodeList<Statement> consequent)
         {
-            if (test == Test && NodeList.AreSame(consequent, Consequent))
+            if (test == Test && NodeList.AreSame(consequent, _consequent))
             {
                 return this;
             }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class SwitchStatement : Statement
     {
-        private readonly NodeList<SwitchCase> _cases;
+        internal readonly NodeList<SwitchCase> _cases;
 
         public SwitchStatement(Expression discriminant, in NodeList<SwitchCase> cases) : base(Nodes.SwitchStatement)
         {
@@ -14,9 +14,9 @@ namespace Esprima.Ast
         }
 
         public Expression Discriminant { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-        public ref readonly NodeList<SwitchCase> Cases { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _cases; }
+        public ReadOnlySpan<SwitchCase> Cases { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _cases.AsSpan(); }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, Cases);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, _cases);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -25,7 +25,7 @@ namespace Esprima.Ast
 
         public SwitchStatement UpdateWith(Expression discriminant, in NodeList<SwitchCase> cases)
         {
-            if (discriminant == Discriminant && NodeList.AreSame(cases, Cases))
+            if (discriminant == Discriminant && NodeList.AreSame(cases, _cases))
             {
                 return this;
             }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -5,8 +5,8 @@ namespace Esprima.Ast
 {
     public sealed class TemplateLiteral : Expression
     {
-        private readonly NodeList<TemplateElement> _quasis;
-        private readonly NodeList<Expression> _expressions;
+        internal readonly NodeList<TemplateElement> _quasis;
+        internal readonly NodeList<Expression> _expressions;
 
         public TemplateLiteral(
             in NodeList<TemplateElement> quasis,
@@ -17,8 +17,8 @@ namespace Esprima.Ast
             _expressions = expressions;
         }
 
-        public ref readonly NodeList<TemplateElement> Quasis { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _quasis; }
-        public ref readonly NodeList<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _expressions; }
+        public ReadOnlySpan<TemplateElement> Quasis { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _quasis.AsSpan(); }
+        public ReadOnlySpan<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _expressions.AsSpan(); }
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(NodeList.Create(CreateChildNodes()));
 
@@ -40,7 +40,7 @@ namespace Esprima.Ast
 
         public TemplateLiteral UpdateWith(in NodeList<TemplateElement> quasis, in NodeList<Expression> expressions)
         {
-            if (NodeList.AreSame(quasis, Quasis) && NodeList.AreSame(expressions, Expressions))
+            if (NodeList.AreSame(quasis, _quasis) && NodeList.AreSame(expressions, _expressions))
             {
                 return this;
             }

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -5,7 +5,7 @@ namespace Esprima.Ast
 {
     public sealed class VariableDeclaration : Declaration
     {
-        private readonly NodeList<VariableDeclarator> _declarations;
+        internal readonly NodeList<VariableDeclarator> _declarations;
 
         public VariableDeclaration(
             in NodeList<VariableDeclarator> declarations,
@@ -16,10 +16,10 @@ namespace Esprima.Ast
             Kind = kind;
         }
 
-        public ref readonly NodeList<VariableDeclarator> Declarations { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _declarations; }
+        public ReadOnlySpan<VariableDeclarator> Declarations { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _declarations.AsSpan(); }
         public VariableDeclarationKind Kind { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Declarations);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(_declarations);
 
         protected internal override object? Accept(AstVisitor visitor)
         {
@@ -28,7 +28,7 @@ namespace Esprima.Ast
 
         public VariableDeclaration UpdateWith(in NodeList<VariableDeclarator> declarations)
         {
-            if (NodeList.AreSame(declarations, Declarations))
+            if (NodeList.AreSame(declarations, _declarations))
             {
                 return this;
             }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -645,11 +645,11 @@ namespace Esprima
                             break;
                         case "@":
                             var decorators = ParseDecorators();
-                            
+
                             _context.Decorators = decorators;
                             var expression = ParsePrimaryExpression();
                             _context.Decorators = new ArrayList<Decorator>();
-                            
+
                             expr = Finalize(node, expression);
                             break;
                         default:
@@ -1076,7 +1076,7 @@ namespace Esprima
 
                 if (!Match("}") && (property is not Property {Method: true} || Match(",")))
                 {
-                    ExpectCommaSeparator();    
+                    ExpectCommaSeparator();
                 }
             }
 
@@ -1360,7 +1360,7 @@ namespace Esprima
 
                                 if (expr.Type == Nodes.SequenceExpression)
                                 {
-                                    expr = new ArrowParameterPlaceHolder(expr.As<SequenceExpression>().Expressions, false);
+                                    expr = new ArrowParameterPlaceHolder(expr.As<SequenceExpression>()._expressions, false);
                                 }
                                 else
                                 {
@@ -2212,8 +2212,8 @@ namespace Esprima
                 case Nodes.ArrowParameterPlaceHolder:
                     // TODO clean-up
                     var arrowParameterPlaceHolder = expr.As<ArrowParameterPlaceHolder>();
-                    parameters = new ArrayList<Expression>(arrowParameterPlaceHolder.Params.Count);
-                    parameters.AddRange(arrowParameterPlaceHolder.Params);
+                    parameters = new ArrayList<Expression>(arrowParameterPlaceHolder._params._count);
+                    parameters.AddRange(arrowParameterPlaceHolder._params);
                     asyncArrow = arrowParameterPlaceHolder.Async;
                     break;
                 default:
@@ -4398,19 +4398,19 @@ namespace Esprima
             _context.Strict = previousStrict;
             _context.AllowYield = previousAllowYield;
             _context.IsAsync = previousIsAsync;
-            
+
             if (Match(";"))
             {
                 ThrowError(Messages.NoSemicolonAfterDecorator);
             }
-            
+
             return Finalize(node, new Decorator(expression));
         }
 
         private ArrayList<Decorator> ParseDecorators()
         {
             var decorators = new ArrayList<Decorator>();
-            
+
             while (Match("@"))
             {
                 decorators.Add(ParseDecorator());
@@ -4433,7 +4433,7 @@ namespace Esprima
             var isAsync = false;
             var isGenerator = false;
             var isPrivate = false;
-            
+
             var decorators = ParseDecorators();
 
             if (decorators.Count > 0)
@@ -4762,8 +4762,8 @@ namespace Esprima
             while (!Match("}"))
             {
                 var importAttribute = ParseImportAttribute();
-                
-                string? key = string.Empty; 
+
+                string? key = string.Empty;
                 switch (importAttribute.Key)
                 {
                     case Identifier identifier:
@@ -4778,7 +4778,7 @@ namespace Esprima
                 {
                     ThrowError(Messages.DuplicateAssertClauseProperty, key);
                 }
-                
+
                 attributes.Add(importAttribute);
                 if (!Match("}"))
                 {
@@ -4788,7 +4788,7 @@ namespace Esprima
             Expect("}");
             return attributes;
         }
-        
+
         private ImportAttribute ParseImportAttribute()
         {
             var node = CreateNode();
@@ -5103,7 +5103,7 @@ namespace Esprima
                 Literal? source = null;
                 var isExportFromIdentifier = false;
                 ArrayList<ImportAttribute> attributes = new();
-                
+
                 Expect("{");
                 while (!Match("}"))
                 {

--- a/src/Esprima/JsxToken.cs
+++ b/src/Esprima/JsxToken.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Esprima
+﻿namespace Esprima
 {
     public enum JsxTokenType
     {

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -322,16 +322,29 @@ public class AstToJsonConverter : AstJson.IConverter
             Member(name, map[value]);
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected void Member<T>(string name, in NodeList<T> nodes) where T : Node?
         {
             Member(name, nodes, node => node);
         }
 
-        protected void Member<T>(string name, in NodeList<T> list, Func<T, Node?> nodeSelector) where T : Node?
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void Member<T>(string name, in NodeList<T> nodes, Func<T, Node?> nodeSelector) where T : Node?
+        {
+            Member(name, nodes.AsSpan(), nodeSelector);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected void Member<T>(string name, ReadOnlySpan<T> nodes) where T : Node?
+        {
+            Member(name, nodes, node => node);
+        }
+
+        protected void Member<T>(string name, ReadOnlySpan<T> nodes, Func<T, Node?> nodeSelector) where T : Node?
         {
             Member(name);
             _writer.StartArray();
-            foreach (var item in list)
+            foreach (var item in nodes)
             {
                 Visit(nodeSelector(item));
             }
@@ -507,7 +520,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("id", classDeclaration.Id);
                 Member("superClass", classDeclaration.SuperClass);
                 Member("body", classDeclaration.Body);
-                if (classDeclaration.Decorators.Count > 0)
+                if (classDeclaration.Decorators.Length > 0)
                 {
                     Member("decorators", classDeclaration.Decorators);
                 }
@@ -523,7 +536,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("id", classExpression.Id);
                 Member("superClass", classExpression.SuperClass);
                 Member("body", classExpression.Body);
-                if (classExpression.Decorators.Count > 0)
+                if (classExpression.Decorators.Length > 0)
                 {
                     Member("decorators", classExpression.Decorators);
                 }
@@ -597,7 +610,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 if (!_testCompatibilityMode)
                 {
                     Member("exported", exportAllDeclaration.Exported);
-                    if (exportAllDeclaration.Assertions.Count > 0)
+                    if (exportAllDeclaration.Assertions.Length > 0)
                     {
                         Member("assertions", exportAllDeclaration.Assertions);
                     }
@@ -625,7 +638,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("specifiers", exportNamedDeclaration.Specifiers);
                 Member("source", exportNamedDeclaration.Source);
                 // original Esprima doesn't include this information yet
-                if (!_testCompatibilityMode && exportNamedDeclaration.Assertions.Count > 0)
+                if (!_testCompatibilityMode && exportNamedDeclaration.Assertions.Length > 0)
                 {
                     Member("assertions", exportNamedDeclaration.Assertions);
                 }
@@ -797,7 +810,7 @@ public class AstToJsonConverter : AstJson.IConverter
                     Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
                     Range = new Ast.Range(import.Range.Start, import.Range.Start + importToken.Length)
                 };
-                var args = new NodeList<Expression>(new Expression[] { import.Source });
+                var args = new NodeList<Expression>((ReadOnlySpan<Expression>) new[] { import.Source });
                 var callExpression = new CallExpression(callee, args, optional: false)
                 {
                     Location = import.Location,
@@ -841,7 +854,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("specifiers", importDeclaration.Specifiers, e => (Node) e);
                 Member("source", importDeclaration.Source);
                 // original Esprima doesn't include this information yet
-                if (importDeclaration.Assertions.Count > 0)
+                if (importDeclaration.Assertions.Length > 0)
                 {
                     Member("assertions", importDeclaration.Assertions);
                 }
@@ -980,7 +993,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("value", methodDefinition.Value);
                 Member("kind", methodDefinition.Kind);
                 Member("static", methodDefinition.Static);
-                if (methodDefinition.Decorators.Count > 0)
+                if (methodDefinition.Decorators.Length > 0)
                 {
                     Member("decorators", methodDefinition.Decorators);
                 }
@@ -1071,7 +1084,7 @@ public class AstToJsonConverter : AstJson.IConverter
                 Member("value", propertyDefinition.Value);
                 Member("kind", propertyDefinition.Kind);
                 Member("static", propertyDefinition.Static);
-                if (propertyDefinition.Decorators.Count > 0)
+                if (propertyDefinition.Decorators.Length > 0)
                 {
                     Member("decorators", propertyDefinition.Decorators);
                 }

--- a/src/Esprima/Utils/AstRewriter.cs
+++ b/src/Esprima/Utils/AstRewriter.cs
@@ -28,11 +28,11 @@ public class AstRewriter : AstVisitor
             new InvalidOperationException($"When called from {callerName}, rewriting a node of type {nodeType} must return null or a non-null value of the same type. Alternatively, override {callerName} and change it to not visit children of this type.");
     }
 
-    public virtual bool VisitAndConvert<T>(in NodeList<T> nodes, out NodeList<T> newNodes, bool allowNullElement = false, [CallerMemberName] string? callerName = null)
+    public virtual bool VisitAndConvert<T>(ReadOnlySpan<T> nodes, out NodeList<T> newNodes, bool allowNullElement = false, [CallerMemberName] string? callerName = null)
         where T : Node?
     {
         List<T>? newNodeList = null;
-        for (var i = 0; i < nodes.Count; i++)
+        for (var i = 0; i < nodes.Length; i++)
         {
             var node = nodes[i];
 
@@ -60,7 +60,7 @@ public class AstRewriter : AstVisitor
             return true;
         }
 
-        newNodes = nodes;
+        newNodes = new NodeList<T>(nodes);
         return false;
     }
 

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -15,13 +15,11 @@ public class AstVisitor
 
     protected internal virtual object? VisitArrayExpression(ArrayExpression arrayExpression)
     {
-        ref readonly var elements = ref arrayExpression.Elements;
-        for (var i = 0; i < elements.Count; i++)
+        foreach (var expression in arrayExpression.Elements)
         {
-            var expr = elements[i];
-            if (expr is not null)
+            if (expression is not null)
             {
-                Visit(expr);
+                Visit(expression);
             }
         }
 
@@ -30,13 +28,11 @@ public class AstVisitor
 
     protected internal virtual object? VisitArrayPattern(ArrayPattern arrayPattern)
     {
-        ref readonly var elements = ref arrayPattern.Elements;
-        for (var i = 0; i < elements.Count; i++)
+        foreach (var expression in arrayPattern.Elements)
         {
-            var expr = elements[i];
-            if (expr is not null)
+            if (expression is not null)
             {
-                Visit(expr);
+                Visit(expression);
             }
         }
 
@@ -45,10 +41,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
     {
-        ref readonly var parameters = ref arrowFunctionExpression.Params;
-        for (var i = 0; i < parameters.Count; i++)
+        foreach (var parameter in arrowFunctionExpression.Params)
         {
-            Visit(parameters[i]);
+            Visit(parameter);
         }
 
         Visit(arrowFunctionExpression.Body);
@@ -97,10 +92,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitBlockStatement(BlockStatement blockStatement)
     {
-        ref readonly var body = ref blockStatement.Body;
-        for (var i = 0; i < body.Count; i++)
+        foreach (var statement in blockStatement.Body)
         {
-            Visit(body[i]);
+            Visit(statement);
         }
 
         return blockStatement;
@@ -119,10 +113,9 @@ public class AstVisitor
     protected internal virtual object? VisitCallExpression(CallExpression callExpression)
     {
         Visit(callExpression.Callee);
-        ref readonly var arguments = ref callExpression.Arguments;
-        for (var i = 0; i < arguments.Count; i++)
+        foreach (var argument in callExpression.Arguments)
         {
-            Visit(arguments[i]);
+            Visit(argument);
         }
 
         return callExpression;
@@ -149,10 +142,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitClassBody(ClassBody classBody)
     {
-        ref readonly var body = ref classBody.Body;
-        for (var i = 0; i < body.Count; i++)
+        foreach (var statement in classBody.Body)
         {
-            Visit(body[i]);
+            Visit(statement);
         }
 
         return classBody;
@@ -172,10 +164,9 @@ public class AstVisitor
 
         Visit(classDeclaration.Body);
 
-        ref readonly var decorators = ref classDeclaration.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
+        foreach (var decorator in classDeclaration.Decorators)
         {
-            Visit(decorators[i]);
+            Visit(decorator);
         }
 
         return classDeclaration;
@@ -195,10 +186,9 @@ public class AstVisitor
 
         Visit(classExpression.Body);
 
-        ref readonly var decorators = ref classExpression.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
+        foreach (var decorator in classExpression.Decorators)
         {
-            Visit(decorators[i]);
+            Visit(decorator);
         }
 
         return classExpression;
@@ -257,10 +247,9 @@ public class AstVisitor
 
         Visit(exportAllDeclaration.Source);
 
-        ref readonly var assertions = ref exportAllDeclaration.Assertions;
-        for (var i = 0; i < assertions.Count; i++)
+        foreach (var assertion in exportAllDeclaration.Assertions)
         {
-            Visit(assertions[i]);
+            Visit(assertion);
         }
 
         return exportAllDeclaration;
@@ -280,10 +269,9 @@ public class AstVisitor
             Visit(exportNamedDeclaration.Declaration);
         }
 
-        ref readonly var specifiers = ref exportNamedDeclaration.Specifiers;
-        for (var i = 0; i < specifiers.Count; i++)
+        foreach (var specifier in exportNamedDeclaration.Specifiers)
         {
-            Visit(specifiers[i]);
+            Visit(specifier);
         }
 
         if (exportNamedDeclaration.Source is not null)
@@ -291,10 +279,9 @@ public class AstVisitor
             Visit(exportNamedDeclaration.Source);
         }
 
-        ref readonly var assertions = ref exportNamedDeclaration.Assertions;
-        for (var i = 0; i < assertions.Count; i++)
+        foreach (var assertion in exportNamedDeclaration.Assertions)
         {
-            Visit(assertions[i]);
+            Visit(assertion);
         }
 
         return exportNamedDeclaration;
@@ -372,10 +359,9 @@ public class AstVisitor
             Visit(functionDeclaration.Id);
         }
 
-        ref readonly var parameters = ref functionDeclaration.Params;
-        for (var i = 0; i < parameters.Count; i++)
+        foreach (var parameter in functionDeclaration.Params)
         {
-            Visit(parameters[i]);
+            Visit(parameter);
         }
 
         Visit(functionDeclaration.Body);
@@ -390,10 +376,9 @@ public class AstVisitor
             Visit(functionExpression.Id);
         }
 
-        ref readonly var parameters = ref functionExpression.Params;
-        for (var i = 0; i < parameters.Count; i++)
+        foreach (var parameter in functionExpression.Params)
         {
-            Visit(parameters[i]);
+            Visit(parameter);
         }
 
         Visit(functionExpression.Body);
@@ -440,18 +425,16 @@ public class AstVisitor
 
     protected internal virtual object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
-        ref readonly var specifiers = ref importDeclaration.Specifiers;
-        for (var i = 0; i < specifiers.Count; i++)
+        foreach (var specifier in importDeclaration.Specifiers)
         {
-            Visit(specifiers[i]);
+            Visit(specifier);
         }
 
         Visit(importDeclaration.Source);
 
-        ref readonly var assertions = ref importDeclaration.Assertions;
-        for (var i = 0; i < assertions.Count; i++)
+        foreach (var assertion in importDeclaration.Assertions)
         {
-            Visit(assertions[i]);
+            Visit(assertion);
         }
 
         return importDeclaration;
@@ -513,10 +496,9 @@ public class AstVisitor
         Visit(methodDefinition.Key);
         Visit(methodDefinition.Value);
 
-        ref readonly var decorators = ref methodDefinition.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
+        foreach (var decorator in methodDefinition.Decorators)
         {
-            Visit(decorators[i]);
+            Visit(decorator);
         }
 
         return methodDefinition;
@@ -525,10 +507,9 @@ public class AstVisitor
     protected internal virtual object? VisitNewExpression(NewExpression newExpression)
     {
         Visit(newExpression.Callee);
-        ref readonly var arguments = ref newExpression.Arguments;
-        for (var i = 0; i < arguments.Count; i++)
+        foreach (var argument in newExpression.Arguments)
         {
-            Visit(arguments[i]);
+            Visit(argument);
         }
 
         return newExpression;
@@ -536,10 +517,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitObjectExpression(ObjectExpression objectExpression)
     {
-        ref readonly var properties = ref objectExpression.Properties;
-        for (var i = 0; i < properties.Count; i++)
+        foreach (var property in objectExpression.Properties)
         {
-            Visit(properties[i]);
+            Visit(property);
         }
 
         return objectExpression;
@@ -547,10 +527,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitObjectPattern(ObjectPattern objectPattern)
     {
-        ref readonly var properties = ref objectPattern.Properties;
-        for (var i = 0; i < properties.Count; i++)
+        foreach (var property in objectPattern.Properties)
         {
-            Visit(properties[i]);
+            Visit(property);
         }
 
         return objectPattern;
@@ -563,10 +542,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitProgram(Program program)
     {
-        ref readonly var statements = ref program.Body;
-        for (var i = 0; i < statements.Count; i++)
+        foreach (var statement in program.Body)
         {
-            Visit(statements[i]);
+            Visit(statement);
         }
 
         return program;
@@ -589,10 +567,9 @@ public class AstVisitor
             Visit(propertyDefinition.Value);
         }
 
-        ref readonly var decorators = ref propertyDefinition.Decorators;
-        for (var i = 0; i < decorators.Count; i++)
+        foreach (var decorator in propertyDefinition.Decorators)
         {
-            Visit(decorators[i]);
+            Visit(decorator);
         }
 
         return propertyDefinition;
@@ -617,10 +594,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitSequenceExpression(SequenceExpression sequenceExpression)
     {
-        ref readonly var expressions = ref sequenceExpression.Expressions;
-        for (var i = 0; i < expressions.Count; i++)
+        foreach (var expression in sequenceExpression.Expressions)
         {
-            Visit(expressions[i]);
+            Visit(expression);
         }
 
         return sequenceExpression;
@@ -635,10 +611,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitStaticBlock(StaticBlock staticBlock)
     {
-        ref readonly var body = ref staticBlock.Body;
-        for (var i = 0; i < body.Count; i++)
+        foreach (var statement in staticBlock.Body)
         {
-            Visit(body[i]);
+            Visit(statement);
         }
 
         return staticBlock;
@@ -656,10 +631,9 @@ public class AstVisitor
             Visit(switchCase.Test);
         }
 
-        ref readonly var consequent = ref switchCase.Consequent;
-        for (var i = 0; i < consequent.Count; i++)
+        foreach (var statement in switchCase.Consequent)
         {
-            Visit(consequent[i]);
+            Visit(statement);
         }
 
         return switchCase;
@@ -668,10 +642,9 @@ public class AstVisitor
     protected internal virtual object? VisitSwitchStatement(SwitchStatement switchStatement)
     {
         Visit(switchStatement.Discriminant);
-        ref readonly var cases = ref switchStatement.Cases;
-        for (var i = 0; i < cases.Count; i++)
+        foreach (var switchCase in switchStatement.Cases)
         {
-            Visit(cases[i]);
+            Visit(switchCase);
         }
 
         return switchStatement;
@@ -692,8 +665,8 @@ public class AstVisitor
 
     protected internal virtual object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
     {
-        ref readonly var quasis = ref templateLiteral.Quasis;
-        ref readonly var expressions = ref templateLiteral.Expressions;
+        var quasis = templateLiteral.Quasis;
+        var expressions = templateLiteral.Expressions;
 
         TemplateElement quasi;
         for (var i = 0; !(quasi = quasis[i]).Tail; i++)
@@ -743,10 +716,9 @@ public class AstVisitor
 
     protected internal virtual object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
     {
-        ref readonly var declarations = ref variableDeclaration.Declarations;
-        for (var i = 0; i < declarations.Count; i++)
+        foreach (var declaration in variableDeclaration.Declarations)
         {
-            Visit(declarations[i]);
+            Visit(declaration);
         }
 
         return variableDeclaration;

--- a/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
@@ -52,10 +52,9 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
     public virtual object? VisitJsxElement(JsxElement jsxElement)
     {
         _visitor.Visit(jsxElement.OpeningElement);
-        ref readonly var children = ref jsxElement.Children;
-        for (var i = 0; i < children.Count; i++)
+        foreach (var child in jsxElement.Children)
         {
-            _visitor.Visit(children[i]);
+            _visitor.Visit(child);
         }
 
         if (jsxElement.ClosingElement is not null)
@@ -102,10 +101,9 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
     public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
     {
         _visitor.Visit(jsxOpeningElement.Name);
-        ref readonly var attributes = ref jsxOpeningElement.Attributes;
-        for (var i = 0; i < attributes.Count; i++)
+        foreach (var attribute in jsxOpeningElement.Attributes)
         {
-            _visitor.Visit(attributes[i]);
+            _visitor.Visit(attribute);
         }
 
         return jsxOpeningElement;

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -1,5 +1,4 @@
-﻿using System.Numerics;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Esprima.Ast.Jsx;
 using Esprima.Utils.Jsx;
 using Module = Esprima.Ast.Module;
@@ -204,8 +203,8 @@ sealed class TestRewriter : JsxAstRewriter
         return ForceNewObjectByControlType((Program) base.VisitProgram(program)!,
             node => program switch
             {
-                Module => new Module(node.Body),
-                Script script => new Script(node.Body, script.Strict),
+                Module => new Module(node._body),
+                Script script => new Script(node._body, script.Strict),
                 _ => throw new NotImplementedException($"{program.SourceType} does not implemented yet.")
             });
     }
@@ -219,7 +218,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
     {
         return ForceNewObjectByControlType((FunctionDeclaration) base.VisitFunctionDeclaration(functionDeclaration)!,
-            node => new FunctionDeclaration(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
+            node => new FunctionDeclaration(node.Id, node._params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
     protected internal override object? VisitWithStatement(WithStatement withStatement)
@@ -237,7 +236,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
     {
         return ForceNewObjectByControlType((VariableDeclaration) base.VisitVariableDeclaration(variableDeclaration)!,
-            node => new VariableDeclaration(node.Declarations, node.Kind));
+            node => new VariableDeclaration(node._declarations, node.Kind));
     }
 
     protected internal override object? VisitTryStatement(TryStatement tryStatement)
@@ -255,13 +254,13 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
     {
         return ForceNewObjectByControlType((SwitchStatement) base.VisitSwitchStatement(switchStatement)!,
-            node => new SwitchStatement(node.Discriminant, node.Cases));
+            node => new SwitchStatement(node.Discriminant, node._cases));
     }
 
     protected internal override object? VisitSwitchCase(SwitchCase switchCase)
     {
         return ForceNewObjectByControlType((SwitchCase) base.VisitSwitchCase(switchCase)!,
-            node => new SwitchCase(node.Test, node.Consequent));
+            node => new SwitchCase(node.Test, node._consequent));
     }
 
     protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
@@ -325,7 +324,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
     {
         return ForceNewObjectByControlType((ArrowFunctionExpression) base.VisitArrowFunctionExpression(arrowFunctionExpression)!,
-            node => new ArrowFunctionExpression(node.Params, node.Body, node.Expression, node.Strict, node.Async));
+            node => new ArrowFunctionExpression(node._params, node.Body, node.Expression, node.Strict, node.Async));
     }
 
     protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
@@ -347,19 +346,19 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
     {
         return ForceNewObjectByControlType((SequenceExpression) base.VisitSequenceExpression(sequenceExpression)!,
-            node => new SequenceExpression(node.Expressions));
+            node => new SequenceExpression(node._expressions));
     }
 
     protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
     {
         return ForceNewObjectByControlType((ObjectExpression) base.VisitObjectExpression(objectExpression)!,
-            node => new ObjectExpression(node.Properties));
+            node => new ObjectExpression(node._properties));
     }
 
     protected internal override object? VisitNewExpression(NewExpression newExpression)
     {
         return ForceNewObjectByControlType((NewExpression) base.VisitNewExpression(newExpression)!,
-            node => new NewExpression(node.Callee, node.Arguments));
+            node => new NewExpression(node.Callee, node._arguments));
     }
 
     protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
@@ -397,13 +396,13 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
     {
         return ForceNewObjectByControlType((FunctionExpression) base.VisitFunctionExpression(functionExpression)!,
-            node => new FunctionExpression(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
+            node => new FunctionExpression(node.Id, node._params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
     protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
     {
         return ForceNewObjectByControlType((PropertyDefinition) base.VisitPropertyDefinition(propertyDefinition)!,
-            node => new PropertyDefinition(node.Key, node.Computed, node.Value!, node.Static, node.Decorators));
+            node => new PropertyDefinition(node.Key, node.Computed, node.Value!, node.Static, node._decorators));
     }
 
     protected internal override object? VisitChainExpression(ChainExpression chainExpression)
@@ -415,7 +414,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitClassExpression(ClassExpression classExpression)
     {
         return ForceNewObjectByControlType((ClassExpression) base.VisitClassExpression(classExpression)!,
-            node => new ClassExpression(node.Id, node.SuperClass, node.Body, node.Decorators));
+            node => new ClassExpression(node.Id, node.SuperClass, node.Body, node._decorators));
     }
 
     protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
@@ -427,13 +426,13 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
     {
         return ForceNewObjectByControlType((ExportAllDeclaration) base.VisitExportAllDeclaration(exportAllDeclaration)!,
-            node => new ExportAllDeclaration(node.Source, node.Exported, exportAllDeclaration.Assertions));
+            node => new ExportAllDeclaration(node.Source, node.Exported, exportAllDeclaration._assertions));
     }
 
     protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
     {
         return ForceNewObjectByControlType((ExportNamedDeclaration) base.VisitExportNamedDeclaration(exportNamedDeclaration)!,
-            node => new ExportNamedDeclaration(node.Declaration, node.Specifiers, node.Source, exportNamedDeclaration.Assertions));
+            node => new ExportNamedDeclaration(node.Declaration, node._specifiers, node.Source, exportNamedDeclaration._assertions));
     }
 
     protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
@@ -451,7 +450,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         return ForceNewObjectByControlType((ImportDeclaration) base.VisitImportDeclaration(importDeclaration)!,
-            node => new ImportDeclaration(node.Specifiers, node.Source, importDeclaration.Assertions));
+            node => new ImportDeclaration(node._specifiers, node.Source, importDeclaration._assertions));
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
@@ -475,7 +474,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
     {
         return ForceNewObjectByControlType((MethodDefinition) base.VisitMethodDefinition(methodDefinition)!,
-            node => new MethodDefinition(node.Key, node.Computed, node.Value, node.Kind, node.Static, node.Decorators));
+            node => new MethodDefinition(node.Key, node.Computed, node.Value, node.Kind, node.Static, node._decorators));
     }
 
     protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
@@ -487,13 +486,13 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
     {
         return ForceNewObjectByControlType((ClassDeclaration) base.VisitClassDeclaration(classDeclaration)!,
-            node => new ClassDeclaration(node.Id, node.SuperClass, node.Body, node.Decorators));
+            node => new ClassDeclaration(node.Id, node.SuperClass, node.Body, node._decorators));
     }
 
     protected internal override object? VisitClassBody(ClassBody classBody)
     {
         return ForceNewObjectByControlType((ClassBody) base.VisitClassBody(classBody)!,
-            node => new ClassBody(node.Body));
+            node => new ClassBody(node._body));
     }
 
     protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
@@ -523,7 +522,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
     {
         return ForceNewObjectByControlType((ObjectPattern) base.VisitObjectPattern(objectPattern)!,
-            node => new ObjectPattern(node.Properties));
+            node => new ObjectPattern(node._properties));
     }
 
     protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
@@ -541,7 +540,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
     {
         return ForceNewObjectByControlType((ArrayPattern) base.VisitArrayPattern(arrayPattern)!,
-            node => new ArrayPattern(node.Elements));
+            node => new ArrayPattern(node._elements));
     }
 
     protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
@@ -553,7 +552,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
     {
         return ForceNewObjectByControlType((TemplateLiteral) base.VisitTemplateLiteral(templateLiteral)!,
-            node => new TemplateLiteral(node.Quasis, node.Expressions));
+            node => new TemplateLiteral(node._quasis, node._expressions));
     }
 
     protected internal override object? VisitTemplateElement(TemplateElement templateElement)
@@ -589,7 +588,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitCallExpression(CallExpression callExpression)
     {
         return ForceNewObjectByControlType((CallExpression) base.VisitCallExpression(callExpression)!,
-            node => new CallExpression(node.Callee, node.Arguments, callExpression.Optional));
+            node => new CallExpression(node.Callee, node._arguments, callExpression.Optional));
     }
 
     protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
@@ -601,7 +600,7 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
     {
         return ForceNewObjectByControlType((ArrayExpression) base.VisitArrayExpression(arrayExpression)!,
-            node => new ArrayExpression(node.Elements));
+            node => new ArrayExpression(node._elements));
     }
 
     protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
@@ -625,13 +624,13 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
     {
         return ForceNewObjectByControlType((BlockStatement) base.VisitBlockStatement(blockStatement)!,
-            node => new BlockStatement(node.Body));
+            node => new BlockStatement(node._body));
     }
 
     protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
     {
         return ForceNewObjectByControlType((StaticBlock) base.VisitStaticBlock(staticBlock)!,
-            node => new StaticBlock(node.Body));
+            node => new StaticBlock(node._body));
     }
 
     public override object? VisitJsxAttribute(JsxAttribute jsxAttribute)
@@ -643,7 +642,7 @@ sealed class TestRewriter : JsxAstRewriter
     public override object? VisitJsxElement(JsxElement jsxElement)
     {
         return ForceNewObjectByControlType((JsxElement) base.VisitJsxElement(jsxElement)!,
-            node => new JsxElement(node.OpeningElement, node.Children, node.ClosingElement));
+            node => new JsxElement(node.OpeningElement, node._children, node.ClosingElement));
     }
 
     public override object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
@@ -697,7 +696,7 @@ sealed class TestRewriter : JsxAstRewriter
     public override object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
     {
         return ForceNewObjectByControlType((JsxOpeningElement) base.VisitJsxOpeningElement(jsxOpeningElement)!,
-            node => new JsxOpeningElement(node.Name, node.SelfClosing, node.Attributes));
+            node => new JsxOpeningElement(node.Name, node.SelfClosing, node._attributes));
     }
 
     public override object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)

--- a/test/Esprima.Tests/AstVisitorEventSourceTests.cs
+++ b/test/Esprima.Tests/AstVisitorEventSourceTests.cs
@@ -42,7 +42,7 @@ namespace Esprima.Tests
             visitor.VisitedLiteral += (_, arg) => value = arg;
             visitor.Visit(expression);
 
-            var expectedProperty = expression.Properties.Single().As<Property>();
+            var expectedProperty = expression.Properties[0].As<Property>();
             Assert.Same(expectedProperty, property);
             Assert.Same(expectedProperty.Key, key);
             Assert.Same(expectedProperty.Value, value);

--- a/test/Esprima.Tests/Breaking.cs
+++ b/test/Esprima.Tests/Breaking.cs
@@ -23,10 +23,7 @@
 
 #endregion
 
-using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace Esprima.Tests
 {

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -118,7 +118,7 @@ namespace Esprima.Test
             {
                 var parser = new JavaScriptParser(script);
                 var program = parser.ParseScript();
-                var source = program.Body.First().As<VariableDeclaration>().Declarations.First().As<VariableDeclarator>().Init!.As<Literal>().StringValue!;
+                var source = program.Body[0].As<VariableDeclaration>().Declarations[0].As<VariableDeclarator>().Init!.As<Literal>().StringValue!;
                 script = source;
             }
 

--- a/test/Esprima.Tests/Lazy.cs
+++ b/test/Esprima.Tests/Lazy.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Esprima.Tests
+﻿namespace Esprima.Tests
 {
     internal static class Lazy
     {

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using Xunit;
-
-namespace Esprima.Tests
+﻿namespace Esprima.Tests
 {
     public class LocationTests
     {

--- a/test/Esprima.Tests/NodeListTests.cs
+++ b/test/Esprima.Tests/NodeListTests.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Globalization;
-using System.Linq;
+﻿using System.Globalization;
 using Esprima.Ast;
-using Xunit;
 
 namespace Esprima.Tests
 {

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -28,7 +28,7 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("function p() {}");
             var program = parser.ParseScript();
-            var function = program.Body.First().As<FunctionDeclaration>();
+            var function = program.Body[0].As<FunctionDeclaration>();
 
             Assert.False(function.Strict);
         }
@@ -38,7 +38,7 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("function p() { 'use strict'; }");
             var program = parser.ParseScript();
-            var function = program.Body.First().As<FunctionDeclaration>();
+            var function = program.Body[0].As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
         }
@@ -48,7 +48,7 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("'use strict'; function p() {}");
             var program = parser.ParseScript();
-            var function = program.Body.Skip(1).First().As<FunctionDeclaration>();
+            var function = program.Body[1].As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
         }
@@ -58,7 +58,7 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("function p() {'use strict'; return false;}");
             var program = parser.ParseScript();
-            var function = program.Body.First().As<FunctionDeclaration>();
+            var function = program.Body[0].As<FunctionDeclaration>();
 
             Assert.True(function.Strict);
         }
@@ -68,8 +68,8 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("function p() {'use strict'; function q() { return; } return; }");
             var program = parser.ParseScript();
-            var p = program.Body.First().As<FunctionDeclaration>();
-            var q = p.Body.As<BlockStatement>().Body.Skip(1).First().As<FunctionDeclaration>();
+            var p = program.Body[0].As<FunctionDeclaration>();
+            var q = p.Body.As<BlockStatement>().Body[1].As<FunctionDeclaration>();
 
             Assert.Equal("p", p.Id?.Name);
             Assert.Equal("q", q.Id?.Name);
@@ -83,7 +83,7 @@ namespace Esprima.Tests
         {
             var parser = new JavaScriptParser("here: Hello();");
             var program = parser.ParseScript();
-            var labeledStatement = program.Body.First().As<LabeledStatement>();
+            var labeledStatement = program.Body[0].As<LabeledStatement>();
             var body = labeledStatement.Body;
 
             Assert.Equal(labeledStatement.Label, body.LabelSet);

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using Xunit;
-
-namespace Esprima.Tests
+﻿namespace Esprima.Tests
 {
     public class ScannerTests
     {

--- a/test/Esprima.Tests/SeparatorTests.cs
+++ b/test/Esprima.Tests/SeparatorTests.cs
@@ -1,5 +1,4 @@
 ﻿using Esprima.Ast;
-using Xunit;
 
 namespace Esprima.Tests
 {

--- a/test/Esprima.Tests/StrictModeTests.cs
+++ b/test/Esprima.Tests/StrictModeTests.cs
@@ -1,5 +1,4 @@
 ﻿using Esprima.Ast;
-using Xunit;
 
 namespace Esprima.Tests
 {
@@ -9,7 +8,7 @@ namespace Esprima.Tests
         public void DetectsForFunction()
         {
             var script = new JavaScriptParser("function f() { 'use strict'; }").ParseScript();
-            var function = (FunctionDeclaration) script.Body.First();
+            var function = (FunctionDeclaration) script.Body[0];
             Assert.True(function.Strict);
         }
 
@@ -17,8 +16,8 @@ namespace Esprima.Tests
         public void DetectsForFunctionExpression()
         {
             var script = new JavaScriptParser("var f = function() { 'use strict'; }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var function = (FunctionExpression) variable.Declarations.First().Init!;
+            var variable = (VariableDeclaration) script.Body[0];
+            var function = (FunctionExpression) variable.Declarations[0].Init!;
             Assert.True(function.Strict);
         }
 
@@ -26,8 +25,8 @@ namespace Esprima.Tests
         public void DetectsForArrowFunctionExpression()
         {
             var script = new JavaScriptParser("var f = () => { 'use strict'; }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var function = (ArrowFunctionExpression) variable.Declarations.First().Init!;
+            var variable = (VariableDeclaration) script.Body[0];
+            var function = (ArrowFunctionExpression) variable.Declarations[0].Init!;
             Assert.True(function.Strict);
         }
 
@@ -35,9 +34,9 @@ namespace Esprima.Tests
         public void DetectsForFunctionExpressionInsideObjectExpression()
         {
             var script = new JavaScriptParser("var obj = { method() { 'use strict'; } }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
-            var property = (Property) objectExpression.Properties.First();
+            var variable = (VariableDeclaration) script.Body[0];
+            var objectExpression = (ObjectExpression) variable.Declarations[0].Init!;
+            var property = (Property) objectExpression.Properties[0];
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
         }
@@ -46,9 +45,9 @@ namespace Esprima.Tests
         public void DetectsForAsyncFunctionExpressionInsideObjectExpression_Strict()
         {
             var script = new JavaScriptParser("var obj = { async method() { 'use strict'; } }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
-            var property = (Property) objectExpression.Properties.First();
+            var variable = (VariableDeclaration) script.Body[0];
+            var objectExpression = (ObjectExpression) variable.Declarations[0].Init!;
+            var property = (Property) objectExpression.Properties[0];
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
         }
@@ -57,9 +56,9 @@ namespace Esprima.Tests
         public void DetectsForAsyncFunctionExpressionInsideObjectExpression_NotStrict()
         {
             var script = new JavaScriptParser("var obj = { async method() { } }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
-            var property = (Property) objectExpression.Properties.First();
+            var variable = (VariableDeclaration) script.Body[0];
+            var objectExpression = (ObjectExpression) variable.Declarations[0].Init!;
+            var property = (Property) objectExpression.Properties[0];
             var function = (FunctionExpression) property.Value;
             Assert.False(function.Strict);
         }
@@ -68,9 +67,9 @@ namespace Esprima.Tests
         public void DetectsForFunctionExpressionInsideObjectGetter()
         {
             var script = new JavaScriptParser("var obj = { get prop() { 'use strict'; } }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
-            var property = (Property) objectExpression.Properties.First();
+            var variable = (VariableDeclaration) script.Body[0];
+            var objectExpression = (ObjectExpression) variable.Declarations[0].Init!;
+            var property = (Property) objectExpression.Properties[0];
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
         }
@@ -79,9 +78,9 @@ namespace Esprima.Tests
         public void DetectsForFunctionExpressionInsideObjectSetter()
         {
             var script = new JavaScriptParser("var obj = { set prop(val) { 'use strict'; } }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var objectExpression = (ObjectExpression) variable.Declarations.First().Init!;
-            var property = (Property) objectExpression.Properties.First();
+            var variable = (VariableDeclaration) script.Body[0];
+            var objectExpression = (ObjectExpression) variable.Declarations[0].Init!;
+            var property = (Property) objectExpression.Properties[0];
             var function = (FunctionExpression) property.Value;
             Assert.True(function.Strict);
         }
@@ -90,7 +89,7 @@ namespace Esprima.Tests
         public void DetectsInsideGeneratorFunction()
         {
             var script = new JavaScriptParser("function* f() { 'use strict'; yield 1; }").ParseScript();
-            var function = (FunctionDeclaration) script.Body.First();
+            var function = (FunctionDeclaration) script.Body[0];
             Assert.True(function.Strict);
         }
 
@@ -98,8 +97,8 @@ namespace Esprima.Tests
         public void DetectsInsideGeneratorFunctionExpression()
         {
             var script = new JavaScriptParser("var f = function*() { 'use strict'; yield 1; }").ParseScript();
-            var variable = (VariableDeclaration) script.Body.First();
-            var function = (FunctionExpression) variable.Declarations.First().Init!;
+            var variable = (VariableDeclaration) script.Body[0];
+            var function = (FunctionExpression) variable.Declarations[0].Init!;
             Assert.True(function.Strict);
         }
     }

--- a/test/Esprima.Tests/VisitorTests.cs
+++ b/test/Esprima.Tests/VisitorTests.cs
@@ -1,9 +1,6 @@
-﻿using System.Collections.Generic;
-using System.IO;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Esprima.Test;
 using Esprima.Utils;
-using Xunit;
 
 namespace Esprima.Tests
 {


### PR DESCRIPTION
Instead of returning `ref readonly NodeList<T>` from nodes, changing to return `ReadOnlySpan<T>`. This is more in line with what API's are expected to return and also is idiomatic for using `foreach` with. No longer need to do `ref readonly` on call site. Jint works nicely with the change, only bigger change required is to pass `() => script.Body` as parameter for body processing as Jint wants to hold a reference to iterated list.

@adams85 thoughts?