### PR TITLE
Provide a way for inheritors to dispatch visitation of their custom nodes to AstVisitor.VisitExtension

### DIFF
--- a/src/Esprima/Ast/Jsx/JsxExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpression.cs
@@ -20,6 +20,6 @@ public abstract class JsxExpression : Expression
 
     protected internal sealed override object? Accept(AstVisitor visitor)
     {
-        return visitor is IJsxAstVisitor jsxVisitor ? Accept(jsxVisitor) : visitor.VisitExtension(this);
+        return visitor is IJsxAstVisitor jsxVisitor ? Accept(jsxVisitor) : AcceptAsExtension(visitor);
     }
 }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -18,5 +18,17 @@ namespace Esprima.Ast
         public abstract NodeCollection ChildNodes { get; }
 
         protected internal abstract object? Accept(AstVisitor visitor);
+
+        /// <summary>
+        /// Dispatches the visitation of the current node to <see cref="AstVisitor.VisitExtension(Node)"/>.
+        /// </summary>
+        /// <remarks>
+        /// When defining custom node types, inheritors can use this method to implement the abstract <see cref="Accept(AstVisitor)"/> method.
+        /// </remarks>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected object? AcceptAsExtension(AstVisitor visitor)
+        {
+            return visitor.VisitExtension(this);
+        }
     }
 }


### PR DESCRIPTION
This PR addresses one of the issues outlined in https://github.com/sebastienros/esprima-dotnet/issues/275.

Inheritors who want to extend the AST by introducing custom node types should be able to route the visitation of these custom nodes to `AstVisitor.VisitExtension`. This hasn't been possible so far because `VisitExtension` is declared with `protected internal` accessibility.

We have the following options to tackle the problem:
1. To make `VisitExtension` public. I don't like this idea because this method shouldn't be visible for consumers of the visitor API as it's not intended for them to call it directly.
2. To do [what expression trees do](https://github.com/dotnet/runtime/blob/main/src/libraries/System.Linq.Expressions/src/System/Linq/Expressions/Expression.cs#L163): provide this dispatch as a default implementation for `Node.Accept`, which can then be called from custom subclasses. This could work but I think it's better to keep `Node.Accept` abstract to make sure that maintainers don't forget to implement it when they add new node types.
3. To add a protected method to `Node`, which can be used by inheritors to implement the `Accept` methods of their custom nodes.

I suggest option 3.