### PR TITLE
Add context parameter to AstVisitor.Visit

### DIFF
--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitArrayExpression(this);
+            return visitor.VisitArrayExpression(this, context);
         }
 
         public ArrayExpression UpdateWith(in NodeList<Expression?> elements)

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Elements);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitArrayPattern(this);
+            return visitor.VisitArrayPattern(this, context);
         }
 
         public ArrayPattern UpdateWith(in NodeList<Expression?> elements)

--- a/src/Esprima/Ast/ArrowFunctionExpression.cs
+++ b/src/Esprima/Ast/ArrowFunctionExpression.cs
@@ -35,9 +35,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitArrowFunctionExpression(this);
+            return visitor.VisitArrowFunctionExpression(this, context);
         }
 
         public ArrowFunctionExpression UpdateWith(in NodeList<Expression> parameters, Node body)

--- a/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
+++ b/src/Esprima/Ast/ArrowParameterPlaceHolder.cs
@@ -23,9 +23,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Params);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitArrowParameterPlaceHolder(this);
+            return visitor.VisitArrowParameterPlaceHolder(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -78,9 +78,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Left, Right);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitAssignmentExpression(this);
+            return visitor.VisitAssignmentExpression(this, context);
         }
 
         public AssignmentExpression UpdateWith(Expression left, Expression right)

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -18,9 +18,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Left, Right);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitAssignmentPattern(this);
+            return visitor.VisitAssignmentPattern(this, context);
         }
 
         public AssignmentPattern UpdateWith(Expression left, Expression right)

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitAwaitExpression(this);
+            return visitor.VisitAwaitExpression(this, context);
         }
 
         public AwaitExpression UpdateWith(Expression argument)

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -87,9 +87,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Left, Right);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitBinaryExpression(this);
+            return visitor.VisitBinaryExpression(this, context);
         }
 
         public BinaryExpression UpdateWith(Expression left, Expression right)

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -14,11 +14,11 @@ namespace Esprima.Ast
 
         public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
-        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
-        protected internal sealed override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitBlockStatement(this);
+            return visitor.VisitBlockStatement(this, context);
         }
 
         public BlockStatement UpdateWith(in NodeList<Statement> body)

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Label);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitBreakStatement(this);
+            return visitor.VisitBreakStatement(this, context);
         }
 
         public BreakStatement UpdateWith(Identifier? label)

--- a/src/Esprima/Ast/CallExpression.cs
+++ b/src/Esprima/Ast/CallExpression.cs
@@ -23,9 +23,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitCallExpression(this);
+            return visitor.VisitCallExpression(this, context);
         }
 
         public CallExpression UpdateWith(Expression callee, in NodeList<Expression> arguments)

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -20,9 +20,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Param, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitCatchClause(this);
+            return visitor.VisitCatchClause(this, context);
         }
 
         public CatchClause UpdateWith(Expression? param, BlockStatement body)

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -17,9 +17,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Expression);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitChainExpression(this);
+            return visitor.VisitChainExpression(this, context);
         }
 
         public ChainExpression UpdateWith(Expression expression)

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -19,9 +19,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitClassBody(this);
+            return visitor.VisitClassBody(this, context);
         }
 
         public ClassBody UpdateWith(in NodeList<ClassElement> body)

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -38,9 +38,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitClassDeclaration(this);
+            return visitor.VisitClassDeclaration(this, context);
         }
 
         public ClassDeclaration UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -41,9 +41,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitClassExpression(this);
+            return visitor.VisitClassExpression(this, context);
         }
 
         public ClassExpression UpdateWith(Identifier? id, Expression? superClass, ClassBody body, in NodeList<Decorator> decorators)

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -21,9 +21,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Test, Consequent, Alternate);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitConditionalExpression(this);
+            return visitor.VisitConditionalExpression(this, context);
         }
 
         public ConditionalExpression UpdateWith(Expression test, Expression consequent, Expression alternate)

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Label);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitContinueStatement(this);
+            return visitor.VisitContinueStatement(this, context);
         }
 
         public ContinueStatement UpdateWith(Identifier? label)

--- a/src/Esprima/Ast/DebuggerStatement.cs
+++ b/src/Esprima/Ast/DebuggerStatement.cs
@@ -8,9 +8,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitDebuggerStatement(this);
+            return visitor.VisitDebuggerStatement(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/Decorator.cs
+++ b/src/Esprima/Ast/Decorator.cs
@@ -14,9 +14,9 @@ public sealed class Decorator : Node
 
     public override NodeCollection ChildNodes => new(Expression);
 
-    protected internal override object? Accept(AstVisitor visitor)
+    protected internal override object? Accept(AstVisitor visitor, object? context)
     {
-        return visitor.VisitDecorator(this);
+        return visitor.VisitDecorator(this, context);
     }
 
     public Decorator UpdateWith(Expression expression)

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Body, Test);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitDoWhileStatement(this);
+            return visitor.VisitDoWhileStatement(this, context);
         }
 
         public DoWhileStatement UpdateWith(Statement body, Expression test)

--- a/src/Esprima/Ast/EmptyStatement.cs
+++ b/src/Esprima/Ast/EmptyStatement.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitEmptyStatement(this);
+            return visitor.VisitEmptyStatement(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -38,9 +38,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExportAllDeclaration(this);
+            return visitor.VisitExportAllDeclaration(this, context);
         }
 
         public ExportAllDeclaration UpdateWith(Expression? exported, Literal source, in NodeList<ImportAttribute> assertions)

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -17,9 +17,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Declaration);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExportDefaultDeclaration(this);
+            return visitor.VisitExportDefaultDeclaration(this, context);
         }
 
         public ExportDefaultDeclaration UpdateWith(StatementListItem declaration)

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -45,9 +45,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExportNamedDeclaration(this);
+            return visitor.VisitExportNamedDeclaration(this, context);
         }
 
         public ExportNamedDeclaration UpdateWith(StatementListItem? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> assertions)

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -22,9 +22,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Exported, Local);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExportSpecifier(this);
+            return visitor.VisitExportSpecifier(this, context);
         }
 
         public ExportSpecifier UpdateWith(Expression local, Expression exported)

--- a/src/Esprima/Ast/ExpressionStatement.cs
+++ b/src/Esprima/Ast/ExpressionStatement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public sealed override NodeCollection ChildNodes => new(Expression);
 
-        protected internal sealed override object? Accept(AstVisitor visitor)
+        protected internal sealed override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExpressionStatement(this);
+            return visitor.VisitExpressionStatement(this, context);
         }
 
         protected virtual ExpressionStatement Rewrite(Expression expression)

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -21,9 +21,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Left, Right, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitForInStatement(this);
+            return visitor.VisitForInStatement(this, context);
         }
 
         public ForInStatement UpdateWith(Node left, Expression right, Statement body)

--- a/src/Esprima/Ast/ForOfStatement.cs
+++ b/src/Esprima/Ast/ForOfStatement.cs
@@ -24,9 +24,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Left, Right, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitForOfStatement(this);
+            return visitor.VisitForOfStatement(this, context);
         }
 
         public ForOfStatement UpdateWith(Node left, Expression right, Statement body)

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -28,9 +28,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Init, Test, Update, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitForStatement(this);
+            return visitor.VisitForStatement(this, context);
         }
 
         public ForStatement UpdateWith(StatementListItem? init, Expression? test, Expression? update, Statement body)

--- a/src/Esprima/Ast/FunctionDeclaration.cs
+++ b/src/Esprima/Ast/FunctionDeclaration.cs
@@ -37,9 +37,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitFunctionDeclaration(this);
+            return visitor.VisitFunctionDeclaration(this, context);
         }
 
         public FunctionDeclaration UpdateWith(Identifier? id, in NodeList<Expression> parameters, BlockStatement body)

--- a/src/Esprima/Ast/FunctionExpression.cs
+++ b/src/Esprima/Ast/FunctionExpression.cs
@@ -37,9 +37,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Id, Params, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitFunctionExpression(this);
+            return visitor.VisitFunctionExpression(this, context);
         }
 
         public FunctionExpression UpdateWith(Identifier? id, in NodeList<Expression> parameters, BlockStatement body)

--- a/src/Esprima/Ast/Identifier.cs
+++ b/src/Esprima/Ast/Identifier.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitIdentifier(this);
+            return visitor.VisitIdentifier(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -22,9 +22,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Test, Consequent, Alternate);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitIfStatement(this);
+            return visitor.VisitIfStatement(this, context);
         }
 
         public IfStatement UpdateWith(Expression test, Statement consequent, Statement? alternate)

--- a/src/Esprima/Ast/Import.cs
+++ b/src/Esprima/Ast/Import.cs
@@ -20,9 +20,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Source, Attributes);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitImport(this);
+            return visitor.VisitImport(this, context);
         }
 
         public Import UpdateWith(Expression source, Expression? attributes)

--- a/src/Esprima/Ast/ImportAttribute.cs
+++ b/src/Esprima/Ast/ImportAttribute.cs
@@ -19,9 +19,9 @@ public sealed class ImportAttribute : Node
 
     public override NodeCollection ChildNodes => new(Key, Value);
 
-    protected internal override object? Accept(AstVisitor visitor)
+    protected internal override object? Accept(AstVisitor visitor, object? context)
     {
-        return visitor.VisitImportAttribute(this);
+        return visitor.VisitImportAttribute(this, context);
     }
 
     public ImportAttribute UpdateWith(Expression key, Literal value)

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -40,9 +40,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitImportDeclaration(this);
+            return visitor.VisitImportDeclaration(this, context);
         }
 
         public ImportDeclaration UpdateWith(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> assertions)

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Local);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitImportDefaultSpecifier(this);
+            return visitor.VisitImportDefaultSpecifier(this, context);
         }
 
         public ImportDefaultSpecifier UpdateWith(Identifier local)

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Local);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitImportNamespaceSpecifier(this);
+            return visitor.VisitImportNamespaceSpecifier(this, context);
         }
 
         public ImportNamespaceSpecifier UpdateWith(Identifier local)

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -17,9 +17,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Local, Imported);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitImportSpecifier(this);
+            return visitor.VisitImportSpecifier(this, context);
         }
 
         public ImportSpecifier UpdateWith(Expression imported, Identifier local)

--- a/src/Esprima/Ast/Jsx/JsxAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxAttribute.cs
@@ -16,9 +16,9 @@ public sealed class JsxAttribute : JsxExpression
 
     public override NodeCollection ChildNodes => new(Name, Value);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxAttribute(this);
+        return visitor.VisitJsxAttribute(this, context);
     }
 
     public JsxAttribute UpdateWith(JsxExpression name, Expression? value)

--- a/src/Esprima/Ast/Jsx/JsxClosingElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxClosingElement.cs
@@ -14,9 +14,9 @@ public sealed class JsxClosingElement : JsxExpression
 
     public override NodeCollection ChildNodes => new(Name);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxClosingElement(this);
+        return visitor.VisitJsxClosingElement(this, context);
     }
 
     public JsxClosingElement UpdateWith(JsxExpression name)

--- a/src/Esprima/Ast/Jsx/JsxClosingFragment.cs
+++ b/src/Esprima/Ast/Jsx/JsxClosingFragment.cs
@@ -10,8 +10,8 @@ public sealed class JsxClosingFragment : JsxExpression
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxClosingFragment(this);
+        return visitor.VisitJsxClosingFragment(this, context);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -20,9 +20,9 @@ public sealed class JsxElement : JsxExpression
 
     public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(OpeningElement, Children, ClosingElement);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxElement(this);
+        return visitor.VisitJsxElement(this, context);
     }
 
     public JsxElement UpdateWith(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement)

--- a/src/Esprima/Ast/Jsx/JsxEmptyExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxEmptyExpression.cs
@@ -10,8 +10,8 @@ public sealed class JsxEmptyExpression : JsxExpression
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxEmptyExpression(this);
+        return visitor.VisitJsxEmptyExpression(this, context);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpression.cs
@@ -16,10 +16,10 @@ public abstract class JsxExpression : Expression
 
     public new JsxNodeType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-    protected abstract object? Accept(IJsxAstVisitor visitor);
+    protected abstract object? Accept(IJsxAstVisitor visitor, object? context);
 
-    protected internal sealed override object? Accept(AstVisitor visitor)
+    protected internal sealed override object? Accept(AstVisitor visitor, object? context)
     {
-        return visitor is IJsxAstVisitor jsxVisitor ? Accept(jsxVisitor) : AcceptAsExtension(visitor);
+        return visitor is IJsxAstVisitor jsxVisitor ? Accept(jsxVisitor, context) : AcceptAsExtension(visitor, context);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
@@ -14,9 +14,9 @@ public sealed class JsxExpressionContainer : JsxExpression
 
     public override NodeCollection ChildNodes => new(Expression);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxExpressionContainer(this);
+        return visitor.VisitJsxExpressionContainer(this, context);
     }
 
     public JsxExpressionContainer UpdateWith(Expression expression)

--- a/src/Esprima/Ast/Jsx/JsxIdentifier.cs
+++ b/src/Esprima/Ast/Jsx/JsxIdentifier.cs
@@ -16,8 +16,8 @@ public sealed class JsxIdentifier : JsxExpression
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxIdentifier(this);
+        return visitor.VisitJsxIdentifier(this, context);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
@@ -16,9 +16,9 @@ public sealed class JsxMemberExpression : JsxExpression
 
     public override NodeCollection ChildNodes => new(Object, Property);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxMemberExpression(this);
+        return visitor.VisitJsxMemberExpression(this, context);
     }
 
     public JsxMemberExpression UpdateWith(JsxExpression obj, JsxIdentifier property)

--- a/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
+++ b/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
@@ -18,9 +18,9 @@ public sealed class JsxNamespacedName : JsxExpression
 
     public override NodeCollection ChildNodes => new(Name, Namespace);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxNamespacedName(this);
+        return visitor.VisitJsxNamespacedName(this, context);
     }
 
     public JsxNamespacedName UpdateWith(JsxIdentifier name, JsxIdentifier @namespace)

--- a/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningElement.cs
@@ -20,9 +20,9 @@ public sealed class JsxOpeningElement : JsxExpression
 
     public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Name, Attributes);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxOpeningElement(this);
+        return visitor.VisitJsxOpeningElement(this, context);
     }
 
     public JsxOpeningElement UpdateWith(JsxExpression name, in NodeList<JsxExpression> attributes)

--- a/src/Esprima/Ast/Jsx/JsxOpeningFragment.cs
+++ b/src/Esprima/Ast/Jsx/JsxOpeningFragment.cs
@@ -14,8 +14,8 @@ public sealed class JsxOpeningFragment : JsxExpression
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxOpeningFragment(this);
+        return visitor.VisitJsxOpeningFragment(this, context);
     }
 }

--- a/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
@@ -14,9 +14,9 @@ public sealed class JsxSpreadAttribute : JsxExpression
 
     public override NodeCollection ChildNodes => new(Argument);
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxSpreadAttribute(this);
+        return visitor.VisitJsxSpreadAttribute(this, context);
     }
 
     public JsxSpreadAttribute UpdateWith(Expression argument)

--- a/src/Esprima/Ast/Jsx/JsxText.cs
+++ b/src/Esprima/Ast/Jsx/JsxText.cs
@@ -18,8 +18,8 @@ public sealed class JsxText : JsxExpression
 
     public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-    protected override object? Accept(IJsxAstVisitor visitor)
+    protected override object? Accept(IJsxAstVisitor visitor, object? context)
     {
-        return visitor.VisitJsxText(this);
+        return visitor.VisitJsxText(this, context);
     }
 }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -17,9 +17,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Label, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitLabeledStatement(this);
+            return visitor.VisitLabeledStatement(this, context);
         }
 
         public LabeledStatement UpdateWith(Identifier label, Statement body)

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -55,11 +55,11 @@ namespace Esprima.Ast
         public Regex? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.RegularExpression ? (Regex?) Value : null; }
         public BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger?) Value : null; }
 
-        public sealed override NodeCollection ChildNodes => NodeCollection.Empty;
+        public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal sealed override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitLiteral(this);
+            return visitor.VisitLiteral(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/MemberExpression.cs
+++ b/src/Esprima/Ast/MemberExpression.cs
@@ -22,11 +22,11 @@ namespace Esprima.Ast
         public bool Computed { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public bool Optional { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        public override NodeCollection ChildNodes => new(Object, Property);
+        public sealed override NodeCollection ChildNodes => new(Object, Property);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal sealed override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitMemberExpression(this);
+            return visitor.VisitMemberExpression(this, context);
         }
 
         protected abstract MemberExpression Rewrite(Expression obj, Expression property);

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Meta, Property);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitMetaProperty(this);
+            return visitor.VisitMetaProperty(this, context);
         }
 
         public MetaProperty UpdateWith(Identifier meta, Identifier property)

--- a/src/Esprima/Ast/MethodDefinition.cs
+++ b/src/Esprima/Ast/MethodDefinition.cs
@@ -29,9 +29,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Key, Value);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitMethodDefinition(this);
+            return visitor.VisitMethodDefinition(this, context);
         }
 
         public MethodDefinition UpdateWith(Expression key, FunctionExpression value, in NodeList<Decorator> decorators)

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -21,9 +21,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Callee, Arguments);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitNewExpression(this);
+            return visitor.VisitNewExpression(this, context);
         }
 
         public NewExpression UpdateWith(Expression callee, in NodeList<Expression> arguments)

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -17,18 +17,18 @@ namespace Esprima.Ast
 
         public abstract NodeCollection ChildNodes { get; }
 
-        protected internal abstract object? Accept(AstVisitor visitor);
+        protected internal abstract object? Accept(AstVisitor visitor, object? context);
 
         /// <summary>
-        /// Dispatches the visitation of the current node to <see cref="AstVisitor.VisitExtension(Node)"/>.
+        /// Dispatches the visitation of the current node to <see cref="AstVisitor.VisitExtension(Node, object?)"/>.
         /// </summary>
         /// <remarks>
-        /// When defining custom node types, inheritors can use this method to implement the abstract <see cref="Accept(AstVisitor)"/> method.
+        /// When defining custom node types, inheritors can use this method to implement the abstract <see cref="Accept(AstVisitor, object?)"/> method.
         /// </remarks>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        protected object? AcceptAsExtension(AstVisitor visitor)
+        protected object? AcceptAsExtension(AstVisitor visitor, object? context)
         {
-            return visitor.VisitExtension(this);
+            return visitor.VisitExtension(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitObjectExpression(this);
+            return visitor.VisitObjectExpression(this, context);
         }
 
         public ObjectExpression UpdateWith(in NodeList<Expression> properties)

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Properties);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitObjectPattern(this);
+            return visitor.VisitObjectPattern(this, context);
         }
 
         public ObjectPattern UpdateWith(in NodeList<Node> properties)

--- a/src/Esprima/Ast/PrivateIdentifier.cs
+++ b/src/Esprima/Ast/PrivateIdentifier.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitPrivateIdentifier(this);
+            return visitor.VisitPrivateIdentifier(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -16,11 +16,11 @@ namespace Esprima.Ast
 
         public abstract SourceType SourceType { get; }
 
-        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal sealed override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitProgram(this);
+            return visitor.VisitProgram(this, context);
         }
 
         protected abstract Program Rewrite(in NodeList<Statement> body);

--- a/src/Esprima/Ast/Property.cs
+++ b/src/Esprima/Ast/Property.cs
@@ -39,9 +39,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Key, Value);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitProperty(this);
+            return visitor.VisitProperty(this, context);
         }
 
         public Property UpdateWith(Expression key, Expression value)

--- a/src/Esprima/Ast/PropertyDefinition.cs
+++ b/src/Esprima/Ast/PropertyDefinition.cs
@@ -39,9 +39,9 @@ namespace Esprima.Ast
             }
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitPropertyDefinition(this);
+            return visitor.VisitPropertyDefinition(this, context);
         }
 
         public PropertyDefinition UpdateWith(Expression key, Expression? value, in NodeList<Decorator> decorators)

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -17,9 +17,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitRestElement(this);
+            return visitor.VisitRestElement(this, context);
         }
 
         public RestElement UpdateWith(Expression argument)

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitReturnStatement(this);
+            return visitor.VisitReturnStatement(this, context);
         }
 
         public ReturnStatement UpdateWith(Expression? argument)

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Expressions);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitSequenceExpression(this);
+            return visitor.VisitSequenceExpression(this, context);
         }
 
         public SequenceExpression UpdateWith(in NodeList<Expression> expressions)

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitSpreadElement(this);
+            return visitor.VisitSpreadElement(this, context);
         }
 
         public SpreadElement UpdateWith(Expression argument)

--- a/src/Esprima/Ast/StaticBlock.cs
+++ b/src/Esprima/Ast/StaticBlock.cs
@@ -14,11 +14,11 @@ namespace Esprima.Ast
 
         public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
-        public sealed override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
+        public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Body);
 
-        protected internal sealed override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitStaticBlock(this);
+            return visitor.VisitStaticBlock(this, context);
         }
 
         public StaticBlock UpdateWith(in NodeList<Statement> body)

--- a/src/Esprima/Ast/Super.cs
+++ b/src/Esprima/Ast/Super.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitSuper(this);
+            return visitor.VisitSuper(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -18,9 +18,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Test, Consequent);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitSwitchCase(this);
+            return visitor.VisitSwitchCase(this, context);
         }
 
         public SwitchCase UpdateWith(Expression? test, in NodeList<Statement> consequent)

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -18,9 +18,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Discriminant, Cases);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitSwitchStatement(this);
+            return visitor.VisitSwitchStatement(this, context);
         }
 
         public SwitchStatement UpdateWith(Expression discriminant, in NodeList<SwitchCase> cases)

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Tag, Quasi);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitTaggedTemplateExpression(this);
+            return visitor.VisitTaggedTemplateExpression(this, context);
         }
 
         public TaggedTemplateExpression UpdateWith(Expression tag, TemplateLiteral quasi)

--- a/src/Esprima/Ast/TemplateElement.cs
+++ b/src/Esprima/Ast/TemplateElement.cs
@@ -18,9 +18,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitTemplateElement(this);
+            return visitor.VisitTemplateElement(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -33,9 +33,9 @@ namespace Esprima.Ast
             yield return quasi;
         }
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitTemplateLiteral(this);
+            return visitor.VisitTemplateLiteral(this, context);
         }
 
         public TemplateLiteral UpdateWith(in NodeList<TemplateElement> quasis, in NodeList<Expression> expressions)

--- a/src/Esprima/Ast/ThisExpression.cs
+++ b/src/Esprima/Ast/ThisExpression.cs
@@ -10,9 +10,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => NodeCollection.Empty;
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitThisExpression(this);
+            return visitor.VisitThisExpression(this, context);
         }
     }
 }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -14,9 +14,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitThrowStatement(this);
+            return visitor.VisitThrowStatement(this, context);
         }
 
         public ThrowStatement UpdateWith(Expression argument)

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -22,9 +22,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Block, Handler, Finalizer);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitTryStatement(this);
+            return visitor.VisitTryStatement(this, context);
         }
 
         public TryStatement UpdateWith(BlockStatement block, CatchClause? handler, BlockStatement? finalizer)

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -61,9 +61,9 @@ namespace Esprima.Ast
 
         public sealed override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal sealed override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitUnaryExpression(this);
+            return visitor.VisitUnaryExpression(this, context);
         }
 
         protected virtual UnaryExpression Rewrite(Expression argument)

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -21,9 +21,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => GenericChildNodeYield.Yield(Declarations);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitVariableDeclaration(this);
+            return visitor.VisitVariableDeclaration(this, context);
         }
 
         public VariableDeclaration UpdateWith(in NodeList<VariableDeclarator> declarations)

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -20,9 +20,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Id, Init);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitVariableDeclarator(this);
+            return visitor.VisitVariableDeclarator(this, context);
         }
 
         public VariableDeclarator UpdateWith(Expression id, Expression? init)

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Test, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitWhileStatement(this);
+            return visitor.VisitWhileStatement(this, context);
         }
 
         public WhileStatement UpdateWith(Expression test, Statement body)

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Object, Body);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitWithStatement(this);
+            return visitor.VisitWithStatement(this, context);
         }
 
         public WithStatement UpdateWith(Expression obj, Statement body)

--- a/src/Esprima/Ast/YieldExpression.cs
+++ b/src/Esprima/Ast/YieldExpression.cs
@@ -16,9 +16,9 @@ namespace Esprima.Ast
 
         public override NodeCollection ChildNodes => new(Argument);
 
-        protected internal override object? Accept(AstVisitor visitor)
+        protected internal override object? Accept(AstVisitor visitor, object? context)
         {
-            return visitor.VisitYieldExpression(this);
+            return visitor.VisitYieldExpression(this, context);
         }
 
         public YieldExpression UpdateWith(Expression? argument)

--- a/src/Esprima/Utils/AstJson.cs
+++ b/src/Esprima/Utils/AstJson.cs
@@ -339,11 +339,11 @@ public class AstToJsonConverter : AstJson.IConverter
             _writer.EndArray();
         }
 
-        public override object? Visit(Node? node)
+        public override object? Visit(Node? node, object? context = null)
         {
             if (node is not null)
             {
-                return base.Visit(node);
+                return base.Visit(node, context);
             }
             else
             {
@@ -352,7 +352,7 @@ public class AstToJsonConverter : AstJson.IConverter
             }
         }
 
-        protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+        protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression, object? context)
         {
             using (StartNodeObject(arrayExpression))
             {
@@ -362,7 +362,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return arrayExpression;
         }
 
-        protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
+        protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern, object? context)
         {
             using (StartNodeObject(arrayPattern))
             {
@@ -372,7 +372,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return arrayPattern;
         }
 
-        protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+        protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression, object? context)
         {
             using (StartNodeObject(arrowFunctionExpression))
             {
@@ -392,7 +392,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return arrowFunctionExpression;
         }
 
-        protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+        protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression, object? context)
         {
             using (StartNodeObject(assignmentExpression))
             {
@@ -404,7 +404,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return assignmentExpression;
         }
 
-        protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+        protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern, object? context)
         {
             using (StartNodeObject(assignmentPattern))
             {
@@ -415,7 +415,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return assignmentPattern;
         }
 
-        protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+        protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression, object? context)
         {
             using (StartNodeObject(awaitExpression))
             {
@@ -425,7 +425,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return awaitExpression;
         }
 
-        protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+        protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression, object? context)
         {
             using (StartNodeObject(binaryExpression))
             {
@@ -437,7 +437,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return binaryExpression;
         }
 
-        protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
+        protected internal override object? VisitBlockStatement(BlockStatement blockStatement, object? context)
         {
             using (StartNodeObject(blockStatement))
             {
@@ -447,7 +447,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return blockStatement;
         }
 
-        protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
+        protected internal override object? VisitBreakStatement(BreakStatement breakStatement, object? context)
         {
             using (StartNodeObject(breakStatement))
             {
@@ -457,7 +457,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return breakStatement;
         }
 
-        protected internal override object? VisitCallExpression(CallExpression callExpression)
+        protected internal override object? VisitCallExpression(CallExpression callExpression, object? context)
         {
             using (StartNodeObject(callExpression))
             {
@@ -469,7 +469,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return callExpression;
         }
 
-        protected internal override object? VisitCatchClause(CatchClause catchClause)
+        protected internal override object? VisitCatchClause(CatchClause catchClause, object? context)
         {
             using (StartNodeObject(catchClause))
             {
@@ -480,7 +480,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return catchClause;
         }
 
-        protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+        protected internal override object? VisitChainExpression(ChainExpression chainExpression, object? context)
         {
             using (StartNodeObject(chainExpression))
             {
@@ -490,7 +490,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return chainExpression;
         }
 
-        protected internal override object? VisitClassBody(ClassBody classBody)
+        protected internal override object? VisitClassBody(ClassBody classBody, object? context)
         {
             using (StartNodeObject(classBody))
             {
@@ -500,7 +500,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return classBody;
         }
 
-        protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+        protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration, object? context)
         {
             using (StartNodeObject(classDeclaration))
             {
@@ -516,7 +516,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return classDeclaration;
         }
 
-        protected internal override object? VisitClassExpression(ClassExpression classExpression)
+        protected internal override object? VisitClassExpression(ClassExpression classExpression, object? context)
         {
             using (StartNodeObject(classExpression))
             {
@@ -532,7 +532,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return classExpression;
         }
 
-        protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+        protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression, object? context)
         {
             using (StartNodeObject(conditionalExpression))
             {
@@ -544,7 +544,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return conditionalExpression;
         }
 
-        protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+        protected internal override object? VisitContinueStatement(ContinueStatement continueStatement, object? context)
         {
             using (StartNodeObject(continueStatement))
             {
@@ -554,13 +554,13 @@ public class AstToJsonConverter : AstJson.IConverter
             return continueStatement;
         }
 
-        protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+        protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement, object? context)
         {
             EmptyNodeObject(debuggerStatement);
             return debuggerStatement;
         }
 
-        protected internal override object? VisitDecorator(Decorator decorator)
+        protected internal override object? VisitDecorator(Decorator decorator, object? context)
         {
             using (StartNodeObject(decorator))
             {
@@ -570,7 +570,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return decorator;
         }
 
-        protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+        protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement, object? context)
         {
             using (StartNodeObject(doWhileStatement))
             {
@@ -581,13 +581,13 @@ public class AstToJsonConverter : AstJson.IConverter
             return doWhileStatement;
         }
 
-        protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
+        protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement, object? context)
         {
             EmptyNodeObject(emptyStatement);
             return emptyStatement;
         }
 
-        protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+        protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration, object? context)
         {
             using (StartNodeObject(exportAllDeclaration))
             {
@@ -607,7 +607,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return exportAllDeclaration;
         }
 
-        protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+        protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration, object? context)
         {
             using (StartNodeObject(exportDefaultDeclaration))
             {
@@ -617,7 +617,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return exportDefaultDeclaration;
         }
 
-        protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+        protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration, object? context)
         {
             using (StartNodeObject(exportNamedDeclaration))
             {
@@ -634,7 +634,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return exportNamedDeclaration;
         }
 
-        protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
+        protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier, object? context)
         {
             using (StartNodeObject(exportSpecifier))
             {
@@ -645,7 +645,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return exportSpecifier;
         }
 
-        protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+        protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement, object? context)
         {
             using (StartNodeObject(expressionStatement))
             {
@@ -660,12 +660,12 @@ public class AstToJsonConverter : AstJson.IConverter
             return expressionStatement;
         }
 
-        protected internal override object? VisitExtension(Node node)
+        protected internal override object? VisitExtension(Node node, object? context)
         {
             throw new NotSupportedException("Unknown node type: " + node.Type);
         }
 
-        protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+        protected internal override object? VisitForInStatement(ForInStatement forInStatement, object? context)
         {
             using (StartNodeObject(forInStatement))
             {
@@ -678,7 +678,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return forInStatement;
         }
 
-        protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+        protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement, object? context)
         {
             using (StartNodeObject(forOfStatement))
             {
@@ -691,7 +691,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return forOfStatement;
         }
 
-        protected internal override object? VisitForStatement(ForStatement forStatement)
+        protected internal override object? VisitForStatement(ForStatement forStatement, object? context)
         {
             using (StartNodeObject(forStatement))
             {
@@ -704,7 +704,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return forStatement;
         }
 
-        protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+        protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration, object? context)
         {
             using (StartNodeObject(functionDeclaration))
             {
@@ -724,7 +724,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return functionDeclaration;
         }
 
-        protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+        protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression, object? context)
         {
             using (StartNodeObject(functionExpression))
             {
@@ -744,7 +744,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return functionExpression;
         }
 
-        protected internal override object? VisitIdentifier(Identifier identifier)
+        protected internal override object? VisitIdentifier(Identifier identifier, object? context)
         {
             using (StartNodeObject(identifier))
             {
@@ -754,7 +754,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return identifier;
         }
 
-        protected internal override object? VisitIfStatement(IfStatement ifStatement)
+        protected internal override object? VisitIfStatement(IfStatement ifStatement, object? context)
         {
             using (StartNodeObject(ifStatement))
             {
@@ -774,7 +774,7 @@ public class AstToJsonConverter : AstJson.IConverter
 
         private sealed class ImportCompat : Expression
         {
-            protected internal override object? Accept(AstVisitor visitor)
+            protected internal override object? Accept(AstVisitor visitor, object? context)
             {
                 return ((VisitorBase) visitor).VisitImportCompat(this);
             }
@@ -784,7 +784,7 @@ public class AstToJsonConverter : AstJson.IConverter
             public override NodeCollection ChildNodes => NodeCollection.Empty;
         }
 
-        protected internal override object? VisitImport(Import import)
+        protected internal override object? VisitImport(Import import, object? context)
         {
             // original Esprima uses CallExpression to represent dynamic imports currently,
             // so we need to rewrite our representation to match this expectation
@@ -823,7 +823,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return import;
         }
 
-        protected internal override object? VisitImportAttribute(ImportAttribute importAttribute)
+        protected internal override object? VisitImportAttribute(ImportAttribute importAttribute, object? context)
         {
             using (StartNodeObject(importAttribute))
             {
@@ -834,7 +834,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return importAttribute;
         }
 
-        protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
+        protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration, object? context)
         {
             using (StartNodeObject(importDeclaration))
             {
@@ -850,7 +850,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return importDeclaration;
         }
 
-        protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+        protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier, object? context)
         {
             using (StartNodeObject(importDefaultSpecifier))
             {
@@ -860,7 +860,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return importDefaultSpecifier;
         }
 
-        protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+        protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier, object? context)
         {
             using (StartNodeObject(importNamespaceSpecifier))
             {
@@ -870,7 +870,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return importNamespaceSpecifier;
         }
 
-        protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
+        protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier, object? context)
         {
             using (StartNodeObject(importSpecifier))
             {
@@ -881,7 +881,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return importSpecifier;
         }
 
-        protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+        protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement, object? context)
         {
             using (StartNodeObject(labeledStatement))
             {
@@ -892,7 +892,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return labeledStatement;
         }
 
-        protected internal override object? VisitLiteral(Literal literal)
+        protected internal override object? VisitLiteral(Literal literal, object? context)
         {
             using (StartNodeObject(literal))
             {
@@ -947,7 +947,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return literal;
         }
 
-        protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+        protected internal override object? VisitMemberExpression(MemberExpression memberExpression, object? context)
         {
             using (StartNodeObject(memberExpression))
             {
@@ -960,7 +960,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return memberExpression;
         }
 
-        protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+        protected internal override object? VisitMetaProperty(MetaProperty metaProperty, object? context)
         {
             using (StartNodeObject(metaProperty))
             {
@@ -971,7 +971,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return metaProperty;
         }
 
-        protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+        protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition, object? context)
         {
             using (StartNodeObject(methodDefinition))
             {
@@ -989,7 +989,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return methodDefinition;
         }
 
-        protected internal override object? VisitNewExpression(NewExpression newExpression)
+        protected internal override object? VisitNewExpression(NewExpression newExpression, object? context)
         {
             using (StartNodeObject(newExpression))
             {
@@ -1000,7 +1000,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return newExpression;
         }
 
-        protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+        protected internal override object? VisitObjectExpression(ObjectExpression objectExpression, object? context)
         {
             using (StartNodeObject(objectExpression))
             {
@@ -1010,7 +1010,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return objectExpression;
         }
 
-        protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
+        protected internal override object? VisitObjectPattern(ObjectPattern objectPattern, object? context)
         {
             using (StartNodeObject(objectPattern))
             {
@@ -1020,7 +1020,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return objectPattern;
         }
 
-        protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+        protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier, object? context)
         {
             using (StartNodeObject(privateIdentifier))
             {
@@ -1030,7 +1030,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return privateIdentifier;
         }
 
-        protected internal override object? VisitProgram(Program program)
+        protected internal override object? VisitProgram(Program program, object? context)
         {
             using (StartNodeObject(program))
             {
@@ -1047,7 +1047,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return program;
         }
 
-        protected internal override object? VisitProperty(Property property)
+        protected internal override object? VisitProperty(Property property, object? context)
         {
             using (StartNodeObject(property))
             {
@@ -1062,7 +1062,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return property;
         }
 
-        protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+        protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition, object? context)
         {
             using (StartNodeObject(propertyDefinition))
             {
@@ -1080,7 +1080,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return propertyDefinition;
         }
 
-        protected internal override object? VisitRestElement(RestElement restElement)
+        protected internal override object? VisitRestElement(RestElement restElement, object? context)
         {
             using (StartNodeObject(restElement))
             {
@@ -1090,7 +1090,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return restElement;
         }
 
-        protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
+        protected internal override object? VisitReturnStatement(ReturnStatement returnStatement, object? context)
         {
             using (StartNodeObject(returnStatement))
             {
@@ -1100,7 +1100,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return returnStatement;
         }
 
-        protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+        protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression, object? context)
         {
             using (StartNodeObject(sequenceExpression))
             {
@@ -1110,7 +1110,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return sequenceExpression;
         }
 
-        protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+        protected internal override object? VisitSpreadElement(SpreadElement spreadElement, object? context)
         {
             using (StartNodeObject(spreadElement))
             {
@@ -1120,7 +1120,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return spreadElement;
         }
 
-        protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
+        protected internal override object? VisitStaticBlock(StaticBlock staticBlock, object? context)
         {
             using (StartNodeObject(staticBlock))
             {
@@ -1130,13 +1130,13 @@ public class AstToJsonConverter : AstJson.IConverter
             return staticBlock;
         }
 
-        protected internal override object? VisitSuper(Super super)
+        protected internal override object? VisitSuper(Super super, object? context)
         {
             EmptyNodeObject(super);
             return super;
         }
 
-        protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+        protected internal override object? VisitSwitchCase(SwitchCase switchCase, object? context)
         {
             using (StartNodeObject(switchCase))
             {
@@ -1147,7 +1147,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return switchCase;
         }
 
-        protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+        protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement, object? context)
         {
             using (StartNodeObject(switchStatement))
             {
@@ -1158,7 +1158,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return switchStatement;
         }
 
-        protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+        protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression, object? context)
         {
             using (StartNodeObject(taggedTemplateExpression))
             {
@@ -1169,7 +1169,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return taggedTemplateExpression;
         }
 
-        protected internal override object? VisitTemplateElement(TemplateElement templateElement)
+        protected internal override object? VisitTemplateElement(TemplateElement templateElement, object? context)
         {
             using (StartNodeObject(templateElement))
             {
@@ -1184,7 +1184,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return templateElement;
         }
 
-        protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+        protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral, object? context)
         {
             using (StartNodeObject(templateLiteral))
             {
@@ -1195,13 +1195,13 @@ public class AstToJsonConverter : AstJson.IConverter
             return templateLiteral;
         }
 
-        protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+        protected internal override object? VisitThisExpression(ThisExpression thisExpression, object? context)
         {
             EmptyNodeObject(thisExpression);
             return thisExpression;
         }
 
-        protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+        protected internal override object? VisitThrowStatement(ThrowStatement throwStatement, object? context)
         {
             using (StartNodeObject(throwStatement))
             {
@@ -1211,7 +1211,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return throwStatement;
         }
 
-        protected internal override object? VisitTryStatement(TryStatement tryStatement)
+        protected internal override object? VisitTryStatement(TryStatement tryStatement, object? context)
         {
             using (StartNodeObject(tryStatement))
             {
@@ -1223,7 +1223,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return tryStatement;
         }
 
-        protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+        protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression, object? context)
         {
             using (StartNodeObject(unaryExpression))
             {
@@ -1235,7 +1235,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return unaryExpression;
         }
 
-        protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+        protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration, object? context)
         {
             using (StartNodeObject(variableDeclaration))
             {
@@ -1246,7 +1246,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return variableDeclaration;
         }
 
-        protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+        protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator, object? context)
         {
             using (StartNodeObject(variableDeclarator))
             {
@@ -1257,7 +1257,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return variableDeclarator;
         }
 
-        protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+        protected internal override object? VisitWhileStatement(WhileStatement whileStatement, object? context)
         {
             using (StartNodeObject(whileStatement))
             {
@@ -1268,7 +1268,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return whileStatement;
         }
 
-        protected internal override object? VisitWithStatement(WithStatement withStatement)
+        protected internal override object? VisitWithStatement(WithStatement withStatement, object? context)
         {
             using (StartNodeObject(withStatement))
             {
@@ -1279,7 +1279,7 @@ public class AstToJsonConverter : AstJson.IConverter
             return withStatement;
         }
 
-        protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+        protected internal override object? VisitYieldExpression(YieldExpression yieldExpression, object? context)
         {
             using (StartNodeObject(yieldExpression))
             {

--- a/src/Esprima/Utils/AstRewriter.cs
+++ b/src/Esprima/Utils/AstRewriter.cs
@@ -5,7 +5,7 @@ namespace Esprima.Utils;
 
 public class AstRewriter : AstVisitor
 {
-    public virtual T VisitAndConvert<T>(T node, bool allowNull = false, [CallerMemberName] string? callerName = null)
+    public virtual T VisitAndConvert<T>(T node, object? context = null, bool allowNull = false, [CallerMemberName] string? callerName = null)
         where T : Node?
     {
         if (node is null)
@@ -13,7 +13,7 @@ public class AstRewriter : AstVisitor
             return allowNull ? null! : throw new ArgumentNullException(nameof(node));
         }
 
-        return Visit(node) switch
+        return Visit(node, context) switch
         {
             T convertedNode => convertedNode,
             null when allowNull => null!,
@@ -28,7 +28,7 @@ public class AstRewriter : AstVisitor
             new InvalidOperationException($"When called from {callerName}, rewriting a node of type {nodeType} must return null or a non-null value of the same type. Alternatively, override {callerName} and change it to not visit children of this type.");
     }
 
-    public virtual bool VisitAndConvert<T>(in NodeList<T> nodes, out NodeList<T> newNodes, bool allowNullElement = false, [CallerMemberName] string? callerName = null)
+    public virtual bool VisitAndConvert<T>(in NodeList<T> nodes, out NodeList<T> newNodes, object? context = null, bool allowNullElement = false, [CallerMemberName] string? callerName = null)
         where T : Node?
     {
         List<T>? newNodeList = null;
@@ -36,7 +36,7 @@ public class AstRewriter : AstVisitor
         {
             var node = nodes[i];
 
-            var newNode = VisitAndConvert(node, allowNull: allowNullElement, callerName);
+            var newNode = VisitAndConvert(node, context, allowNull: allowNullElement, callerName);
 
             if (newNodeList is not null)
             {
@@ -64,502 +64,502 @@ public class AstRewriter : AstVisitor
         return false;
     }
 
-    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression, object? context)
     {
-        VisitAndConvert(arrayExpression.Elements, out var elements, allowNullElement: true);
+        VisitAndConvert(arrayExpression.Elements, out var elements, context, allowNullElement: true);
 
         return arrayExpression.UpdateWith(elements);
     }
 
-    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
+    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern, object? context)
     {
-        VisitAndConvert(arrayPattern.Elements, out var elements, allowNullElement: true);
+        VisitAndConvert(arrayPattern.Elements, out var elements, context, allowNullElement: true);
 
         return arrayPattern.UpdateWith(elements);
     }
 
-    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression, object? context)
     {
-        VisitAndConvert(arrowFunctionExpression.Params, out var parameters);
-        var body = VisitAndConvert(arrowFunctionExpression.Body);
+        VisitAndConvert(arrowFunctionExpression.Params, out var parameters, context);
+        var body = VisitAndConvert(arrowFunctionExpression.Body, context);
 
         return arrowFunctionExpression.UpdateWith(parameters, body);
     }
 
-    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression, object? context)
     {
-        var left = VisitAndConvert(assignmentExpression.Left);
-        var right = VisitAndConvert(assignmentExpression.Right);
+        var left = VisitAndConvert(assignmentExpression.Left, context);
+        var right = VisitAndConvert(assignmentExpression.Right, context);
 
         return assignmentExpression.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern, object? context)
     {
-        var left = VisitAndConvert(assignmentPattern.Left);
-        var right = VisitAndConvert(assignmentPattern.Right);
+        var left = VisitAndConvert(assignmentPattern.Left, context);
+        var right = VisitAndConvert(assignmentPattern.Right, context);
 
         return assignmentPattern.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression, object? context)
     {
-        var argument = VisitAndConvert(awaitExpression.Argument);
+        var argument = VisitAndConvert(awaitExpression.Argument, context);
 
         return awaitExpression.UpdateWith(argument);
     }
 
-    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression, object? context)
     {
-        var left = VisitAndConvert(binaryExpression.Left);
-        var right = VisitAndConvert(binaryExpression.Right);
+        var left = VisitAndConvert(binaryExpression.Left, context);
+        var right = VisitAndConvert(binaryExpression.Right, context);
 
         return binaryExpression.UpdateWith(left, right);
     }
 
-    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
+    protected internal override object? VisitBlockStatement(BlockStatement blockStatement, object? context)
     {
-        VisitAndConvert(blockStatement.Body, out var body);
+        VisitAndConvert(blockStatement.Body, out var body, context);
 
         return blockStatement.UpdateWith(body);
     }
 
-    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
+    protected internal override object? VisitBreakStatement(BreakStatement breakStatement, object? context)
     {
-        var label = VisitAndConvert(breakStatement.Label, allowNull: true);
+        var label = VisitAndConvert(breakStatement.Label, context, allowNull: true);
 
         return breakStatement.UpdateWith(label);
     }
 
-    protected internal override object? VisitCallExpression(CallExpression callExpression)
+    protected internal override object? VisitCallExpression(CallExpression callExpression, object? context)
     {
-        var callee = VisitAndConvert(callExpression.Callee);
-        VisitAndConvert(callExpression.Arguments, out var arguments);
+        var callee = VisitAndConvert(callExpression.Callee, context);
+        VisitAndConvert(callExpression.Arguments, out var arguments, context);
 
         return callExpression.UpdateWith(callee, arguments);
     }
 
-    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    protected internal override object? VisitCatchClause(CatchClause catchClause, object? context)
     {
-        var param = VisitAndConvert(catchClause.Param, allowNull: true);
-        var body = VisitAndConvert(catchClause.Body);
+        var param = VisitAndConvert(catchClause.Param, context, allowNull: true);
+        var body = VisitAndConvert(catchClause.Body, context);
 
         return catchClause.UpdateWith(param, body);
     }
 
-    protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+    protected internal override object? VisitChainExpression(ChainExpression chainExpression, object? context)
     {
-        var expression = VisitAndConvert(chainExpression.Expression);
+        var expression = VisitAndConvert(chainExpression.Expression, context);
 
         return chainExpression.UpdateWith(expression);
     }
 
-    protected internal override object? VisitClassBody(ClassBody classBody)
+    protected internal override object? VisitClassBody(ClassBody classBody, object? context)
     {
-        VisitAndConvert(classBody.Body, out var body);
+        VisitAndConvert(classBody.Body, out var body, context);
 
         return classBody.UpdateWith(body);
     }
 
-    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration, object? context)
     {
-        var id = VisitAndConvert(classDeclaration.Id, allowNull: true);
-        var superClass = VisitAndConvert(classDeclaration.SuperClass, allowNull: true);
-        var body = VisitAndConvert(classDeclaration.Body);
-        VisitAndConvert(classDeclaration.Decorators, out var decorators);
+        var id = VisitAndConvert(classDeclaration.Id, context, allowNull: true);
+        var superClass = VisitAndConvert(classDeclaration.SuperClass, context, allowNull: true);
+        var body = VisitAndConvert(classDeclaration.Body, context);
+        VisitAndConvert(classDeclaration.Decorators, out var decorators, context);
 
         return classDeclaration.UpdateWith(id, superClass, body, decorators);
     }
 
-    protected internal override object? VisitClassExpression(ClassExpression classExpression)
+    protected internal override object? VisitClassExpression(ClassExpression classExpression, object? context)
     {
-        var id = VisitAndConvert(classExpression.Id, allowNull: true);
-        var superClass = VisitAndConvert(classExpression.SuperClass, allowNull: true);
-        var body = VisitAndConvert(classExpression.Body);
-        VisitAndConvert(classExpression.Decorators, out var decorators);
+        var id = VisitAndConvert(classExpression.Id, context, allowNull: true);
+        var superClass = VisitAndConvert(classExpression.SuperClass, context, allowNull: true);
+        var body = VisitAndConvert(classExpression.Body, context);
+        VisitAndConvert(classExpression.Decorators, out var decorators, context);
 
         return classExpression.UpdateWith(id, superClass, body, decorators);
     }
 
-    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression, object? context)
     {
-        var test = VisitAndConvert(conditionalExpression.Test);
-        var consequent = VisitAndConvert(conditionalExpression.Consequent);
-        var alternate = VisitAndConvert(conditionalExpression.Alternate);
+        var test = VisitAndConvert(conditionalExpression.Test, context);
+        var consequent = VisitAndConvert(conditionalExpression.Consequent, context);
+        var alternate = VisitAndConvert(conditionalExpression.Alternate, context);
 
         return conditionalExpression.UpdateWith(test, consequent, alternate);
     }
 
-    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement, object? context)
     {
-        var label = VisitAndConvert(continueStatement.Label, allowNull: true);
+        var label = VisitAndConvert(continueStatement.Label, context, allowNull: true);
 
         return continueStatement.UpdateWith(label);
     }
 
-    protected internal override object? VisitDecorator(Decorator decorator)
+    protected internal override object? VisitDecorator(Decorator decorator, object? context)
     {
-        var expression = VisitAndConvert(decorator.Expression);
+        var expression = VisitAndConvert(decorator.Expression, context);
 
         return decorator.UpdateWith(expression);
     }
 
-    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement, object? context)
     {
-        var body = VisitAndConvert(doWhileStatement.Body);
-        var test = VisitAndConvert(doWhileStatement.Test);
+        var body = VisitAndConvert(doWhileStatement.Body, context);
+        var test = VisitAndConvert(doWhileStatement.Test, context);
 
         return doWhileStatement.UpdateWith(body, test);
     }
 
-    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration, object? context)
     {
-        var exported = VisitAndConvert(exportAllDeclaration.Exported, allowNull: true);
-        var source = VisitAndConvert(exportAllDeclaration.Source);
-        VisitAndConvert(exportAllDeclaration.Assertions, out var assertions);
+        var exported = VisitAndConvert(exportAllDeclaration.Exported, context, allowNull: true);
+        var source = VisitAndConvert(exportAllDeclaration.Source, context);
+        VisitAndConvert(exportAllDeclaration.Assertions, out var assertions, context);
 
         return exportAllDeclaration.UpdateWith(exported, source, assertions);
     }
 
-    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration, object? context)
     {
-        var declaration = VisitAndConvert(exportDefaultDeclaration.Declaration);
+        var declaration = VisitAndConvert(exportDefaultDeclaration.Declaration, context);
 
         return exportDefaultDeclaration.UpdateWith(declaration);
     }
 
-    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration, object? context)
     {
-        var declaration = VisitAndConvert(exportNamedDeclaration.Declaration, allowNull: true);
-        VisitAndConvert(exportNamedDeclaration.Specifiers, out var specifiers);
-        var source = VisitAndConvert(exportNamedDeclaration.Source, allowNull: true);
-        VisitAndConvert(exportNamedDeclaration.Assertions, out var assertions);
+        var declaration = VisitAndConvert(exportNamedDeclaration.Declaration, context, allowNull: true);
+        VisitAndConvert(exportNamedDeclaration.Specifiers, out var specifiers, context);
+        var source = VisitAndConvert(exportNamedDeclaration.Source, context, allowNull: true);
+        VisitAndConvert(exportNamedDeclaration.Assertions, out var assertions, context);
 
         return exportNamedDeclaration.UpdateWith(declaration, specifiers, source, assertions);
     }
 
-    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
+    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier, object? context)
     {
-        var local = VisitAndConvert(exportSpecifier.Local);
-        var exported = VisitAndConvert(exportSpecifier.Exported);
+        var local = VisitAndConvert(exportSpecifier.Local, context);
+        var exported = VisitAndConvert(exportSpecifier.Exported, context);
 
         return exportSpecifier.UpdateWith(local, exported);
     }
 
-    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement, object? context)
     {
-        var expression = VisitAndConvert(expressionStatement.Expression);
+        var expression = VisitAndConvert(expressionStatement.Expression, context);
 
         return expressionStatement.UpdateWith(expression);
     }
 
-    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+    protected internal override object? VisitForInStatement(ForInStatement forInStatement, object? context)
     {
-        var left = VisitAndConvert(forInStatement.Left);
-        var right = VisitAndConvert(forInStatement.Right);
-        var body = VisitAndConvert(forInStatement.Body);
+        var left = VisitAndConvert(forInStatement.Left, context);
+        var right = VisitAndConvert(forInStatement.Right, context);
+        var body = VisitAndConvert(forInStatement.Body, context);
 
         return forInStatement.UpdateWith(left, right, body);
     }
 
-    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement, object? context)
     {
-        var left = VisitAndConvert(forOfStatement.Left);
-        var right = VisitAndConvert(forOfStatement.Right);
-        var body = VisitAndConvert(forOfStatement.Body);
+        var left = VisitAndConvert(forOfStatement.Left, context);
+        var right = VisitAndConvert(forOfStatement.Right, context);
+        var body = VisitAndConvert(forOfStatement.Body, context);
 
         return forOfStatement.UpdateWith(left, right, body);
     }
 
-    protected internal override object? VisitForStatement(ForStatement forStatement)
+    protected internal override object? VisitForStatement(ForStatement forStatement, object? context)
     {
-        var init = VisitAndConvert(forStatement.Init, allowNull: true);
-        var test = VisitAndConvert(forStatement.Test, allowNull: true);
-        var update = VisitAndConvert(forStatement.Update, allowNull: true);
-        var body = VisitAndConvert(forStatement.Body);
+        var init = VisitAndConvert(forStatement.Init, context, allowNull: true);
+        var test = VisitAndConvert(forStatement.Test, context, allowNull: true);
+        var update = VisitAndConvert(forStatement.Update, context, allowNull: true);
+        var body = VisitAndConvert(forStatement.Body, context);
 
         return forStatement.UpdateWith(init, test, update, body);
     }
 
-    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration, object? context)
     {
-        var id = VisitAndConvert(functionDeclaration.Id, allowNull: true);
-        VisitAndConvert(functionDeclaration.Params, out var parameters);
-        var body = VisitAndConvert(functionDeclaration.Body);
+        var id = VisitAndConvert(functionDeclaration.Id, context, allowNull: true);
+        VisitAndConvert(functionDeclaration.Params, out var parameters, context);
+        var body = VisitAndConvert(functionDeclaration.Body, context);
 
         return functionDeclaration.UpdateWith(id, parameters, body);
     }
 
-    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression, object? context)
     {
-        var id = VisitAndConvert(functionExpression.Id, allowNull: true);
-        VisitAndConvert(functionExpression.Params, out var parameters);
-        var body = VisitAndConvert(functionExpression.Body);
+        var id = VisitAndConvert(functionExpression.Id, context, allowNull: true);
+        VisitAndConvert(functionExpression.Params, out var parameters, context);
+        var body = VisitAndConvert(functionExpression.Body, context);
 
         return functionExpression.UpdateWith(id, parameters, body);
     }
 
-    protected internal override object? VisitIfStatement(IfStatement ifStatement)
+    protected internal override object? VisitIfStatement(IfStatement ifStatement, object? context)
     {
-        var test = VisitAndConvert(ifStatement.Test);
-        var consequent = VisitAndConvert(ifStatement.Consequent);
-        var alternate = VisitAndConvert(ifStatement.Alternate, allowNull: true);
+        var test = VisitAndConvert(ifStatement.Test, context);
+        var consequent = VisitAndConvert(ifStatement.Consequent, context);
+        var alternate = VisitAndConvert(ifStatement.Alternate, context, allowNull: true);
 
         return ifStatement.UpdateWith(test, consequent, alternate);
     }
 
-    protected internal override object? VisitImport(Import import)
+    protected internal override object? VisitImport(Import import, object? context)
     {
-        var source = VisitAndConvert(import.Source);
-        var attributes = VisitAndConvert(import.Attributes, allowNull: true);
+        var source = VisitAndConvert(import.Source, context);
+        var attributes = VisitAndConvert(import.Attributes, context, allowNull: true);
 
         return import.UpdateWith(source, attributes);
     }
 
-    protected internal override object? VisitImportAttribute(ImportAttribute importAttribute)
+    protected internal override object? VisitImportAttribute(ImportAttribute importAttribute, object? context)
     {
-        var key = VisitAndConvert(importAttribute.Key);
-        var value = VisitAndConvert(importAttribute.Value);
+        var key = VisitAndConvert(importAttribute.Key, context);
+        var value = VisitAndConvert(importAttribute.Value, context);
 
         return importAttribute.UpdateWith(key, value);
     }
 
-    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
+    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration, object? context)
     {
-        VisitAndConvert(importDeclaration.Specifiers, out var specifiers);
+        VisitAndConvert(importDeclaration.Specifiers, out var specifiers, context);
 
-        var source = VisitAndConvert(importDeclaration.Source);
+        var source = VisitAndConvert(importDeclaration.Source, context);
 
-        VisitAndConvert(importDeclaration.Assertions, out var assertions);
+        VisitAndConvert(importDeclaration.Assertions, out var assertions, context);
 
         return importDeclaration.UpdateWith(specifiers, source, assertions);
     }
 
-    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier, object? context)
     {
-        var local = VisitAndConvert(importDefaultSpecifier.Local);
+        var local = VisitAndConvert(importDefaultSpecifier.Local, context);
 
         return importDefaultSpecifier.UpdateWith(local);
     }
 
-    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier, object? context)
     {
-        var local = VisitAndConvert(importNamespaceSpecifier.Local);
+        var local = VisitAndConvert(importNamespaceSpecifier.Local, context);
 
         return importNamespaceSpecifier.UpdateWith(local);
     }
 
-    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
+    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier, object? context)
     {
-        var imported = VisitAndConvert(importSpecifier.Imported);
-        var local = VisitAndConvert(importSpecifier.Local);
+        var imported = VisitAndConvert(importSpecifier.Imported, context);
+        var local = VisitAndConvert(importSpecifier.Local, context);
 
         return importSpecifier.UpdateWith(imported, local);
     }
 
-    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement, object? context)
     {
-        var label = VisitAndConvert(labeledStatement.Label);
-        var body = VisitAndConvert(labeledStatement.Body);
+        var label = VisitAndConvert(labeledStatement.Label, context);
+        var body = VisitAndConvert(labeledStatement.Body, context);
 
         return labeledStatement.UpdateWith(label, body);
     }
 
-    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal override object? VisitMemberExpression(MemberExpression memberExpression, object? context)
     {
-        var obj = VisitAndConvert(memberExpression.Object);
-        var property = VisitAndConvert(memberExpression.Property);
+        var obj = VisitAndConvert(memberExpression.Object, context);
+        var property = VisitAndConvert(memberExpression.Property, context);
 
         return memberExpression.UpdateWith(obj, property);
     }
 
-    protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+    protected internal override object? VisitMetaProperty(MetaProperty metaProperty, object? context)
     {
-        var meta = VisitAndConvert(metaProperty.Meta);
-        var property = VisitAndConvert(metaProperty.Property);
+        var meta = VisitAndConvert(metaProperty.Meta, context);
+        var property = VisitAndConvert(metaProperty.Property, context);
 
         return metaProperty.UpdateWith(meta, property);
     }
 
-    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition, object? context)
     {
-        var key = VisitAndConvert(methodDefinition.Key);
-        var value = VisitAndConvert(methodDefinition.Value);
-        VisitAndConvert(methodDefinition.Decorators, out var decorators);
+        var key = VisitAndConvert(methodDefinition.Key, context);
+        var value = VisitAndConvert(methodDefinition.Value, context);
+        VisitAndConvert(methodDefinition.Decorators, out var decorators, context);
 
         return methodDefinition.UpdateWith(key, value, decorators);
     }
 
-    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    protected internal override object? VisitNewExpression(NewExpression newExpression, object? context)
     {
-        var callee = VisitAndConvert(newExpression.Callee);
-        VisitAndConvert(newExpression.Arguments, out var arguments);
+        var callee = VisitAndConvert(newExpression.Callee, context);
+        VisitAndConvert(newExpression.Arguments, out var arguments, context);
 
         return newExpression.UpdateWith(callee, arguments);
     }
 
-    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression, object? context)
     {
-        VisitAndConvert(objectExpression.Properties, out var properties);
+        VisitAndConvert(objectExpression.Properties, out var properties, context);
 
         return objectExpression.UpdateWith(properties);
     }
 
-    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
+    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern, object? context)
     {
-        VisitAndConvert(objectPattern.Properties, out var properties);
+        VisitAndConvert(objectPattern.Properties, out var properties, context);
 
         return objectPattern.UpdateWith(properties);
     }
 
-    protected internal override object? VisitProgram(Program program)
+    protected internal override object? VisitProgram(Program program, object? context)
     {
-        VisitAndConvert(program.Body, out var body);
+        VisitAndConvert(program.Body, out var body, context);
 
         return program.UpdateWith(body);
     }
 
-    protected internal override object? VisitProperty(Property property)
+    protected internal override object? VisitProperty(Property property, object? context)
     {
-        var key = VisitAndConvert(property.Key);
-        var value = VisitAndConvert(property.Value);
+        var key = VisitAndConvert(property.Key, context);
+        var value = VisitAndConvert(property.Value, context);
 
         return property.UpdateWith(key, value);
     }
 
-    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition, object? context)
     {
-        var key = VisitAndConvert(propertyDefinition.Key);
-        var value = VisitAndConvert(propertyDefinition.Value, allowNull: true);
-        VisitAndConvert(propertyDefinition.Decorators, out var decorators);
+        var key = VisitAndConvert(propertyDefinition.Key, context);
+        var value = VisitAndConvert(propertyDefinition.Value, context, allowNull: true);
+        VisitAndConvert(propertyDefinition.Decorators, out var decorators, context);
 
         return propertyDefinition.UpdateWith(key, value, decorators);
     }
 
-    protected internal override object? VisitRestElement(RestElement restElement)
+    protected internal override object? VisitRestElement(RestElement restElement, object? context)
     {
-        var argument = VisitAndConvert(restElement.Argument);
+        var argument = VisitAndConvert(restElement.Argument, context);
 
         return restElement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
+    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement, object? context)
     {
-        var argument = VisitAndConvert(returnStatement.Argument, allowNull: true);
+        var argument = VisitAndConvert(returnStatement.Argument, context, allowNull: true);
 
         return returnStatement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression, object? context)
     {
-        VisitAndConvert(sequenceExpression.Expressions, out var expressions);
+        VisitAndConvert(sequenceExpression.Expressions, out var expressions, context);
 
         return sequenceExpression.UpdateWith(expressions);
     }
 
-    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal override object? VisitSpreadElement(SpreadElement spreadElement, object? context)
     {
-        var argument = VisitAndConvert(spreadElement.Argument);
+        var argument = VisitAndConvert(spreadElement.Argument, context);
 
         return spreadElement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
+    protected internal override object? VisitStaticBlock(StaticBlock staticBlock, object? context)
     {
-        VisitAndConvert(staticBlock.Body, out var body);
+        VisitAndConvert(staticBlock.Body, out var body, context);
 
         return staticBlock.UpdateWith(body);
     }
 
-    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+    protected internal override object? VisitSwitchCase(SwitchCase switchCase, object? context)
     {
-        var test = VisitAndConvert(switchCase.Test, allowNull: true);
-        VisitAndConvert(switchCase.Consequent, out var consequent);
+        var test = VisitAndConvert(switchCase.Test, context, allowNull: true);
+        VisitAndConvert(switchCase.Consequent, out var consequent, context);
 
         return switchCase.UpdateWith(test, consequent);
     }
 
-    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement, object? context)
     {
-        var discriminant = VisitAndConvert(switchStatement.Discriminant);
-        VisitAndConvert(switchStatement.Cases, out var cases);
+        var discriminant = VisitAndConvert(switchStatement.Discriminant, context);
+        VisitAndConvert(switchStatement.Cases, out var cases, context);
 
         return switchStatement.UpdateWith(discriminant, cases);
     }
 
-    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression, object? context)
     {
-        var tag = VisitAndConvert(taggedTemplateExpression.Tag);
-        var quasi = VisitAndConvert(taggedTemplateExpression.Quasi);
+        var tag = VisitAndConvert(taggedTemplateExpression.Tag, context);
+        var quasi = VisitAndConvert(taggedTemplateExpression.Quasi, context);
 
         return taggedTemplateExpression.UpdateWith(tag, quasi);
     }
 
-    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral, object? context)
     {
-        VisitAndConvert(templateLiteral.Quasis, out var quasis);
-        VisitAndConvert(templateLiteral.Expressions, out var expressions);
+        VisitAndConvert(templateLiteral.Quasis, out var quasis, context);
+        VisitAndConvert(templateLiteral.Expressions, out var expressions, context);
 
         return templateLiteral.UpdateWith(quasis, expressions);
     }
 
-    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement, object? context)
     {
-        var argument = VisitAndConvert(throwStatement.Argument);
+        var argument = VisitAndConvert(throwStatement.Argument, context);
 
         return throwStatement.UpdateWith(argument);
     }
 
-    protected internal override object? VisitTryStatement(TryStatement tryStatement)
+    protected internal override object? VisitTryStatement(TryStatement tryStatement, object? context)
     {
-        var block = VisitAndConvert(tryStatement.Block);
-        var handler = VisitAndConvert(tryStatement.Handler, allowNull: true);
-        var finalizer = VisitAndConvert(tryStatement.Finalizer, allowNull: true);
+        var block = VisitAndConvert(tryStatement.Block, context);
+        var handler = VisitAndConvert(tryStatement.Handler, context, allowNull: true);
+        var finalizer = VisitAndConvert(tryStatement.Finalizer, context, allowNull: true);
 
         return tryStatement.UpdateWith(block, handler, finalizer);
     }
 
-    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression, object? context)
     {
-        var argument = VisitAndConvert(unaryExpression.Argument);
+        var argument = VisitAndConvert(unaryExpression.Argument, context);
 
         return unaryExpression.UpdateWith(argument);
     }
 
-    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration, object? context)
     {
-        VisitAndConvert(variableDeclaration.Declarations, out var declarations);
+        VisitAndConvert(variableDeclaration.Declarations, out var declarations, context);
 
         return variableDeclaration.UpdateWith(declarations);
     }
 
-    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator, object? context)
     {
-        var id = VisitAndConvert(variableDeclarator.Id);
-        var init = VisitAndConvert(variableDeclarator.Init, allowNull: true);
+        var id = VisitAndConvert(variableDeclarator.Id, context);
+        var init = VisitAndConvert(variableDeclarator.Init, context, allowNull: true);
 
         return variableDeclarator.UpdateWith(id, init);
     }
 
-    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+    protected internal override object? VisitWhileStatement(WhileStatement whileStatement, object? context)
     {
-        var test = VisitAndConvert(whileStatement.Test);
-        var body = VisitAndConvert(whileStatement.Body);
+        var test = VisitAndConvert(whileStatement.Test, context);
+        var body = VisitAndConvert(whileStatement.Body, context);
 
         return whileStatement.UpdateWith(test, body);
     }
 
-    protected internal override object? VisitWithStatement(WithStatement withStatement)
+    protected internal override object? VisitWithStatement(WithStatement withStatement, object? context)
     {
-        var obj = VisitAndConvert(withStatement.Object);
-        var body = VisitAndConvert(withStatement.Body);
+        var obj = VisitAndConvert(withStatement.Object, context);
+        var body = VisitAndConvert(withStatement.Body, context);
 
         return withStatement.UpdateWith(obj, body);
     }
 
-    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression, object? context)
     {
-        var argument = VisitAndConvert(yieldExpression.Argument, allowNull: true);
+        var argument = VisitAndConvert(yieldExpression.Argument, context, allowNull: true);
 
         return yieldExpression.UpdateWith(argument);
     }

--- a/src/Esprima/Utils/AstVisitor.cs
+++ b/src/Esprima/Utils/AstVisitor.cs
@@ -8,12 +8,12 @@ public class AstVisitor
     private static Exception UnsupportedNodeType(Type nodeType, [CallerMemberName] string? callerName = null) =>
         new NotImplementedException($"The visitor does not support nodes of type {nodeType}. You can override {callerName} to handle this case.");
 
-    public virtual object? Visit(Node node)
+    public virtual object? Visit(Node node, object? context = null)
     {
-        return node.Accept(this);
+        return node.Accept(this, context);
     }
 
-    protected internal virtual object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal virtual object? VisitArrayExpression(ArrayExpression arrayExpression, object? context)
     {
         ref readonly var elements = ref arrayExpression.Elements;
         for (var i = 0; i < elements.Count; i++)
@@ -21,14 +21,14 @@ public class AstVisitor
             var expr = elements[i];
             if (expr is not null)
             {
-                Visit(expr);
+                Visit(expr, context);
             }
         }
 
         return arrayExpression;
     }
 
-    protected internal virtual object? VisitArrayPattern(ArrayPattern arrayPattern)
+    protected internal virtual object? VisitArrayPattern(ArrayPattern arrayPattern, object? context)
     {
         ref readonly var elements = ref arrayPattern.Elements;
         for (var i = 0; i < elements.Count; i++)
@@ -36,27 +36,27 @@ public class AstVisitor
             var expr = elements[i];
             if (expr is not null)
             {
-                Visit(expr);
+                Visit(expr, context);
             }
         }
 
         return arrayPattern;
     }
 
-    protected internal virtual object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+    protected internal virtual object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression, object? context)
     {
         ref readonly var parameters = ref arrowFunctionExpression.Params;
         for (var i = 0; i < parameters.Count; i++)
         {
-            Visit(parameters[i]);
+            Visit(parameters[i], context);
         }
 
-        Visit(arrowFunctionExpression.Body);
+        Visit(arrowFunctionExpression.Body, context);
 
         return arrowFunctionExpression;
     }
 
-    protected internal virtual object? VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder)
+    protected internal virtual object? VisitArrowParameterPlaceHolder(ArrowParameterPlaceHolder arrowParameterPlaceHolder, object? context)
     {
         // Seems that ArrowParameterPlaceHolder nodes never appear in the final tree and only used during the construction of a tree.
         // Though we provide the VisitArrowParameterPlaceHolder method for inheritors in case they still needed it.
@@ -64,258 +64,258 @@ public class AstVisitor
         throw UnsupportedNodeType(arrowParameterPlaceHolder.GetType());
     }
 
-    protected internal virtual object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+    protected internal virtual object? VisitAssignmentExpression(AssignmentExpression assignmentExpression, object? context)
     {
-        Visit(assignmentExpression.Left);
-        Visit(assignmentExpression.Right);
+        Visit(assignmentExpression.Left, context);
+        Visit(assignmentExpression.Right, context);
 
         return assignmentExpression;
     }
 
-    protected internal virtual object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal virtual object? VisitAssignmentPattern(AssignmentPattern assignmentPattern, object? context)
     {
-        Visit(assignmentPattern.Left);
-        Visit(assignmentPattern.Right);
+        Visit(assignmentPattern.Left, context);
+        Visit(assignmentPattern.Right, context);
 
         return assignmentPattern;
     }
 
-    protected internal virtual object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal virtual object? VisitAwaitExpression(AwaitExpression awaitExpression, object? context)
     {
-        Visit(awaitExpression.Argument);
+        Visit(awaitExpression.Argument, context);
 
         return awaitExpression;
     }
 
-    protected internal virtual object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal virtual object? VisitBinaryExpression(BinaryExpression binaryExpression, object? context)
     {
-        Visit(binaryExpression.Left);
-        Visit(binaryExpression.Right);
+        Visit(binaryExpression.Left, context);
+        Visit(binaryExpression.Right, context);
 
         return binaryExpression;
     }
 
-    protected internal virtual object? VisitBlockStatement(BlockStatement blockStatement)
+    protected internal virtual object? VisitBlockStatement(BlockStatement blockStatement, object? context)
     {
         ref readonly var body = ref blockStatement.Body;
         for (var i = 0; i < body.Count; i++)
         {
-            Visit(body[i]);
+            Visit(body[i], context);
         }
 
         return blockStatement;
     }
 
-    protected internal virtual object? VisitBreakStatement(BreakStatement breakStatement)
+    protected internal virtual object? VisitBreakStatement(BreakStatement breakStatement, object? context)
     {
         if (breakStatement.Label is not null)
         {
-            Visit(breakStatement.Label);
+            Visit(breakStatement.Label, context);
         }
 
         return breakStatement;
     }
 
-    protected internal virtual object? VisitCallExpression(CallExpression callExpression)
+    protected internal virtual object? VisitCallExpression(CallExpression callExpression, object? context)
     {
-        Visit(callExpression.Callee);
+        Visit(callExpression.Callee, context);
         ref readonly var arguments = ref callExpression.Arguments;
         for (var i = 0; i < arguments.Count; i++)
         {
-            Visit(arguments[i]);
+            Visit(arguments[i], context);
         }
 
         return callExpression;
     }
 
-    protected internal virtual object? VisitCatchClause(CatchClause catchClause)
+    protected internal virtual object? VisitCatchClause(CatchClause catchClause, object? context)
     {
         if (catchClause.Param is not null)
         {
-            Visit(catchClause.Param);
+            Visit(catchClause.Param, context);
         }
 
-        Visit(catchClause.Body);
+        Visit(catchClause.Body, context);
 
         return catchClause;
     }
 
-    protected internal virtual object? VisitChainExpression(ChainExpression chainExpression)
+    protected internal virtual object? VisitChainExpression(ChainExpression chainExpression, object? context)
     {
-        Visit(chainExpression.Expression);
+        Visit(chainExpression.Expression, context);
 
         return chainExpression;
     }
 
-    protected internal virtual object? VisitClassBody(ClassBody classBody)
+    protected internal virtual object? VisitClassBody(ClassBody classBody, object? context)
     {
         ref readonly var body = ref classBody.Body;
         for (var i = 0; i < body.Count; i++)
         {
-            Visit(body[i]);
+            Visit(body[i], context);
         }
 
         return classBody;
     }
 
-    protected internal virtual object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal virtual object? VisitClassDeclaration(ClassDeclaration classDeclaration, object? context)
     {
         if (classDeclaration.Id is not null)
         {
-            Visit(classDeclaration.Id);
+            Visit(classDeclaration.Id, context);
         }
 
         if (classDeclaration.SuperClass is not null)
         {
-            Visit(classDeclaration.SuperClass);
+            Visit(classDeclaration.SuperClass, context);
         }
 
-        Visit(classDeclaration.Body);
+        Visit(classDeclaration.Body, context);
 
         ref readonly var decorators = ref classDeclaration.Decorators;
         for (var i = 0; i < decorators.Count; i++)
         {
-            Visit(decorators[i]);
+            Visit(decorators[i], context);
         }
 
         return classDeclaration;
     }
 
-    protected internal virtual object? VisitClassExpression(ClassExpression classExpression)
+    protected internal virtual object? VisitClassExpression(ClassExpression classExpression, object? context)
     {
         if (classExpression.Id is not null)
         {
-            Visit(classExpression.Id);
+            Visit(classExpression.Id, context);
         }
 
         if (classExpression.SuperClass is not null)
         {
-            Visit(classExpression.SuperClass);
+            Visit(classExpression.SuperClass, context);
         }
 
-        Visit(classExpression.Body);
+        Visit(classExpression.Body, context);
 
         ref readonly var decorators = ref classExpression.Decorators;
         for (var i = 0; i < decorators.Count; i++)
         {
-            Visit(decorators[i]);
+            Visit(decorators[i], context);
         }
 
         return classExpression;
     }
 
-    protected internal virtual object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal virtual object? VisitConditionalExpression(ConditionalExpression conditionalExpression, object? context)
     {
-        Visit(conditionalExpression.Test);
-        Visit(conditionalExpression.Consequent);
-        Visit(conditionalExpression.Alternate);
+        Visit(conditionalExpression.Test, context);
+        Visit(conditionalExpression.Consequent, context);
+        Visit(conditionalExpression.Alternate, context);
 
         return conditionalExpression;
     }
 
-    protected internal virtual object? VisitContinueStatement(ContinueStatement continueStatement)
+    protected internal virtual object? VisitContinueStatement(ContinueStatement continueStatement, object? context)
     {
         if (continueStatement.Label is not null)
         {
-            Visit(continueStatement.Label);
+            Visit(continueStatement.Label, context);
         }
 
         return continueStatement;
     }
 
-    protected internal virtual object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+    protected internal virtual object? VisitDebuggerStatement(DebuggerStatement debuggerStatement, object? context)
     {
         return debuggerStatement;
     }
 
-    protected internal virtual object? VisitDecorator(Decorator decorator)
+    protected internal virtual object? VisitDecorator(Decorator decorator, object? context)
     {
-        Visit(decorator.Expression);
+        Visit(decorator.Expression, context);
 
         return decorator;
     }
 
-    protected internal virtual object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    protected internal virtual object? VisitDoWhileStatement(DoWhileStatement doWhileStatement, object? context)
     {
-        Visit(doWhileStatement.Body);
-        Visit(doWhileStatement.Test);
+        Visit(doWhileStatement.Body, context);
+        Visit(doWhileStatement.Test, context);
 
         return doWhileStatement;
     }
 
-    protected internal virtual object? VisitEmptyStatement(EmptyStatement emptyStatement)
+    protected internal virtual object? VisitEmptyStatement(EmptyStatement emptyStatement, object? context)
     {
         return emptyStatement;
     }
 
-    protected internal virtual object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+    protected internal virtual object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration, object? context)
     {
         if (exportAllDeclaration.Exported is not null)
         {
-            Visit(exportAllDeclaration.Exported);
+            Visit(exportAllDeclaration.Exported, context);
         }
 
-        Visit(exportAllDeclaration.Source);
+        Visit(exportAllDeclaration.Source, context);
 
         ref readonly var assertions = ref exportAllDeclaration.Assertions;
         for (var i = 0; i < assertions.Count; i++)
         {
-            Visit(assertions[i]);
+            Visit(assertions[i], context);
         }
 
         return exportAllDeclaration;
     }
 
-    protected internal virtual object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal virtual object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration, object? context)
     {
-        Visit(exportDefaultDeclaration.Declaration);
+        Visit(exportDefaultDeclaration.Declaration, context);
 
         return exportDefaultDeclaration;
     }
 
-    protected internal virtual object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+    protected internal virtual object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration, object? context)
     {
         if (exportNamedDeclaration.Declaration is not null)
         {
-            Visit(exportNamedDeclaration.Declaration);
+            Visit(exportNamedDeclaration.Declaration, context);
         }
 
         ref readonly var specifiers = ref exportNamedDeclaration.Specifiers;
         for (var i = 0; i < specifiers.Count; i++)
         {
-            Visit(specifiers[i]);
+            Visit(specifiers[i], context);
         }
 
         if (exportNamedDeclaration.Source is not null)
         {
-            Visit(exportNamedDeclaration.Source);
+            Visit(exportNamedDeclaration.Source, context);
         }
 
         ref readonly var assertions = ref exportNamedDeclaration.Assertions;
         for (var i = 0; i < assertions.Count; i++)
         {
-            Visit(assertions[i]);
+            Visit(assertions[i], context);
         }
 
         return exportNamedDeclaration;
     }
 
-    protected internal virtual object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
+    protected internal virtual object? VisitExportSpecifier(ExportSpecifier exportSpecifier, object? context)
     {
-        Visit(exportSpecifier.Local);
-        Visit(exportSpecifier.Exported);
+        Visit(exportSpecifier.Local, context);
+        Visit(exportSpecifier.Exported, context);
 
         return exportSpecifier;
     }
 
-    protected internal virtual object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    protected internal virtual object? VisitExpressionStatement(ExpressionStatement expressionStatement, object? context)
     {
-        Visit(expressionStatement.Expression);
+        Visit(expressionStatement.Expression, context);
 
         return expressionStatement;
     }
 
-    protected internal virtual object? VisitExtension(Node node)
+    protected internal virtual object? VisitExtension(Node node, object? context)
     {
         // Node type Extension is used to represent extensions to the standard AST (for example, see JSX parsing).
         // Nodes of this type never appear in the tree returned by the core parser (JavaScriptParser),
@@ -325,372 +325,372 @@ public class AstVisitor
         throw UnsupportedNodeType(node.GetType());
     }
 
-    protected internal virtual object? VisitForInStatement(ForInStatement forInStatement)
+    protected internal virtual object? VisitForInStatement(ForInStatement forInStatement, object? context)
     {
-        Visit(forInStatement.Left);
-        Visit(forInStatement.Right);
-        Visit(forInStatement.Body);
+        Visit(forInStatement.Left, context);
+        Visit(forInStatement.Right, context);
+        Visit(forInStatement.Body, context);
 
         return forInStatement;
     }
 
-    protected internal virtual object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal virtual object? VisitForOfStatement(ForOfStatement forOfStatement, object? context)
     {
-        Visit(forOfStatement.Left);
-        Visit(forOfStatement.Right);
-        Visit(forOfStatement.Body);
+        Visit(forOfStatement.Left, context);
+        Visit(forOfStatement.Right, context);
+        Visit(forOfStatement.Body, context);
 
         return forOfStatement;
     }
 
-    protected internal virtual object? VisitForStatement(ForStatement forStatement)
+    protected internal virtual object? VisitForStatement(ForStatement forStatement, object? context)
     {
         if (forStatement.Init is not null)
         {
-            Visit(forStatement.Init);
+            Visit(forStatement.Init, context);
         }
 
         if (forStatement.Test is not null)
         {
-            Visit(forStatement.Test);
+            Visit(forStatement.Test, context);
         }
 
         if (forStatement.Update is not null)
         {
-            Visit(forStatement.Update);
+            Visit(forStatement.Update, context);
         }
 
-        Visit(forStatement.Body);
+        Visit(forStatement.Body, context);
 
         return forStatement;
     }
 
-    protected internal virtual object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    protected internal virtual object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration, object? context)
     {
         if (functionDeclaration.Id is not null)
         {
-            Visit(functionDeclaration.Id);
+            Visit(functionDeclaration.Id, context);
         }
 
         ref readonly var parameters = ref functionDeclaration.Params;
         for (var i = 0; i < parameters.Count; i++)
         {
-            Visit(parameters[i]);
+            Visit(parameters[i], context);
         }
 
-        Visit(functionDeclaration.Body);
+        Visit(functionDeclaration.Body, context);
 
         return functionDeclaration;
     }
 
-    protected internal virtual object? VisitFunctionExpression(FunctionExpression functionExpression)
+    protected internal virtual object? VisitFunctionExpression(FunctionExpression functionExpression, object? context)
     {
         if (functionExpression.Id is not null)
         {
-            Visit(functionExpression.Id);
+            Visit(functionExpression.Id, context);
         }
 
         ref readonly var parameters = ref functionExpression.Params;
         for (var i = 0; i < parameters.Count; i++)
         {
-            Visit(parameters[i]);
+            Visit(parameters[i], context);
         }
 
-        Visit(functionExpression.Body);
+        Visit(functionExpression.Body, context);
 
         return functionExpression;
     }
 
-    protected internal virtual object? VisitIdentifier(Identifier identifier)
+    protected internal virtual object? VisitIdentifier(Identifier identifier, object? context)
     {
         return identifier;
     }
 
-    protected internal virtual object? VisitIfStatement(IfStatement ifStatement)
+    protected internal virtual object? VisitIfStatement(IfStatement ifStatement, object? context)
     {
-        Visit(ifStatement.Test);
-        Visit(ifStatement.Consequent);
+        Visit(ifStatement.Test, context);
+        Visit(ifStatement.Consequent, context);
         if (ifStatement.Alternate is not null)
         {
-            Visit(ifStatement.Alternate);
+            Visit(ifStatement.Alternate, context);
         }
 
         return ifStatement;
     }
 
-    protected internal virtual object? VisitImport(Import import)
+    protected internal virtual object? VisitImport(Import import, object? context)
     {
-        Visit(import.Source);
+        Visit(import.Source, context);
 
         if (import.Attributes is not null)
         {
-            Visit(import.Attributes);
+            Visit(import.Attributes, context);
         }
 
         return import;
     }
 
-    protected internal virtual object? VisitImportAttribute(ImportAttribute importAttribute)
+    protected internal virtual object? VisitImportAttribute(ImportAttribute importAttribute, object? context)
     {
-        Visit(importAttribute.Key);
-        Visit(importAttribute.Value);
+        Visit(importAttribute.Key, context);
+        Visit(importAttribute.Value, context);
 
         return importAttribute;
     }
 
-    protected internal virtual object? VisitImportDeclaration(ImportDeclaration importDeclaration)
+    protected internal virtual object? VisitImportDeclaration(ImportDeclaration importDeclaration, object? context)
     {
         ref readonly var specifiers = ref importDeclaration.Specifiers;
         for (var i = 0; i < specifiers.Count; i++)
         {
-            Visit(specifiers[i]);
+            Visit(specifiers[i], context);
         }
 
-        Visit(importDeclaration.Source);
+        Visit(importDeclaration.Source, context);
 
         ref readonly var assertions = ref importDeclaration.Assertions;
         for (var i = 0; i < assertions.Count; i++)
         {
-            Visit(assertions[i]);
+            Visit(assertions[i], context);
         }
 
         return importDeclaration;
     }
 
-    protected internal virtual object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+    protected internal virtual object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier, object? context)
     {
-        Visit(importDefaultSpecifier.Local);
+        Visit(importDefaultSpecifier.Local, context);
 
         return importDefaultSpecifier;
     }
 
-    protected internal virtual object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    protected internal virtual object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier, object? context)
     {
-        Visit(importNamespaceSpecifier.Local);
+        Visit(importNamespaceSpecifier.Local, context);
 
         return importNamespaceSpecifier;
     }
 
-    protected internal virtual object? VisitImportSpecifier(ImportSpecifier importSpecifier)
+    protected internal virtual object? VisitImportSpecifier(ImportSpecifier importSpecifier, object? context)
     {
-        Visit(importSpecifier.Imported);
-        Visit(importSpecifier.Local);
+        Visit(importSpecifier.Imported, context);
+        Visit(importSpecifier.Local, context);
 
         return importSpecifier;
     }
 
-    protected internal virtual object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    protected internal virtual object? VisitLabeledStatement(LabeledStatement labeledStatement, object? context)
     {
-        Visit(labeledStatement.Label);
-        Visit(labeledStatement.Body);
+        Visit(labeledStatement.Label, context);
+        Visit(labeledStatement.Body, context);
 
         return labeledStatement;
     }
 
-    protected internal virtual object? VisitLiteral(Literal literal)
+    protected internal virtual object? VisitLiteral(Literal literal, object? context)
     {
         return literal;
     }
 
-    protected internal virtual object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal virtual object? VisitMemberExpression(MemberExpression memberExpression, object? context)
     {
-        Visit(memberExpression.Object);
-        Visit(memberExpression.Property);
+        Visit(memberExpression.Object, context);
+        Visit(memberExpression.Property, context);
 
         return memberExpression;
     }
 
-    protected internal virtual object? VisitMetaProperty(MetaProperty metaProperty)
+    protected internal virtual object? VisitMetaProperty(MetaProperty metaProperty, object? context)
     {
-        Visit(metaProperty.Meta);
-        Visit(metaProperty.Property);
+        Visit(metaProperty.Meta, context);
+        Visit(metaProperty.Property, context);
 
         return metaProperty;
     }
 
-    protected internal virtual object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    protected internal virtual object? VisitMethodDefinition(MethodDefinition methodDefinition, object? context)
     {
-        Visit(methodDefinition.Key);
-        Visit(methodDefinition.Value);
+        Visit(methodDefinition.Key, context);
+        Visit(methodDefinition.Value, context);
 
         ref readonly var decorators = ref methodDefinition.Decorators;
         for (var i = 0; i < decorators.Count; i++)
         {
-            Visit(decorators[i]);
+            Visit(decorators[i], context);
         }
 
         return methodDefinition;
     }
 
-    protected internal virtual object? VisitNewExpression(NewExpression newExpression)
+    protected internal virtual object? VisitNewExpression(NewExpression newExpression, object? context)
     {
-        Visit(newExpression.Callee);
+        Visit(newExpression.Callee, context);
         ref readonly var arguments = ref newExpression.Arguments;
         for (var i = 0; i < arguments.Count; i++)
         {
-            Visit(arguments[i]);
+            Visit(arguments[i], context);
         }
 
         return newExpression;
     }
 
-    protected internal virtual object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal virtual object? VisitObjectExpression(ObjectExpression objectExpression, object? context)
     {
         ref readonly var properties = ref objectExpression.Properties;
         for (var i = 0; i < properties.Count; i++)
         {
-            Visit(properties[i]);
+            Visit(properties[i], context);
         }
 
         return objectExpression;
     }
 
-    protected internal virtual object? VisitObjectPattern(ObjectPattern objectPattern)
+    protected internal virtual object? VisitObjectPattern(ObjectPattern objectPattern, object? context)
     {
         ref readonly var properties = ref objectPattern.Properties;
         for (var i = 0; i < properties.Count; i++)
         {
-            Visit(properties[i]);
+            Visit(properties[i], context);
         }
 
         return objectPattern;
     }
 
-    protected internal virtual object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+    protected internal virtual object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier, object? context)
     {
         return privateIdentifier;
     }
 
-    protected internal virtual object? VisitProgram(Program program)
+    protected internal virtual object? VisitProgram(Program program, object? context)
     {
         ref readonly var statements = ref program.Body;
         for (var i = 0; i < statements.Count; i++)
         {
-            Visit(statements[i]);
+            Visit(statements[i], context);
         }
 
         return program;
     }
 
-    protected internal virtual object? VisitProperty(Property property)
+    protected internal virtual object? VisitProperty(Property property, object? context)
     {
-        Visit(property.Key);
-        Visit(property.Value);
+        Visit(property.Key, context);
+        Visit(property.Value, context);
 
         return property;
     }
 
-    protected internal virtual object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    protected internal virtual object? VisitPropertyDefinition(PropertyDefinition propertyDefinition, object? context)
     {
-        Visit(propertyDefinition.Key);
+        Visit(propertyDefinition.Key, context);
 
         if (propertyDefinition.Value is not null)
         {
-            Visit(propertyDefinition.Value);
+            Visit(propertyDefinition.Value, context);
         }
 
         ref readonly var decorators = ref propertyDefinition.Decorators;
         for (var i = 0; i < decorators.Count; i++)
         {
-            Visit(decorators[i]);
+            Visit(decorators[i], context);
         }
 
         return propertyDefinition;
     }
 
-    protected internal virtual object? VisitRestElement(RestElement restElement)
+    protected internal virtual object? VisitRestElement(RestElement restElement, object? context)
     {
-        Visit(restElement.Argument);
+        Visit(restElement.Argument, context);
 
         return restElement;
     }
 
-    protected internal virtual object? VisitReturnStatement(ReturnStatement returnStatement)
+    protected internal virtual object? VisitReturnStatement(ReturnStatement returnStatement, object? context)
     {
         if (returnStatement.Argument is not null)
         {
-            Visit(returnStatement.Argument);
+            Visit(returnStatement.Argument, context);
         }
 
         return returnStatement;
     }
 
-    protected internal virtual object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal virtual object? VisitSequenceExpression(SequenceExpression sequenceExpression, object? context)
     {
         ref readonly var expressions = ref sequenceExpression.Expressions;
         for (var i = 0; i < expressions.Count; i++)
         {
-            Visit(expressions[i]);
+            Visit(expressions[i], context);
         }
 
         return sequenceExpression;
     }
 
-    protected internal virtual object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal virtual object? VisitSpreadElement(SpreadElement spreadElement, object? context)
     {
-        Visit(spreadElement.Argument);
+        Visit(spreadElement.Argument, context);
 
         return spreadElement;
     }
 
-    protected internal virtual object? VisitStaticBlock(StaticBlock staticBlock)
+    protected internal virtual object? VisitStaticBlock(StaticBlock staticBlock, object? context)
     {
         ref readonly var body = ref staticBlock.Body;
         for (var i = 0; i < body.Count; i++)
         {
-            Visit(body[i]);
+            Visit(body[i], context);
         }
 
         return staticBlock;
     }
 
-    protected internal virtual object? VisitSuper(Super super)
+    protected internal virtual object? VisitSuper(Super super, object? context)
     {
         return super;
     }
 
-    protected internal virtual object? VisitSwitchCase(SwitchCase switchCase)
+    protected internal virtual object? VisitSwitchCase(SwitchCase switchCase, object? context)
     {
         if (switchCase.Test is not null)
         {
-            Visit(switchCase.Test);
+            Visit(switchCase.Test, context);
         }
 
         ref readonly var consequent = ref switchCase.Consequent;
         for (var i = 0; i < consequent.Count; i++)
         {
-            Visit(consequent[i]);
+            Visit(consequent[i], context);
         }
 
         return switchCase;
     }
 
-    protected internal virtual object? VisitSwitchStatement(SwitchStatement switchStatement)
+    protected internal virtual object? VisitSwitchStatement(SwitchStatement switchStatement, object? context)
     {
-        Visit(switchStatement.Discriminant);
+        Visit(switchStatement.Discriminant, context);
         ref readonly var cases = ref switchStatement.Cases;
         for (var i = 0; i < cases.Count; i++)
         {
-            Visit(cases[i]);
+            Visit(cases[i], context);
         }
 
         return switchStatement;
     }
 
-    protected internal virtual object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    protected internal virtual object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression, object? context)
     {
-        Visit(taggedTemplateExpression.Tag);
-        Visit(taggedTemplateExpression.Quasi);
+        Visit(taggedTemplateExpression.Tag, context);
+        Visit(taggedTemplateExpression.Quasi, context);
 
         return taggedTemplateExpression;
     }
 
-    protected internal virtual object? VisitTemplateElement(TemplateElement templateElement)
+    protected internal virtual object? VisitTemplateElement(TemplateElement templateElement, object? context)
     {
         return templateElement;
     }
 
-    protected internal virtual object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    protected internal virtual object? VisitTemplateLiteral(TemplateLiteral templateLiteral, object? context)
     {
         ref readonly var quasis = ref templateLiteral.Quasis;
         ref readonly var expressions = ref templateLiteral.Expressions;
@@ -698,92 +698,92 @@ public class AstVisitor
         TemplateElement quasi;
         for (var i = 0; !(quasi = quasis[i]).Tail; i++)
         {
-            Visit(quasi);
-            Visit(expressions[i]);
+            Visit(quasi, context);
+            Visit(expressions[i], context);
         }
-        Visit(quasi);
+        Visit(quasi, context);
 
         return templateLiteral;
     }
 
-    protected internal virtual object? VisitThisExpression(ThisExpression thisExpression)
+    protected internal virtual object? VisitThisExpression(ThisExpression thisExpression, object? context)
     {
         return thisExpression;
     }
 
-    protected internal virtual object? VisitThrowStatement(ThrowStatement throwStatement)
+    protected internal virtual object? VisitThrowStatement(ThrowStatement throwStatement, object? context)
     {
-        Visit(throwStatement.Argument);
+        Visit(throwStatement.Argument, context);
 
         return throwStatement;
     }
 
-    protected internal virtual object? VisitTryStatement(TryStatement tryStatement)
+    protected internal virtual object? VisitTryStatement(TryStatement tryStatement, object? context)
     {
-        Visit(tryStatement.Block);
+        Visit(tryStatement.Block, context);
         if (tryStatement.Handler is not null)
         {
-            Visit(tryStatement.Handler);
+            Visit(tryStatement.Handler, context);
         }
 
         if (tryStatement.Finalizer is not null)
         {
-            Visit(tryStatement.Finalizer);
+            Visit(tryStatement.Finalizer, context);
         }
 
         return tryStatement;
     }
 
-    protected internal virtual object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal virtual object? VisitUnaryExpression(UnaryExpression unaryExpression, object? context)
     {
-        Visit(unaryExpression.Argument);
+        Visit(unaryExpression.Argument, context);
 
         return unaryExpression;
     }
 
-    protected internal virtual object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    protected internal virtual object? VisitVariableDeclaration(VariableDeclaration variableDeclaration, object? context)
     {
         ref readonly var declarations = ref variableDeclaration.Declarations;
         for (var i = 0; i < declarations.Count; i++)
         {
-            Visit(declarations[i]);
+            Visit(declarations[i], context);
         }
 
         return variableDeclaration;
     }
 
-    protected internal virtual object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    protected internal virtual object? VisitVariableDeclarator(VariableDeclarator variableDeclarator, object? context)
     {
-        Visit(variableDeclarator.Id);
+        Visit(variableDeclarator.Id, context);
         if (variableDeclarator.Init is not null)
         {
-            Visit(variableDeclarator.Init);
+            Visit(variableDeclarator.Init, context);
         }
 
         return variableDeclarator;
     }
 
-    protected internal virtual object? VisitWhileStatement(WhileStatement whileStatement)
+    protected internal virtual object? VisitWhileStatement(WhileStatement whileStatement, object? context)
     {
-        Visit(whileStatement.Test);
-        Visit(whileStatement.Body);
+        Visit(whileStatement.Test, context);
+        Visit(whileStatement.Body, context);
 
         return whileStatement;
     }
 
-    protected internal virtual object? VisitWithStatement(WithStatement withStatement)
+    protected internal virtual object? VisitWithStatement(WithStatement withStatement, object? context)
     {
-        Visit(withStatement.Object);
-        Visit(withStatement.Body);
+        Visit(withStatement.Object, context);
+        Visit(withStatement.Body, context);
 
         return withStatement;
     }
 
-    protected internal virtual object? VisitYieldExpression(YieldExpression yieldExpression)
+    protected internal virtual object? VisitYieldExpression(YieldExpression yieldExpression, object? context)
     {
         if (yieldExpression.Argument is not null)
         {
-            Visit(yieldExpression.Argument);
+            Visit(yieldExpression.Argument, context);
         }
 
         return yieldExpression;

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -151,570 +151,570 @@ public class AstVisitorEventSource : AstVisitor
     public event EventHandler<YieldExpression>? VisitingYieldExpression;
     public event EventHandler<YieldExpression>? VisitedYieldExpression;
 
-    public override object? Visit(Node node)
+    public override object? Visit(Node node, object? context = null)
     {
         VisitingNode?.Invoke(this, node);
-        var result = base.Visit(node);
+        var result = base.Visit(node, context);
         VisitedNode?.Invoke(this, node);
         return result;
     }
 
-    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression, object? context)
     {
         VisitingArrayExpression?.Invoke(this, arrayExpression);
-        var result = base.VisitArrayExpression(arrayExpression);
+        var result = base.VisitArrayExpression(arrayExpression, context);
         VisitedArrayExpression?.Invoke(this, arrayExpression);
         return result;
     }
 
-    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
+    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern, object? context)
     {
         VisitingArrayPattern?.Invoke(this, arrayPattern);
-        var result = base.VisitArrayPattern(arrayPattern);
+        var result = base.VisitArrayPattern(arrayPattern, context);
         VisitedArrayPattern?.Invoke(this, arrayPattern);
         return result;
     }
 
-    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression, object? context)
     {
         VisitingArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
-        var result = base.VisitArrowFunctionExpression(arrowFunctionExpression);
+        var result = base.VisitArrowFunctionExpression(arrowFunctionExpression, context);
         VisitedArrowFunctionExpression?.Invoke(this, arrowFunctionExpression);
         return result;
     }
 
-    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression, object? context)
     {
         VisitingAssignmentExpression?.Invoke(this, assignmentExpression);
-        var result = base.VisitAssignmentExpression(assignmentExpression);
+        var result = base.VisitAssignmentExpression(assignmentExpression, context);
         VisitedAssignmentExpression?.Invoke(this, assignmentExpression);
         return result;
     }
 
-    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern, object? context)
     {
         VisitingAssignmentPattern?.Invoke(this, assignmentPattern);
-        var result = base.VisitAssignmentPattern(assignmentPattern);
+        var result = base.VisitAssignmentPattern(assignmentPattern, context);
         VisitedAssignmentPattern?.Invoke(this, assignmentPattern);
         return result;
     }
 
-    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression, object? context)
     {
         VisitingAwaitExpression?.Invoke(this, awaitExpression);
-        var result = base.VisitAwaitExpression(awaitExpression);
+        var result = base.VisitAwaitExpression(awaitExpression, context);
         VisitedAwaitExpression?.Invoke(this, awaitExpression);
         return result;
     }
 
-    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression, object? context)
     {
         VisitingBinaryExpression?.Invoke(this, binaryExpression);
-        var result = base.VisitBinaryExpression(binaryExpression);
+        var result = base.VisitBinaryExpression(binaryExpression, context);
         VisitedBinaryExpression?.Invoke(this, binaryExpression);
         return result;
     }
 
-    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
+    protected internal override object? VisitBlockStatement(BlockStatement blockStatement, object? context)
     {
         VisitingBlockStatement?.Invoke(this, blockStatement);
-        var result = base.VisitBlockStatement(blockStatement);
+        var result = base.VisitBlockStatement(blockStatement, context);
         VisitedBlockStatement?.Invoke(this, blockStatement);
         return result;
     }
 
-    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
+    protected internal override object? VisitBreakStatement(BreakStatement breakStatement, object? context)
     {
         VisitingBreakStatement?.Invoke(this, breakStatement);
-        var result = base.VisitBreakStatement(breakStatement);
+        var result = base.VisitBreakStatement(breakStatement, context);
         VisitedBreakStatement?.Invoke(this, breakStatement);
         return result;
     }
 
-    protected internal override object? VisitCallExpression(CallExpression callExpression)
+    protected internal override object? VisitCallExpression(CallExpression callExpression, object? context)
     {
         VisitingCallExpression?.Invoke(this, callExpression);
-        var result = base.VisitCallExpression(callExpression);
+        var result = base.VisitCallExpression(callExpression, context);
         VisitedCallExpression?.Invoke(this, callExpression);
         return result;
     }
 
-    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    protected internal override object? VisitCatchClause(CatchClause catchClause, object? context)
     {
         VisitingCatchClause?.Invoke(this, catchClause);
-        var result = base.VisitCatchClause(catchClause);
+        var result = base.VisitCatchClause(catchClause, context);
         VisitedCatchClause?.Invoke(this, catchClause);
         return result;
     }
 
-    protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+    protected internal override object? VisitChainExpression(ChainExpression chainExpression, object? context)
     {
         VisitingChainExpression?.Invoke(this, chainExpression);
-        var result = base.VisitChainExpression(chainExpression);
+        var result = base.VisitChainExpression(chainExpression, context);
         VisitedChainExpression?.Invoke(this, chainExpression);
         return result;
     }
 
-    protected internal override object? VisitClassBody(ClassBody classBody)
+    protected internal override object? VisitClassBody(ClassBody classBody, object? context)
     {
         VisitingClassBody?.Invoke(this, classBody);
-        var result = base.VisitClassBody(classBody);
+        var result = base.VisitClassBody(classBody, context);
         VisitedClassBody?.Invoke(this, classBody);
         return result;
     }
 
-    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration, object? context)
     {
         VisitingClassDeclaration?.Invoke(this, classDeclaration);
-        var result = base.VisitClassDeclaration(classDeclaration);
+        var result = base.VisitClassDeclaration(classDeclaration, context);
         VisitedClassDeclaration?.Invoke(this, classDeclaration);
         return result;
     }
 
-    protected internal override object? VisitClassExpression(ClassExpression classExpression)
+    protected internal override object? VisitClassExpression(ClassExpression classExpression, object? context)
     {
         VisitingClassExpression?.Invoke(this, classExpression);
-        var result = base.VisitClassExpression(classExpression);
+        var result = base.VisitClassExpression(classExpression, context);
         VisitedClassExpression?.Invoke(this, classExpression);
         return result;
     }
 
-    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression, object? context)
     {
         VisitingConditionalExpression?.Invoke(this, conditionalExpression);
-        var result = base.VisitConditionalExpression(conditionalExpression);
+        var result = base.VisitConditionalExpression(conditionalExpression, context);
         VisitedConditionalExpression?.Invoke(this, conditionalExpression);
         return result;
     }
 
-    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement, object? context)
     {
         VisitingContinueStatement?.Invoke(this, continueStatement);
-        var result = base.VisitContinueStatement(continueStatement);
+        var result = base.VisitContinueStatement(continueStatement, context);
         VisitedContinueStatement?.Invoke(this, continueStatement);
         return result;
     }
 
-    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement, object? context)
     {
         VisitingDebuggerStatement?.Invoke(this, debuggerStatement);
-        var result = base.VisitDebuggerStatement(debuggerStatement);
+        var result = base.VisitDebuggerStatement(debuggerStatement, context);
         VisitedDebuggerStatement?.Invoke(this, debuggerStatement);
         return result;
     }
 
-    protected internal override object? VisitDecorator(Decorator decorator)
+    protected internal override object? VisitDecorator(Decorator decorator, object? context)
     {
         VisitingDecorator?.Invoke(this, decorator);
-        var result = base.VisitDecorator(decorator);
+        var result = base.VisitDecorator(decorator, context);
         VisitedDecorator?.Invoke(this, decorator);
         return result;
     }
 
-    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement, object? context)
     {
         VisitingDoWhileStatement?.Invoke(this, doWhileStatement);
-        var result = base.VisitDoWhileStatement(doWhileStatement);
+        var result = base.VisitDoWhileStatement(doWhileStatement, context);
         VisitedDoWhileStatement?.Invoke(this, doWhileStatement);
         return result;
     }
 
-    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
+    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement, object? context)
     {
         VisitingEmptyStatement?.Invoke(this, emptyStatement);
-        var result = base.VisitEmptyStatement(emptyStatement);
+        var result = base.VisitEmptyStatement(emptyStatement, context);
         VisitedEmptyStatement?.Invoke(this, emptyStatement);
         return result;
     }
 
-    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration, object? context)
     {
         VisitingExportAllDeclaration?.Invoke(this, exportAllDeclaration);
-        var result = base.VisitExportAllDeclaration(exportAllDeclaration);
+        var result = base.VisitExportAllDeclaration(exportAllDeclaration, context);
         VisitedExportAllDeclaration?.Invoke(this, exportAllDeclaration);
         return result;
     }
 
-    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration, object? context)
     {
         VisitingExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
-        var result = base.VisitExportDefaultDeclaration(exportDefaultDeclaration);
+        var result = base.VisitExportDefaultDeclaration(exportDefaultDeclaration, context);
         VisitedExportDefaultDeclaration?.Invoke(this, exportDefaultDeclaration);
         return result;
     }
 
-    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration, object? context)
     {
         VisitingExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
-        var result = base.VisitExportNamedDeclaration(exportNamedDeclaration);
+        var result = base.VisitExportNamedDeclaration(exportNamedDeclaration, context);
         VisitedExportNamedDeclaration?.Invoke(this, exportNamedDeclaration);
         return result;
     }
 
-    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
+    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier, object? context)
     {
         VisitingExportSpecifier?.Invoke(this, exportSpecifier);
-        var result = base.VisitExportSpecifier(exportSpecifier);
+        var result = base.VisitExportSpecifier(exportSpecifier, context);
         VisitedExportSpecifier?.Invoke(this, exportSpecifier);
         return result;
     }
 
-    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement, object? context)
     {
         VisitingExpressionStatement?.Invoke(this, expressionStatement);
-        var result = base.VisitExpressionStatement(expressionStatement);
+        var result = base.VisitExpressionStatement(expressionStatement, context);
         VisitedExpressionStatement?.Invoke(this, expressionStatement);
         return result;
     }
 
-    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+    protected internal override object? VisitForInStatement(ForInStatement forInStatement, object? context)
     {
         VisitingForInStatement?.Invoke(this, forInStatement);
-        var result = base.VisitForInStatement(forInStatement);
+        var result = base.VisitForInStatement(forInStatement, context);
         VisitedForInStatement?.Invoke(this, forInStatement);
         return result;
     }
 
-    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement, object? context)
     {
         VisitingForOfStatement?.Invoke(this, forOfStatement);
-        var result = base.VisitForOfStatement(forOfStatement);
+        var result = base.VisitForOfStatement(forOfStatement, context);
         VisitedForOfStatement?.Invoke(this, forOfStatement);
         return result;
     }
 
-    protected internal override object? VisitForStatement(ForStatement forStatement)
+    protected internal override object? VisitForStatement(ForStatement forStatement, object? context)
     {
         VisitingForStatement?.Invoke(this, forStatement);
-        var result = base.VisitForStatement(forStatement);
+        var result = base.VisitForStatement(forStatement, context);
         VisitedForStatement?.Invoke(this, forStatement);
         return result;
     }
 
-    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration, object? context)
     {
         VisitingFunctionDeclaration?.Invoke(this, functionDeclaration);
-        var result = base.VisitFunctionDeclaration(functionDeclaration);
+        var result = base.VisitFunctionDeclaration(functionDeclaration, context);
         VisitedFunctionDeclaration?.Invoke(this, functionDeclaration);
         return result;
     }
 
-    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression, object? context)
     {
         VisitingFunctionExpression?.Invoke(this, functionExpression);
-        var result = base.VisitFunctionExpression(functionExpression);
+        var result = base.VisitFunctionExpression(functionExpression, context);
         VisitedFunctionExpression?.Invoke(this, functionExpression);
         return result;
     }
 
-    protected internal override object? VisitIdentifier(Identifier identifier)
+    protected internal override object? VisitIdentifier(Identifier identifier, object? context)
     {
         VisitingIdentifier?.Invoke(this, identifier);
-        var result = base.VisitIdentifier(identifier);
+        var result = base.VisitIdentifier(identifier, context);
         VisitedIdentifier?.Invoke(this, identifier);
         return result;
     }
 
-    protected internal override object? VisitIfStatement(IfStatement ifStatement)
+    protected internal override object? VisitIfStatement(IfStatement ifStatement, object? context)
     {
         VisitingIfStatement?.Invoke(this, ifStatement);
-        var result = base.VisitIfStatement(ifStatement);
+        var result = base.VisitIfStatement(ifStatement, context);
         VisitedIfStatement?.Invoke(this, ifStatement);
         return result;
     }
 
-    protected internal override object? VisitImport(Import import)
+    protected internal override object? VisitImport(Import import, object? context)
     {
         VisitingImport?.Invoke(this, import);
-        var result = base.VisitImport(import);
+        var result = base.VisitImport(import, context);
         VisitedImport?.Invoke(this, import);
         return result;
     }
 
-    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
+    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration, object? context)
     {
         VisitingImportDeclaration?.Invoke(this, importDeclaration);
-        var result = base.VisitImportDeclaration(importDeclaration);
+        var result = base.VisitImportDeclaration(importDeclaration, context);
         VisitedImportDeclaration?.Invoke(this, importDeclaration);
         return result;
     }
 
-    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier, object? context)
     {
         VisitingImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
-        var result = base.VisitImportDefaultSpecifier(importDefaultSpecifier);
+        var result = base.VisitImportDefaultSpecifier(importDefaultSpecifier, context);
         VisitedImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
         return result;
     }
 
-    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier, object? context)
     {
         VisitingImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
-        var result = base.VisitImportNamespaceSpecifier(importNamespaceSpecifier);
+        var result = base.VisitImportNamespaceSpecifier(importNamespaceSpecifier, context);
         VisitedImportNamespaceSpecifier?.Invoke(this, importNamespaceSpecifier);
         return result;
     }
 
-    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
+    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier, object? context)
     {
         VisitingImportSpecifier?.Invoke(this, importSpecifier);
-        var result = base.VisitImportSpecifier(importSpecifier);
+        var result = base.VisitImportSpecifier(importSpecifier, context);
         VisitedImportSpecifier?.Invoke(this, importSpecifier);
         return result;
     }
 
-    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement, object? context)
     {
         VisitingLabeledStatement?.Invoke(this, labeledStatement);
-        var result = base.VisitLabeledStatement(labeledStatement);
+        var result = base.VisitLabeledStatement(labeledStatement, context);
         VisitedLabeledStatement?.Invoke(this, labeledStatement);
         return result;
     }
 
-    protected internal override object? VisitLiteral(Literal literal)
+    protected internal override object? VisitLiteral(Literal literal, object? context)
     {
         VisitingLiteral?.Invoke(this, literal);
-        var result = base.VisitLiteral(literal);
+        var result = base.VisitLiteral(literal, context);
         VisitedLiteral?.Invoke(this, literal);
         return result;
     }
 
-    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal override object? VisitMemberExpression(MemberExpression memberExpression, object? context)
     {
         VisitingMemberExpression?.Invoke(this, memberExpression);
-        var result = base.VisitMemberExpression(memberExpression);
+        var result = base.VisitMemberExpression(memberExpression, context);
         VisitedMemberExpression?.Invoke(this, memberExpression);
         return result;
     }
 
-    protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+    protected internal override object? VisitMetaProperty(MetaProperty metaProperty, object? context)
     {
         VisitingMetaProperty?.Invoke(this, metaProperty);
-        var result = base.VisitMetaProperty(metaProperty);
+        var result = base.VisitMetaProperty(metaProperty, context);
         VisitedMetaProperty?.Invoke(this, metaProperty);
         return result;
     }
 
-    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition, object? context)
     {
         VisitingMethodDefinition?.Invoke(this, methodDefinition);
-        var result = base.VisitMethodDefinition(methodDefinition);
+        var result = base.VisitMethodDefinition(methodDefinition, context);
         VisitedMethodDefinition?.Invoke(this, methodDefinition);
         return result;
     }
 
-    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    protected internal override object? VisitNewExpression(NewExpression newExpression, object? context)
     {
         VisitingNewExpression?.Invoke(this, newExpression);
-        var result = base.VisitNewExpression(newExpression);
+        var result = base.VisitNewExpression(newExpression, context);
         VisitedNewExpression?.Invoke(this, newExpression);
         return result;
     }
 
-    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression, object? context)
     {
         VisitingObjectExpression?.Invoke(this, objectExpression);
-        var result = base.VisitObjectExpression(objectExpression);
+        var result = base.VisitObjectExpression(objectExpression, context);
         VisitedObjectExpression?.Invoke(this, objectExpression);
         return result;
     }
 
-    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
+    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern, object? context)
     {
         VisitingObjectPattern?.Invoke(this, objectPattern);
-        var result = base.VisitObjectPattern(objectPattern);
+        var result = base.VisitObjectPattern(objectPattern, context);
         VisitedObjectPattern?.Invoke(this, objectPattern);
         return result;
     }
 
-    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier, object? context)
     {
         VisitingPrivateIdentifier?.Invoke(this, privateIdentifier);
-        var result = base.VisitPrivateIdentifier(privateIdentifier);
+        var result = base.VisitPrivateIdentifier(privateIdentifier, context);
         VisitedPrivateIdentifier?.Invoke(this, privateIdentifier);
         return result;
     }
 
-    protected internal override object? VisitProgram(Program program)
+    protected internal override object? VisitProgram(Program program, object? context)
     {
         VisitingProgram?.Invoke(this, program);
-        var result = base.VisitProgram(program);
+        var result = base.VisitProgram(program, context);
         VisitedProgram?.Invoke(this, program);
         return result;
     }
 
-    protected internal override object? VisitProperty(Property property)
+    protected internal override object? VisitProperty(Property property, object? context)
     {
         VisitingProperty?.Invoke(this, property);
-        var result = base.VisitProperty(property);
+        var result = base.VisitProperty(property, context);
         VisitedProperty?.Invoke(this, property);
         return result;
     }
 
-    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition, object? context)
     {
         VisitingPropertyDefinition?.Invoke(this, propertyDefinition);
-        var result = base.VisitPropertyDefinition(propertyDefinition);
+        var result = base.VisitPropertyDefinition(propertyDefinition, context);
         VisitedPropertyDefinition?.Invoke(this, propertyDefinition);
         return result;
     }
 
-    protected internal override object? VisitRestElement(RestElement restElement)
+    protected internal override object? VisitRestElement(RestElement restElement, object? context)
     {
         VisitingRestElement?.Invoke(this, restElement);
-        var result = base.VisitRestElement(restElement);
+        var result = base.VisitRestElement(restElement, context);
         VisitedRestElement?.Invoke(this, restElement);
         return result;
     }
 
-    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
+    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement, object? context)
     {
         VisitingReturnStatement?.Invoke(this, returnStatement);
-        var result = base.VisitReturnStatement(returnStatement);
+        var result = base.VisitReturnStatement(returnStatement, context);
         VisitedReturnStatement?.Invoke(this, returnStatement);
         return result;
     }
 
-    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression, object? context)
     {
         VisitingSequenceExpression?.Invoke(this, sequenceExpression);
-        var result = base.VisitSequenceExpression(sequenceExpression);
+        var result = base.VisitSequenceExpression(sequenceExpression, context);
         VisitedSequenceExpression?.Invoke(this, sequenceExpression);
         return result;
     }
 
-    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal override object? VisitSpreadElement(SpreadElement spreadElement, object? context)
     {
         VisitingSpreadElement?.Invoke(this, spreadElement);
-        var result = base.VisitSpreadElement(spreadElement);
+        var result = base.VisitSpreadElement(spreadElement, context);
         VisitedSpreadElement?.Invoke(this, spreadElement);
         return result;
     }
 
-    protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
+    protected internal override object? VisitStaticBlock(StaticBlock staticBlock, object? context)
     {
         VisitingStaticBlock?.Invoke(this, staticBlock);
-        var result = base.VisitStaticBlock(staticBlock);
+        var result = base.VisitStaticBlock(staticBlock, context);
         VisitedStaticBlock?.Invoke(this, staticBlock);
         return result;
     }
 
-    protected internal override object? VisitSuper(Super super)
+    protected internal override object? VisitSuper(Super super, object? context)
     {
         VisitingSuper?.Invoke(this, super);
-        var result = base.VisitSuper(super);
+        var result = base.VisitSuper(super, context);
         VisitedSuper?.Invoke(this, super);
         return result;
     }
 
-    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+    protected internal override object? VisitSwitchCase(SwitchCase switchCase, object? context)
     {
         VisitingSwitchCase?.Invoke(this, switchCase);
-        var result = base.VisitSwitchCase(switchCase);
+        var result = base.VisitSwitchCase(switchCase, context);
         VisitedSwitchCase?.Invoke(this, switchCase);
         return result;
     }
 
-    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement, object? context)
     {
         VisitingSwitchStatement?.Invoke(this, switchStatement);
-        var result = base.VisitSwitchStatement(switchStatement);
+        var result = base.VisitSwitchStatement(switchStatement, context);
         VisitedSwitchStatement?.Invoke(this, switchStatement);
         return result;
     }
 
-    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression, object? context)
     {
         VisitingTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
-        var result = base.VisitTaggedTemplateExpression(taggedTemplateExpression);
+        var result = base.VisitTaggedTemplateExpression(taggedTemplateExpression, context);
         VisitedTaggedTemplateExpression?.Invoke(this, taggedTemplateExpression);
         return result;
     }
 
-    protected internal override object? VisitTemplateElement(TemplateElement templateElement)
+    protected internal override object? VisitTemplateElement(TemplateElement templateElement, object? context)
     {
         VisitingTemplateElement?.Invoke(this, templateElement);
-        var result = base.VisitTemplateElement(templateElement);
+        var result = base.VisitTemplateElement(templateElement, context);
         VisitedTemplateElement?.Invoke(this, templateElement);
         return result;
     }
 
-    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral, object? context)
     {
         VisitingTemplateLiteral?.Invoke(this, templateLiteral);
-        var result = base.VisitTemplateLiteral(templateLiteral);
+        var result = base.VisitTemplateLiteral(templateLiteral, context);
         VisitedTemplateLiteral?.Invoke(this, templateLiteral);
         return result;
     }
 
-    protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+    protected internal override object? VisitThisExpression(ThisExpression thisExpression, object? context)
     {
         VisitingThisExpression?.Invoke(this, thisExpression);
-        var result = base.VisitThisExpression(thisExpression);
+        var result = base.VisitThisExpression(thisExpression, context);
         VisitedThisExpression?.Invoke(this, thisExpression);
         return result;
     }
 
-    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement, object? context)
     {
         VisitingThrowStatement?.Invoke(this, throwStatement);
-        var result = base.VisitThrowStatement(throwStatement);
+        var result = base.VisitThrowStatement(throwStatement, context);
         VisitedThrowStatement?.Invoke(this, throwStatement);
         return result;
     }
 
-    protected internal override object? VisitTryStatement(TryStatement tryStatement)
+    protected internal override object? VisitTryStatement(TryStatement tryStatement, object? context)
     {
         VisitingTryStatement?.Invoke(this, tryStatement);
-        var result = base.VisitTryStatement(tryStatement);
+        var result = base.VisitTryStatement(tryStatement, context);
         VisitedTryStatement?.Invoke(this, tryStatement);
         return result;
     }
 
-    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression, object? context)
     {
         VisitingUnaryExpression?.Invoke(this, unaryExpression);
-        var result = base.VisitUnaryExpression(unaryExpression);
+        var result = base.VisitUnaryExpression(unaryExpression, context);
         VisitedUnaryExpression?.Invoke(this, unaryExpression);
         return result;
     }
 
-    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration, object? context)
     {
         VisitingVariableDeclaration?.Invoke(this, variableDeclaration);
-        var result = base.VisitVariableDeclaration(variableDeclaration);
+        var result = base.VisitVariableDeclaration(variableDeclaration, context);
         VisitedVariableDeclaration?.Invoke(this, variableDeclaration);
         return result;
     }
 
-    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator, object? context)
     {
         VisitingVariableDeclarator?.Invoke(this, variableDeclarator);
-        var result = base.VisitVariableDeclarator(variableDeclarator);
+        var result = base.VisitVariableDeclarator(variableDeclarator, context);
         VisitedVariableDeclarator?.Invoke(this, variableDeclarator);
         return result;
     }
 
-    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+    protected internal override object? VisitWhileStatement(WhileStatement whileStatement, object? context)
     {
         VisitingWhileStatement?.Invoke(this, whileStatement);
-        var result = base.VisitWhileStatement(whileStatement);
+        var result = base.VisitWhileStatement(whileStatement, context);
         VisitedWhileStatement?.Invoke(this, whileStatement);
         return result;
     }
 
-    protected internal override object? VisitWithStatement(WithStatement withStatement)
+    protected internal override object? VisitWithStatement(WithStatement withStatement, object? context)
     {
         VisitingWithStatement?.Invoke(this, withStatement);
-        var result = base.VisitWithStatement(withStatement);
+        var result = base.VisitWithStatement(withStatement, context);
         VisitedWithStatement?.Invoke(this, withStatement);
         return result;
     }
 
-    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression, object? context)
     {
         VisitingYieldExpression?.Invoke(this, yieldExpression);
-        var result = base.VisitYieldExpression(yieldExpression);
+        var result = base.VisitYieldExpression(yieldExpression, context);
         VisitedYieldExpression?.Invoke(this, yieldExpression);
         return result;
     }

--- a/src/Esprima/Utils/Jsx/IJsxAstVisitor.cs
+++ b/src/Esprima/Utils/Jsx/IJsxAstVisitor.cs
@@ -4,17 +4,17 @@ namespace Esprima.Utils.Jsx;
 
 public interface IJsxAstVisitor
 {
-    object? VisitJsxAttribute(JsxAttribute jsxAttribute);
-    object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement);
-    object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment);
-    object? VisitJsxElement(JsxElement jsxElement);
-    object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression);
-    object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer);
-    object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier);
-    object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression);
-    object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName);
-    object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement);
-    object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment);
-    object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute);
-    object? VisitJsxText(JsxText jsxText);
+    object? VisitJsxAttribute(JsxAttribute jsxAttribute, object? context);
+    object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context);
+    object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context);
+    object? VisitJsxElement(JsxElement jsxElement, object? context);
+    object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context);
+    object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context);
+    object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context);
+    object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context);
+    object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context);
+    object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context);
+    object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context);
+    object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context);
+    object? VisitJsxText(JsxText jsxText, object? context);
 }

--- a/src/Esprima/Utils/Jsx/JsxAstJson.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstJson.cs
@@ -33,7 +33,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return base.GetNodeType(node);
         }
 
-        object? IJsxAstVisitor.VisitJsxAttribute(JsxAttribute jsxAttribute)
+        object? IJsxAstVisitor.VisitJsxAttribute(JsxAttribute jsxAttribute, object? context)
         {
             using (StartNodeObject(jsxAttribute))
             {
@@ -44,7 +44,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxAttribute;
         }
 
-        object? IJsxAstVisitor.VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+        object? IJsxAstVisitor.VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context)
         {
             using (StartNodeObject(jsxClosingElement))
             {
@@ -54,7 +54,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxClosingElement;
         }
 
-        object? IJsxAstVisitor.VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
+        object? IJsxAstVisitor.VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context)
         {
             using (StartNodeObject(jsxClosingFragment))
             {
@@ -63,7 +63,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxClosingFragment;
         }
 
-        object? IJsxAstVisitor.VisitJsxElement(JsxElement jsxElement)
+        object? IJsxAstVisitor.VisitJsxElement(JsxElement jsxElement, object? context)
         {
             using (StartNodeObject(jsxElement))
             {
@@ -75,7 +75,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxElement;
         }
 
-        object? IJsxAstVisitor.VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+        object? IJsxAstVisitor.VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context)
         {
             using (StartNodeObject(jsxEmptyExpression))
             {
@@ -84,7 +84,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxEmptyExpression;
         }
 
-        object? IJsxAstVisitor.VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+        object? IJsxAstVisitor.VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context)
         {
             using (StartNodeObject(jsxExpressionContainer))
             {
@@ -94,7 +94,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxExpressionContainer;
         }
 
-        object? IJsxAstVisitor.VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+        object? IJsxAstVisitor.VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context)
         {
             using (StartNodeObject(jsxIdentifier))
             {
@@ -104,7 +104,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxIdentifier;
         }
 
-        object? IJsxAstVisitor.VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+        object? IJsxAstVisitor.VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context)
         {
             using (StartNodeObject(jsxMemberExpression))
             {
@@ -115,7 +115,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxMemberExpression;
         }
 
-        object? IJsxAstVisitor.VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+        object? IJsxAstVisitor.VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context)
         {
             using (StartNodeObject(jsxNamespacedName))
             {
@@ -126,7 +126,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxNamespacedName;
         }
 
-        object? IJsxAstVisitor.VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+        object? IJsxAstVisitor.VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context)
         {
             using (StartNodeObject(jsxOpeningElement))
             {
@@ -138,7 +138,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxOpeningElement;
         }
 
-        object? IJsxAstVisitor.VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+        object? IJsxAstVisitor.VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context)
         {
             using (StartNodeObject(jsxOpeningFragment))
             {
@@ -148,7 +148,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxOpeningFragment;
         }
 
-        object? IJsxAstVisitor.VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+        object? IJsxAstVisitor.VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context)
         {
             using (StartNodeObject(jsxSpreadAttribute))
             {
@@ -158,7 +158,7 @@ public sealed class JsxAstToJsonConverter : AstToJsonConverter
             return jsxSpreadAttribute;
         }
 
-        object? IJsxAstVisitor.VisitJsxText(JsxText jsxText)
+        object? IJsxAstVisitor.VisitJsxText(JsxText jsxText, object? context)
         {
             using (StartNodeObject(jsxText))
             {

--- a/src/Esprima/Utils/Jsx/JsxAstRewriter.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstRewriter.cs
@@ -29,90 +29,90 @@ public class JsxAstRewriter : AstRewriter, IJsxAstVisitor
         _jsxVisitor = JsxAstVisitor.CreateJsxVisitorFor(this);
     }
 
-    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute, object? context)
     {
-        var name = _rewriter.VisitAndConvert(jsxAttribute.Name);
-        var value = _rewriter.VisitAndConvert(jsxAttribute.Value, allowNull: true);
+        var name = _rewriter.VisitAndConvert(jsxAttribute.Name, context);
+        var value = _rewriter.VisitAndConvert(jsxAttribute.Value, context, allowNull: true);
 
         return jsxAttribute.UpdateWith(name, value);
     }
 
-    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context)
     {
-        var name = _rewriter.VisitAndConvert(jsxClosingElement.Name);
+        var name = _rewriter.VisitAndConvert(jsxClosingElement.Name, context);
 
         return jsxClosingElement.UpdateWith(name);
     }
 
-    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
+    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context)
     {
-        return _jsxVisitor.VisitJsxClosingFragment(jsxClosingFragment);
+        return _jsxVisitor.VisitJsxClosingFragment(jsxClosingFragment, context);
     }
 
-    public virtual object? VisitJsxElement(JsxElement jsxElement)
+    public virtual object? VisitJsxElement(JsxElement jsxElement, object? context)
     {
-        var openingElement = _rewriter.VisitAndConvert(jsxElement.OpeningElement);
-        _rewriter.VisitAndConvert(jsxElement.Children, out var children);
-        var closingElement = _rewriter.VisitAndConvert(jsxElement.ClosingElement, allowNull: true);
+        var openingElement = _rewriter.VisitAndConvert(jsxElement.OpeningElement, context);
+        _rewriter.VisitAndConvert(jsxElement.Children, out var children, context);
+        var closingElement = _rewriter.VisitAndConvert(jsxElement.ClosingElement, context, allowNull: true);
 
         return jsxElement.UpdateWith(openingElement, children, closingElement);
     }
 
-    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context)
     {
-        return _jsxVisitor.VisitJsxEmptyExpression(jsxEmptyExpression);
+        return _jsxVisitor.VisitJsxEmptyExpression(jsxEmptyExpression, context);
     }
 
-    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context)
     {
-        var expression = _rewriter.VisitAndConvert(jsxExpressionContainer.Expression);
+        var expression = _rewriter.VisitAndConvert(jsxExpressionContainer.Expression, context);
 
         return jsxExpressionContainer.UpdateWith(expression);
     }
 
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context)
     {
-        return _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
+        return _jsxVisitor.VisitJsxIdentifier(jsxIdentifier, context);
     }
 
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context)
     {
-        var obj = _rewriter.VisitAndConvert(jsxMemberExpression.Object);
-        var property = _rewriter.VisitAndConvert(jsxMemberExpression.Property);
+        var obj = _rewriter.VisitAndConvert(jsxMemberExpression.Object, context);
+        var property = _rewriter.VisitAndConvert(jsxMemberExpression.Property, context);
 
         return jsxMemberExpression.UpdateWith(obj, property);
     }
 
-    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context)
     {
-        var name = _rewriter.VisitAndConvert(jsxNamespacedName.Name);
-        var @namespace = _rewriter.VisitAndConvert(jsxNamespacedName.Namespace);
+        var name = _rewriter.VisitAndConvert(jsxNamespacedName.Name, context);
+        var @namespace = _rewriter.VisitAndConvert(jsxNamespacedName.Namespace, context);
 
         return jsxNamespacedName.UpdateWith(name, @namespace);
     }
 
-    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context)
     {
-        var name = _rewriter.VisitAndConvert(jsxOpeningElement.Name);
-        _rewriter.VisitAndConvert(jsxOpeningElement.Attributes, out var attributes);
+        var name = _rewriter.VisitAndConvert(jsxOpeningElement.Name, context);
+        _rewriter.VisitAndConvert(jsxOpeningElement.Attributes, out var attributes, context);
 
         return jsxOpeningElement.UpdateWith(name, attributes);
     }
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context)
     {
-        return _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
+        return _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment, context);
     }
 
-    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context)
     {
-        var argument = _rewriter.VisitAndConvert(jsxSpreadAttribute.Argument);
+        var argument = _rewriter.VisitAndConvert(jsxSpreadAttribute.Argument, context);
 
         return jsxSpreadAttribute.UpdateWith(argument);
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
+    public virtual object? VisitJsxText(JsxText jsxText, object? context)
     {
-        return _jsxVisitor.VisitJsxText(jsxText);
+        return _jsxVisitor.VisitJsxText(jsxText, context);
     }
 }

--- a/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstVisitor.cs
@@ -26,104 +26,104 @@ public class JsxAstVisitor : AstVisitor, IJsxAstVisitor
         _visitor = visitor;
     }
 
-    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute, object? context)
     {
-        _visitor.Visit(jsxAttribute.Name);
+        _visitor.Visit(jsxAttribute.Name, context);
         if (jsxAttribute.Value is not null)
         {
-            _visitor.Visit(jsxAttribute.Value);
+            _visitor.Visit(jsxAttribute.Value, context);
         }
 
         return jsxAttribute;
     }
 
-    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context)
     {
-        _visitor.Visit(jsxClosingElement.Name);
+        _visitor.Visit(jsxClosingElement.Name, context);
 
         return jsxClosingElement;
     }
 
-    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
+    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context)
     {
         return jsxClosingFragment;
     }
 
-    public virtual object? VisitJsxElement(JsxElement jsxElement)
+    public virtual object? VisitJsxElement(JsxElement jsxElement, object? context)
     {
-        _visitor.Visit(jsxElement.OpeningElement);
+        _visitor.Visit(jsxElement.OpeningElement, context);
         ref readonly var children = ref jsxElement.Children;
         for (var i = 0; i < children.Count; i++)
         {
-            _visitor.Visit(children[i]);
+            _visitor.Visit(children[i], context);
         }
 
         if (jsxElement.ClosingElement is not null)
         {
-            _visitor.Visit(jsxElement.ClosingElement);
+            _visitor.Visit(jsxElement.ClosingElement, context);
         }
 
         return jsxElement;
     }
 
-    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context)
     {
         return jsxEmptyExpression;
     }
 
-    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context)
     {
-        _visitor.Visit(jsxExpressionContainer.Expression);
+        _visitor.Visit(jsxExpressionContainer.Expression, context);
 
         return jsxExpressionContainer;
     }
 
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context)
     {
         return jsxIdentifier;
     }
 
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context)
     {
-        _visitor.Visit(jsxMemberExpression.Object);
-        _visitor.Visit(jsxMemberExpression.Property);
+        _visitor.Visit(jsxMemberExpression.Object, context);
+        _visitor.Visit(jsxMemberExpression.Property, context);
 
         return jsxMemberExpression;
     }
 
-    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context)
     {
-        _visitor.Visit(jsxNamespacedName.Name);
-        _visitor.Visit(jsxNamespacedName.Namespace);
+        _visitor.Visit(jsxNamespacedName.Name, context);
+        _visitor.Visit(jsxNamespacedName.Namespace, context);
 
         return jsxNamespacedName;
     }
 
-    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context)
     {
-        _visitor.Visit(jsxOpeningElement.Name);
+        _visitor.Visit(jsxOpeningElement.Name, context);
         ref readonly var attributes = ref jsxOpeningElement.Attributes;
         for (var i = 0; i < attributes.Count; i++)
         {
-            _visitor.Visit(attributes[i]);
+            _visitor.Visit(attributes[i], context);
         }
 
         return jsxOpeningElement;
     }
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context)
     {
         return jsxOpeningFragment;
     }
 
-    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context)
     {
-        _visitor.Visit(jsxSpreadAttribute.Argument);
+        _visitor.Visit(jsxSpreadAttribute.Argument, context);
 
         return jsxSpreadAttribute;
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
+    public virtual object? VisitJsxText(JsxText jsxText, object? context)
     {
         return jsxText;
     }

--- a/src/Esprima/Utils/Jsx/JsxAstVisitorEventSource.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstVisitorEventSource.cs
@@ -38,106 +38,106 @@ public class JsxAstVisitorEventSource : AstVisitorEventSource, IJsxAstVisitor
         _jsxVisitor = JsxAstVisitor.CreateJsxVisitorFor(this);
     }
 
-    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public virtual object? VisitJsxAttribute(JsxAttribute jsxAttribute, object? context)
     {
         VisitingJsxAttribute?.Invoke(this, jsxAttribute);
-        var node = _jsxVisitor.VisitJsxAttribute(jsxAttribute);
+        var node = _jsxVisitor.VisitJsxAttribute(jsxAttribute, context);
         VisitedJsxAttribute?.Invoke(this, jsxAttribute);
         return node;
     }
 
-    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+    public virtual object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context)
     {
         VisitingJsxClosingElement?.Invoke(this, jsxClosingElement);
-        var node = _jsxVisitor.VisitJsxClosingElement(jsxClosingElement);
+        var node = _jsxVisitor.VisitJsxClosingElement(jsxClosingElement, context);
         VisitedJsxClosingElement?.Invoke(this, jsxClosingElement);
         return node;
     }
 
-    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
+    public virtual object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context)
     {
         VisitingJsxClosingFragment?.Invoke(this, jsxClosingFragment);
-        var node = _jsxVisitor.VisitJsxClosingFragment(jsxClosingFragment);
+        var node = _jsxVisitor.VisitJsxClosingFragment(jsxClosingFragment, context);
         VisitedJsxClosingFragment?.Invoke(this, jsxClosingFragment);
         return node;
     }
 
-    public virtual object? VisitJsxElement(JsxElement jsxElement)
+    public virtual object? VisitJsxElement(JsxElement jsxElement, object? context)
     {
         VisitingJsxElement?.Invoke(this, jsxElement);
-        var node = _jsxVisitor.VisitJsxElement(jsxElement);
+        var node = _jsxVisitor.VisitJsxElement(jsxElement, context);
         VisitedJsxElement?.Invoke(this, jsxElement);
         return node;
     }
 
-    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+    public virtual object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context)
     {
         VisitingJsxEmptyExpression?.Invoke(this, jsxEmptyExpression);
-        var node = _jsxVisitor.VisitJsxEmptyExpression(jsxEmptyExpression);
+        var node = _jsxVisitor.VisitJsxEmptyExpression(jsxEmptyExpression, context);
         VisitedJsxEmptyExpression?.Invoke(this, jsxEmptyExpression);
         return node;
     }
 
-    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    public virtual object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context)
     {
         VisitingJsxExpressionContainer?.Invoke(this, jsxExpressionContainer);
-        var node = _jsxVisitor.VisitJsxExpressionContainer(jsxExpressionContainer);
+        var node = _jsxVisitor.VisitJsxExpressionContainer(jsxExpressionContainer, context);
         VisitedJsxExpressionContainer?.Invoke(this, jsxExpressionContainer);
         return node;
     }
 
-    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    public virtual object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context)
     {
         VisitingJsxIdentifier?.Invoke(this, jsxIdentifier);
-        var node = _jsxVisitor.VisitJsxIdentifier(jsxIdentifier);
+        var node = _jsxVisitor.VisitJsxIdentifier(jsxIdentifier, context);
         VisitedJsxIdentifier?.Invoke(this, jsxIdentifier);
         return node;
     }
 
-    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public virtual object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context)
     {
         VisitingJsxMemberExpression?.Invoke(this, jsxMemberExpression);
-        var node = _jsxVisitor.VisitJsxMemberExpression(jsxMemberExpression);
+        var node = _jsxVisitor.VisitJsxMemberExpression(jsxMemberExpression, context);
         VisitedJsxMemberExpression?.Invoke(this, jsxMemberExpression);
         return node;
     }
 
-    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    public virtual object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context)
     {
         VisitingJsxNamespacedName?.Invoke(this, jsxNamespacedName);
-        var node = _jsxVisitor.VisitJsxNamespacedName(jsxNamespacedName);
+        var node = _jsxVisitor.VisitJsxNamespacedName(jsxNamespacedName, context);
         VisitedJsxNamespacedName?.Invoke(this, jsxNamespacedName);
         return node;
     }
 
-    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    public virtual object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context)
     {
         VisitingJsxOpeningElement?.Invoke(this, jsxOpeningElement);
-        var node = _jsxVisitor.VisitJsxOpeningElement(jsxOpeningElement);
+        var node = _jsxVisitor.VisitJsxOpeningElement(jsxOpeningElement, context);
         VisitedJsxOpeningElement?.Invoke(this, jsxOpeningElement);
         return node;
     }
 
-    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    public virtual object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context)
     {
         VisitingJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
-        var node = _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment);
+        var node = _jsxVisitor.VisitJsxOpeningFragment(jsxOpeningFragment, context);
         VisitedJsxOpeningFragment?.Invoke(this, jsxOpeningFragment);
         return node;
     }
 
-    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+    public virtual object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context)
     {
         VisitingJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
-        var node = _jsxVisitor.VisitJsxSpreadAttribute(jsxSpreadAttribute);
+        var node = _jsxVisitor.VisitJsxSpreadAttribute(jsxSpreadAttribute, context);
         VisitedJsxSpreadAttribute?.Invoke(this, jsxSpreadAttribute);
         return node;
     }
 
-    public virtual object? VisitJsxText(JsxText jsxText)
+    public virtual object? VisitJsxText(JsxText jsxText, object? context)
     {
         VisitingJsxText?.Invoke(this, jsxText);
-        var node = _jsxVisitor.VisitJsxText(jsxText);
+        var node = _jsxVisitor.VisitJsxText(jsxText, context);
         VisitedJsxText?.Invoke(this, jsxText);
         return node;
     }

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -199,9 +199,9 @@ sealed class TestRewriter : JsxAstRewriter
         return _controlType == node?.GetType() ? createNew(node) : node;
     }
 
-    protected internal override object? VisitProgram(Program program)
+    protected internal override object? VisitProgram(Program program, object? context)
     {
-        return ForceNewObjectByControlType((Program) base.VisitProgram(program)!,
+        return ForceNewObjectByControlType((Program) base.VisitProgram(program, context)!,
             node => program switch
             {
                 Module => new Module(node.Body),
@@ -210,93 +210,93 @@ sealed class TestRewriter : JsxAstRewriter
             });
     }
 
-    protected internal override object? VisitCatchClause(CatchClause catchClause)
+    protected internal override object? VisitCatchClause(CatchClause catchClause, object? context)
     {
-        return ForceNewObjectByControlType((CatchClause) base.VisitCatchClause(catchClause)!,
+        return ForceNewObjectByControlType((CatchClause) base.VisitCatchClause(catchClause, context)!,
             node => new CatchClause(node.Param, node.Body));
     }
 
-    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration)
+    protected internal override object? VisitFunctionDeclaration(FunctionDeclaration functionDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((FunctionDeclaration) base.VisitFunctionDeclaration(functionDeclaration)!,
+        return ForceNewObjectByControlType((FunctionDeclaration) base.VisitFunctionDeclaration(functionDeclaration, context)!,
             node => new FunctionDeclaration(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
-    protected internal override object? VisitWithStatement(WithStatement withStatement)
+    protected internal override object? VisitWithStatement(WithStatement withStatement, object? context)
     {
-        return ForceNewObjectByControlType((WithStatement) base.VisitWithStatement(withStatement)!,
+        return ForceNewObjectByControlType((WithStatement) base.VisitWithStatement(withStatement, context)!,
             node => new WithStatement(node.Object, node.Body));
     }
 
-    protected internal override object? VisitWhileStatement(WhileStatement whileStatement)
+    protected internal override object? VisitWhileStatement(WhileStatement whileStatement, object? context)
     {
-        return ForceNewObjectByControlType((WhileStatement) base.VisitWhileStatement(whileStatement)!,
+        return ForceNewObjectByControlType((WhileStatement) base.VisitWhileStatement(whileStatement, context)!,
             node => new WhileStatement(node.Test, node.Body));
     }
 
-    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration)
+    protected internal override object? VisitVariableDeclaration(VariableDeclaration variableDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((VariableDeclaration) base.VisitVariableDeclaration(variableDeclaration)!,
+        return ForceNewObjectByControlType((VariableDeclaration) base.VisitVariableDeclaration(variableDeclaration, context)!,
             node => new VariableDeclaration(node.Declarations, node.Kind));
     }
 
-    protected internal override object? VisitTryStatement(TryStatement tryStatement)
+    protected internal override object? VisitTryStatement(TryStatement tryStatement, object? context)
     {
-        return ForceNewObjectByControlType((TryStatement) base.VisitTryStatement(tryStatement)!,
+        return ForceNewObjectByControlType((TryStatement) base.VisitTryStatement(tryStatement, context)!,
             node => new TryStatement(node.Block, node.Handler, node.Finalizer));
     }
 
-    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement)
+    protected internal override object? VisitThrowStatement(ThrowStatement throwStatement, object? context)
     {
-        return ForceNewObjectByControlType((ThrowStatement) base.VisitThrowStatement(throwStatement)!,
+        return ForceNewObjectByControlType((ThrowStatement) base.VisitThrowStatement(throwStatement, context)!,
             node => new ThrowStatement(node.Argument));
     }
 
-    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement)
+    protected internal override object? VisitSwitchStatement(SwitchStatement switchStatement, object? context)
     {
-        return ForceNewObjectByControlType((SwitchStatement) base.VisitSwitchStatement(switchStatement)!,
+        return ForceNewObjectByControlType((SwitchStatement) base.VisitSwitchStatement(switchStatement, context)!,
             node => new SwitchStatement(node.Discriminant, node.Cases));
     }
 
-    protected internal override object? VisitSwitchCase(SwitchCase switchCase)
+    protected internal override object? VisitSwitchCase(SwitchCase switchCase, object? context)
     {
-        return ForceNewObjectByControlType((SwitchCase) base.VisitSwitchCase(switchCase)!,
+        return ForceNewObjectByControlType((SwitchCase) base.VisitSwitchCase(switchCase, context)!,
             node => new SwitchCase(node.Test, node.Consequent));
     }
 
-    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement)
+    protected internal override object? VisitReturnStatement(ReturnStatement returnStatement, object? context)
     {
-        return ForceNewObjectByControlType((ReturnStatement) base.VisitReturnStatement(returnStatement)!,
+        return ForceNewObjectByControlType((ReturnStatement) base.VisitReturnStatement(returnStatement, context)!,
             node => new ReturnStatement(node.Argument));
     }
 
-    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
+    protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement, object? context)
     {
-        return ForceNewObjectByControlType((LabeledStatement) base.VisitLabeledStatement(labeledStatement)!,
+        return ForceNewObjectByControlType((LabeledStatement) base.VisitLabeledStatement(labeledStatement, context)!,
             node => new LabeledStatement(node.Label, node.Body));
     }
 
-    protected internal override object? VisitIfStatement(IfStatement ifStatement)
+    protected internal override object? VisitIfStatement(IfStatement ifStatement, object? context)
     {
-        return ForceNewObjectByControlType((IfStatement) base.VisitIfStatement(ifStatement)!,
+        return ForceNewObjectByControlType((IfStatement) base.VisitIfStatement(ifStatement, context)!,
             node => new IfStatement(node.Test, node.Consequent, node.Alternate));
     }
 
-    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement)
+    protected internal override object? VisitEmptyStatement(EmptyStatement emptyStatement, object? context)
     {
-        return ForceNewObjectByControlType((EmptyStatement) base.VisitEmptyStatement(emptyStatement)!,
+        return ForceNewObjectByControlType((EmptyStatement) base.VisitEmptyStatement(emptyStatement, context)!,
             node => new EmptyStatement());
     }
 
-    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement)
+    protected internal override object? VisitDebuggerStatement(DebuggerStatement debuggerStatement, object? context)
     {
-        return ForceNewObjectByControlType((DebuggerStatement) base.VisitDebuggerStatement(debuggerStatement)!,
+        return ForceNewObjectByControlType((DebuggerStatement) base.VisitDebuggerStatement(debuggerStatement, context)!,
             node => new DebuggerStatement());
     }
 
-    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
+    protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement, object? context)
     {
-        return ForceNewObjectByControlType((ExpressionStatement) base.VisitExpressionStatement(expressionStatement)!,
+        return ForceNewObjectByControlType((ExpressionStatement) base.VisitExpressionStatement(expressionStatement, context)!,
             node => node switch
             {
                 Directive directive => new Directive(node.Expression, directive.Directiv),
@@ -304,33 +304,33 @@ sealed class TestRewriter : JsxAstRewriter
             });
     }
 
-    protected internal override object? VisitForStatement(ForStatement forStatement)
+    protected internal override object? VisitForStatement(ForStatement forStatement, object? context)
     {
-        return ForceNewObjectByControlType((ForStatement) base.VisitForStatement(forStatement)!,
+        return ForceNewObjectByControlType((ForStatement) base.VisitForStatement(forStatement, context)!,
             node => new ForStatement(node.Init, node.Test, node.Update, node.Body));
     }
 
-    protected internal override object? VisitForInStatement(ForInStatement forInStatement)
+    protected internal override object? VisitForInStatement(ForInStatement forInStatement, object? context)
     {
-        return ForceNewObjectByControlType((ForInStatement) base.VisitForInStatement(forInStatement)!,
+        return ForceNewObjectByControlType((ForInStatement) base.VisitForInStatement(forInStatement, context)!,
             node => new ForInStatement(node.Left, node.Right, node.Body));
     }
 
-    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement)
+    protected internal override object? VisitDoWhileStatement(DoWhileStatement doWhileStatement, object? context)
     {
-        return ForceNewObjectByControlType((DoWhileStatement) base.VisitDoWhileStatement(doWhileStatement)!,
+        return ForceNewObjectByControlType((DoWhileStatement) base.VisitDoWhileStatement(doWhileStatement, context)!,
             node => new DoWhileStatement(node.Body, node.Test));
     }
 
-    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression)
+    protected internal override object? VisitArrowFunctionExpression(ArrowFunctionExpression arrowFunctionExpression, object? context)
     {
-        return ForceNewObjectByControlType((ArrowFunctionExpression) base.VisitArrowFunctionExpression(arrowFunctionExpression)!,
+        return ForceNewObjectByControlType((ArrowFunctionExpression) base.VisitArrowFunctionExpression(arrowFunctionExpression, context)!,
             node => new ArrowFunctionExpression(node.Params, node.Body, node.Expression, node.Strict, node.Async));
     }
 
-    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression)
+    protected internal override object? VisitUnaryExpression(UnaryExpression unaryExpression, object? context)
     {
-        return ForceNewObjectByControlType((UnaryExpression) base.VisitUnaryExpression(unaryExpression)!,
+        return ForceNewObjectByControlType((UnaryExpression) base.VisitUnaryExpression(unaryExpression, context)!,
             node => node.Type switch
             {
                 Nodes.UpdateExpression => new UpdateExpression(node.Operator, node.Argument, node.Prefix),
@@ -338,33 +338,33 @@ sealed class TestRewriter : JsxAstRewriter
             });
     }
 
-    protected internal override object? VisitThisExpression(ThisExpression thisExpression)
+    protected internal override object? VisitThisExpression(ThisExpression thisExpression, object? context)
     {
-        return ForceNewObjectByControlType((ThisExpression) base.VisitThisExpression(thisExpression)!,
+        return ForceNewObjectByControlType((ThisExpression) base.VisitThisExpression(thisExpression, context)!,
             node => new ThisExpression());
     }
 
-    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression)
+    protected internal override object? VisitSequenceExpression(SequenceExpression sequenceExpression, object? context)
     {
-        return ForceNewObjectByControlType((SequenceExpression) base.VisitSequenceExpression(sequenceExpression)!,
+        return ForceNewObjectByControlType((SequenceExpression) base.VisitSequenceExpression(sequenceExpression, context)!,
             node => new SequenceExpression(node.Expressions));
     }
 
-    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression)
+    protected internal override object? VisitObjectExpression(ObjectExpression objectExpression, object? context)
     {
-        return ForceNewObjectByControlType((ObjectExpression) base.VisitObjectExpression(objectExpression)!,
+        return ForceNewObjectByControlType((ObjectExpression) base.VisitObjectExpression(objectExpression, context)!,
             node => new ObjectExpression(node.Properties));
     }
 
-    protected internal override object? VisitNewExpression(NewExpression newExpression)
+    protected internal override object? VisitNewExpression(NewExpression newExpression, object? context)
     {
-        return ForceNewObjectByControlType((NewExpression) base.VisitNewExpression(newExpression)!,
+        return ForceNewObjectByControlType((NewExpression) base.VisitNewExpression(newExpression, context)!,
             node => new NewExpression(node.Callee, node.Arguments));
     }
 
-    protected internal override object? VisitMemberExpression(MemberExpression memberExpression)
+    protected internal override object? VisitMemberExpression(MemberExpression memberExpression, object? context)
     {
-        return ForceNewObjectByControlType((MemberExpression) base.VisitMemberExpression(memberExpression)!,
+        return ForceNewObjectByControlType((MemberExpression) base.VisitMemberExpression(memberExpression, context)!,
             node => memberExpression.Computed switch
             {
                 true => new ComputedMemberExpression(node.Object, node.Property, memberExpression.Optional),
@@ -372,9 +372,9 @@ sealed class TestRewriter : JsxAstRewriter
             });
     }
 
-    protected internal override object? VisitLiteral(Literal literal)
+    protected internal override object? VisitLiteral(Literal literal, object? context)
     {
-        return ForceNewObjectByControlType((Literal) base.VisitLiteral(literal)!,
+        return ForceNewObjectByControlType((Literal) base.VisitLiteral(literal, context)!,
             node => node.TokenType switch
             {
                 TokenType.RegularExpression => new Literal(node.Regex!.Pattern, node.Regex.Flags, node.Value, node.Raw),
@@ -382,333 +382,333 @@ sealed class TestRewriter : JsxAstRewriter
             });
     }
 
-    protected internal override object? VisitIdentifier(Identifier identifier)
+    protected internal override object? VisitIdentifier(Identifier identifier, object? context)
     {
-        return ForceNewObjectByControlType((Identifier) base.VisitIdentifier(identifier)!,
+        return ForceNewObjectByControlType((Identifier) base.VisitIdentifier(identifier, context)!,
             node => new Identifier(node.Name));
     }
 
-    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier)
+    protected internal override object? VisitPrivateIdentifier(PrivateIdentifier privateIdentifier, object? context)
     {
-        return ForceNewObjectByControlType((PrivateIdentifier) base.VisitPrivateIdentifier(privateIdentifier)!,
+        return ForceNewObjectByControlType((PrivateIdentifier) base.VisitPrivateIdentifier(privateIdentifier, context)!,
             node => new PrivateIdentifier(node.Name));
     }
 
-    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression)
+    protected internal override object? VisitFunctionExpression(FunctionExpression functionExpression, object? context)
     {
-        return ForceNewObjectByControlType((FunctionExpression) base.VisitFunctionExpression(functionExpression)!,
+        return ForceNewObjectByControlType((FunctionExpression) base.VisitFunctionExpression(functionExpression, context)!,
             node => new FunctionExpression(node.Id, node.Params, node.Body, node.Generator, node.Strict, node.Async));
     }
 
-    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition)
+    protected internal override object? VisitPropertyDefinition(PropertyDefinition propertyDefinition, object? context)
     {
-        return ForceNewObjectByControlType((PropertyDefinition) base.VisitPropertyDefinition(propertyDefinition)!,
+        return ForceNewObjectByControlType((PropertyDefinition) base.VisitPropertyDefinition(propertyDefinition, context)!,
             node => new PropertyDefinition(node.Key, node.Computed, node.Value!, node.Static, node.Decorators));
     }
 
-    protected internal override object? VisitChainExpression(ChainExpression chainExpression)
+    protected internal override object? VisitChainExpression(ChainExpression chainExpression, object? context)
     {
-        return ForceNewObjectByControlType((ChainExpression) base.VisitChainExpression(chainExpression)!,
+        return ForceNewObjectByControlType((ChainExpression) base.VisitChainExpression(chainExpression, context)!,
             node => new ChainExpression(node.Expression));
     }
 
-    protected internal override object? VisitClassExpression(ClassExpression classExpression)
+    protected internal override object? VisitClassExpression(ClassExpression classExpression, object? context)
     {
-        return ForceNewObjectByControlType((ClassExpression) base.VisitClassExpression(classExpression)!,
+        return ForceNewObjectByControlType((ClassExpression) base.VisitClassExpression(classExpression, context)!,
             node => new ClassExpression(node.Id, node.SuperClass, node.Body, node.Decorators));
     }
 
-    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration)
+    protected internal override object? VisitExportDefaultDeclaration(ExportDefaultDeclaration exportDefaultDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((ExportDefaultDeclaration) base.VisitExportDefaultDeclaration(exportDefaultDeclaration)!,
+        return ForceNewObjectByControlType((ExportDefaultDeclaration) base.VisitExportDefaultDeclaration(exportDefaultDeclaration, context)!,
             node => new ExportDefaultDeclaration(node.Declaration));
     }
 
-    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration)
+    protected internal override object? VisitExportAllDeclaration(ExportAllDeclaration exportAllDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((ExportAllDeclaration) base.VisitExportAllDeclaration(exportAllDeclaration)!,
+        return ForceNewObjectByControlType((ExportAllDeclaration) base.VisitExportAllDeclaration(exportAllDeclaration, context)!,
             node => new ExportAllDeclaration(node.Source, node.Exported, exportAllDeclaration.Assertions));
     }
 
-    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration)
+    protected internal override object? VisitExportNamedDeclaration(ExportNamedDeclaration exportNamedDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((ExportNamedDeclaration) base.VisitExportNamedDeclaration(exportNamedDeclaration)!,
+        return ForceNewObjectByControlType((ExportNamedDeclaration) base.VisitExportNamedDeclaration(exportNamedDeclaration, context)!,
             node => new ExportNamedDeclaration(node.Declaration, node.Specifiers, node.Source, exportNamedDeclaration.Assertions));
     }
 
-    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier)
+    protected internal override object? VisitExportSpecifier(ExportSpecifier exportSpecifier, object? context)
     {
-        return ForceNewObjectByControlType((ExportSpecifier) base.VisitExportSpecifier(exportSpecifier)!,
+        return ForceNewObjectByControlType((ExportSpecifier) base.VisitExportSpecifier(exportSpecifier, context)!,
             node => new ExportSpecifier(node.Local, node.Exported));
     }
 
-    protected internal override object? VisitImport(Import import)
+    protected internal override object? VisitImport(Import import, object? context)
     {
-        return ForceNewObjectByControlType((Import) base.VisitImport(import)!,
+        return ForceNewObjectByControlType((Import) base.VisitImport(import, context)!,
             node => new Import(node.Source, import.Attributes));
     }
 
-    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
+    protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((ImportDeclaration) base.VisitImportDeclaration(importDeclaration)!,
+        return ForceNewObjectByControlType((ImportDeclaration) base.VisitImportDeclaration(importDeclaration, context)!,
             node => new ImportDeclaration(node.Specifiers, node.Source, importDeclaration.Assertions));
     }
 
-    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)
+    protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier, object? context)
     {
-        return ForceNewObjectByControlType((ImportNamespaceSpecifier) base.VisitImportNamespaceSpecifier(importNamespaceSpecifier)!,
+        return ForceNewObjectByControlType((ImportNamespaceSpecifier) base.VisitImportNamespaceSpecifier(importNamespaceSpecifier, context)!,
             node => new ImportNamespaceSpecifier(node.Local));
     }
 
-    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier)
+    protected internal override object? VisitImportDefaultSpecifier(ImportDefaultSpecifier importDefaultSpecifier, object? context)
     {
-        return ForceNewObjectByControlType((ImportDefaultSpecifier) base.VisitImportDefaultSpecifier(importDefaultSpecifier)!,
+        return ForceNewObjectByControlType((ImportDefaultSpecifier) base.VisitImportDefaultSpecifier(importDefaultSpecifier, context)!,
             node => new ImportDefaultSpecifier(node.Local));
     }
 
-    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier)
+    protected internal override object? VisitImportSpecifier(ImportSpecifier importSpecifier, object? context)
     {
-        return ForceNewObjectByControlType((ImportSpecifier) base.VisitImportSpecifier(importSpecifier)!,
+        return ForceNewObjectByControlType((ImportSpecifier) base.VisitImportSpecifier(importSpecifier, context)!,
             node => new ImportSpecifier(node.Local, node.Imported));
     }
 
-    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition)
+    protected internal override object? VisitMethodDefinition(MethodDefinition methodDefinition, object? context)
     {
-        return ForceNewObjectByControlType((MethodDefinition) base.VisitMethodDefinition(methodDefinition)!,
+        return ForceNewObjectByControlType((MethodDefinition) base.VisitMethodDefinition(methodDefinition, context)!,
             node => new MethodDefinition(node.Key, node.Computed, node.Value, node.Kind, node.Static, node.Decorators));
     }
 
-    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement)
+    protected internal override object? VisitForOfStatement(ForOfStatement forOfStatement, object? context)
     {
-        return ForceNewObjectByControlType((ForOfStatement) base.VisitForOfStatement(forOfStatement)!,
+        return ForceNewObjectByControlType((ForOfStatement) base.VisitForOfStatement(forOfStatement, context)!,
             node => new ForOfStatement(node.Left, node.Right, node.Body, node.Await));
     }
 
-    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration)
+    protected internal override object? VisitClassDeclaration(ClassDeclaration classDeclaration, object? context)
     {
-        return ForceNewObjectByControlType((ClassDeclaration) base.VisitClassDeclaration(classDeclaration)!,
+        return ForceNewObjectByControlType((ClassDeclaration) base.VisitClassDeclaration(classDeclaration, context)!,
             node => new ClassDeclaration(node.Id, node.SuperClass, node.Body, node.Decorators));
     }
 
-    protected internal override object? VisitClassBody(ClassBody classBody)
+    protected internal override object? VisitClassBody(ClassBody classBody, object? context)
     {
-        return ForceNewObjectByControlType((ClassBody) base.VisitClassBody(classBody)!,
+        return ForceNewObjectByControlType((ClassBody) base.VisitClassBody(classBody, context)!,
             node => new ClassBody(node.Body));
     }
 
-    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression)
+    protected internal override object? VisitYieldExpression(YieldExpression yieldExpression, object? context)
     {
-        return ForceNewObjectByControlType((YieldExpression) base.VisitYieldExpression(yieldExpression)!,
+        return ForceNewObjectByControlType((YieldExpression) base.VisitYieldExpression(yieldExpression, context)!,
             node => new YieldExpression(node.Argument, yieldExpression.Delegate));
     }
 
-    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression)
+    protected internal override object? VisitTaggedTemplateExpression(TaggedTemplateExpression taggedTemplateExpression, object? context)
     {
-        return ForceNewObjectByControlType((TaggedTemplateExpression) base.VisitTaggedTemplateExpression(taggedTemplateExpression)!,
+        return ForceNewObjectByControlType((TaggedTemplateExpression) base.VisitTaggedTemplateExpression(taggedTemplateExpression, context)!,
             node => new TaggedTemplateExpression(node.Tag, node.Quasi));
     }
 
-    protected internal override object? VisitSuper(Super super)
+    protected internal override object? VisitSuper(Super super, object? context)
     {
-        return ForceNewObjectByControlType((Super) base.VisitSuper(super)!,
+        return ForceNewObjectByControlType((Super) base.VisitSuper(super, context)!,
             node => new Super());
     }
 
-    protected internal override object? VisitMetaProperty(MetaProperty metaProperty)
+    protected internal override object? VisitMetaProperty(MetaProperty metaProperty, object? context)
     {
-        return ForceNewObjectByControlType((MetaProperty) base.VisitMetaProperty(metaProperty)!,
+        return ForceNewObjectByControlType((MetaProperty) base.VisitMetaProperty(metaProperty, context)!,
             node => new MetaProperty(node.Meta, node.Property));
     }
 
-    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern)
+    protected internal override object? VisitObjectPattern(ObjectPattern objectPattern, object? context)
     {
-        return ForceNewObjectByControlType((ObjectPattern) base.VisitObjectPattern(objectPattern)!,
+        return ForceNewObjectByControlType((ObjectPattern) base.VisitObjectPattern(objectPattern, context)!,
             node => new ObjectPattern(node.Properties));
     }
 
-    protected internal override object? VisitSpreadElement(SpreadElement spreadElement)
+    protected internal override object? VisitSpreadElement(SpreadElement spreadElement, object? context)
     {
-        return ForceNewObjectByControlType((SpreadElement) base.VisitSpreadElement(spreadElement)!,
+        return ForceNewObjectByControlType((SpreadElement) base.VisitSpreadElement(spreadElement, context)!,
             node => new SpreadElement(node.Argument));
     }
 
-    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern)
+    protected internal override object? VisitAssignmentPattern(AssignmentPattern assignmentPattern, object? context)
     {
-        return ForceNewObjectByControlType((AssignmentPattern) base.VisitAssignmentPattern(assignmentPattern)!,
+        return ForceNewObjectByControlType((AssignmentPattern) base.VisitAssignmentPattern(assignmentPattern, context)!,
             node => new AssignmentPattern(node.Left, node.Right));
     }
 
-    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern)
+    protected internal override object? VisitArrayPattern(ArrayPattern arrayPattern, object? context)
     {
-        return ForceNewObjectByControlType((ArrayPattern) base.VisitArrayPattern(arrayPattern)!,
+        return ForceNewObjectByControlType((ArrayPattern) base.VisitArrayPattern(arrayPattern, context)!,
             node => new ArrayPattern(node.Elements));
     }
 
-    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator)
+    protected internal override object? VisitVariableDeclarator(VariableDeclarator variableDeclarator, object? context)
     {
-        return ForceNewObjectByControlType((VariableDeclarator) base.VisitVariableDeclarator(variableDeclarator)!,
+        return ForceNewObjectByControlType((VariableDeclarator) base.VisitVariableDeclarator(variableDeclarator, context)!,
             node => new VariableDeclarator(node.Id, node.Init));
     }
 
-    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral)
+    protected internal override object? VisitTemplateLiteral(TemplateLiteral templateLiteral, object? context)
     {
-        return ForceNewObjectByControlType((TemplateLiteral) base.VisitTemplateLiteral(templateLiteral)!,
+        return ForceNewObjectByControlType((TemplateLiteral) base.VisitTemplateLiteral(templateLiteral, context)!,
             node => new TemplateLiteral(node.Quasis, node.Expressions));
     }
 
-    protected internal override object? VisitTemplateElement(TemplateElement templateElement)
+    protected internal override object? VisitTemplateElement(TemplateElement templateElement, object? context)
     {
-        return ForceNewObjectByControlType((TemplateElement) base.VisitTemplateElement(templateElement)!,
+        return ForceNewObjectByControlType((TemplateElement) base.VisitTemplateElement(templateElement, context)!,
             node => new TemplateElement(node.Value, node.Tail));
     }
 
-    protected internal override object? VisitRestElement(RestElement restElement)
+    protected internal override object? VisitRestElement(RestElement restElement, object? context)
     {
-        return ForceNewObjectByControlType((RestElement) base.VisitRestElement(restElement)!,
+        return ForceNewObjectByControlType((RestElement) base.VisitRestElement(restElement, context)!,
             node => new RestElement(node.Argument));
     }
 
-    protected internal override object? VisitProperty(Property property)
+    protected internal override object? VisitProperty(Property property, object? context)
     {
-        return ForceNewObjectByControlType((Property) base.VisitProperty(property)!,
+        return ForceNewObjectByControlType((Property) base.VisitProperty(property, context)!,
             node => new Property(property.Kind, node.Key, property.Computed, node.Value, property.Method, property.Shorthand));
     }
 
-    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression)
+    protected internal override object? VisitAwaitExpression(AwaitExpression awaitExpression, object? context)
     {
-        return ForceNewObjectByControlType((AwaitExpression) base.VisitAwaitExpression(awaitExpression)!,
+        return ForceNewObjectByControlType((AwaitExpression) base.VisitAwaitExpression(awaitExpression, context)!,
             node => new AwaitExpression(node.Argument));
     }
 
-    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression)
+    protected internal override object? VisitConditionalExpression(ConditionalExpression conditionalExpression, object? context)
     {
-        return ForceNewObjectByControlType((ConditionalExpression) base.VisitConditionalExpression(conditionalExpression)!,
+        return ForceNewObjectByControlType((ConditionalExpression) base.VisitConditionalExpression(conditionalExpression, context)!,
             node => new ConditionalExpression(node.Test, node.Consequent, node.Alternate));
     }
 
-    protected internal override object? VisitCallExpression(CallExpression callExpression)
+    protected internal override object? VisitCallExpression(CallExpression callExpression, object? context)
     {
-        return ForceNewObjectByControlType((CallExpression) base.VisitCallExpression(callExpression)!,
+        return ForceNewObjectByControlType((CallExpression) base.VisitCallExpression(callExpression, context)!,
             node => new CallExpression(node.Callee, node.Arguments, callExpression.Optional));
     }
 
-    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression)
+    protected internal override object? VisitBinaryExpression(BinaryExpression binaryExpression, object? context)
     {
-        return ForceNewObjectByControlType((BinaryExpression) base.VisitBinaryExpression(binaryExpression)!,
+        return ForceNewObjectByControlType((BinaryExpression) base.VisitBinaryExpression(binaryExpression, context)!,
             node => new BinaryExpression(node.Operator, node.Left, node.Right));
     }
 
-    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression)
+    protected internal override object? VisitArrayExpression(ArrayExpression arrayExpression, object? context)
     {
-        return ForceNewObjectByControlType((ArrayExpression) base.VisitArrayExpression(arrayExpression)!,
+        return ForceNewObjectByControlType((ArrayExpression) base.VisitArrayExpression(arrayExpression, context)!,
             node => new ArrayExpression(node.Elements));
     }
 
-    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression)
+    protected internal override object? VisitAssignmentExpression(AssignmentExpression assignmentExpression, object? context)
     {
-        return ForceNewObjectByControlType((AssignmentExpression) base.VisitAssignmentExpression(assignmentExpression)!,
+        return ForceNewObjectByControlType((AssignmentExpression) base.VisitAssignmentExpression(assignmentExpression, context)!,
             node => new AssignmentExpression(node.Operator, node.Left, node.Right));
     }
 
-    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement)
+    protected internal override object? VisitContinueStatement(ContinueStatement continueStatement, object? context)
     {
-        return ForceNewObjectByControlType((ContinueStatement) base.VisitContinueStatement(continueStatement)!,
+        return ForceNewObjectByControlType((ContinueStatement) base.VisitContinueStatement(continueStatement, context)!,
             node => new ContinueStatement(node.Label));
     }
 
-    protected internal override object? VisitBreakStatement(BreakStatement breakStatement)
+    protected internal override object? VisitBreakStatement(BreakStatement breakStatement, object? context)
     {
-        return ForceNewObjectByControlType((BreakStatement) base.VisitBreakStatement(breakStatement)!,
+        return ForceNewObjectByControlType((BreakStatement) base.VisitBreakStatement(breakStatement, context)!,
             node => new BreakStatement(node.Label));
     }
 
-    protected internal override object? VisitBlockStatement(BlockStatement blockStatement)
+    protected internal override object? VisitBlockStatement(BlockStatement blockStatement, object? context)
     {
-        return ForceNewObjectByControlType((BlockStatement) base.VisitBlockStatement(blockStatement)!,
+        return ForceNewObjectByControlType((BlockStatement) base.VisitBlockStatement(blockStatement, context)!,
             node => new BlockStatement(node.Body));
     }
 
-    protected internal override object? VisitStaticBlock(StaticBlock staticBlock)
+    protected internal override object? VisitStaticBlock(StaticBlock staticBlock, object? context)
     {
-        return ForceNewObjectByControlType((StaticBlock) base.VisitStaticBlock(staticBlock)!,
+        return ForceNewObjectByControlType((StaticBlock) base.VisitStaticBlock(staticBlock, context)!,
             node => new StaticBlock(node.Body));
     }
 
-    public override object? VisitJsxAttribute(JsxAttribute jsxAttribute)
+    public override object? VisitJsxAttribute(JsxAttribute jsxAttribute, object? context)
     {
-        return ForceNewObjectByControlType((JsxAttribute) base.VisitJsxAttribute(jsxAttribute)!,
+        return ForceNewObjectByControlType((JsxAttribute) base.VisitJsxAttribute(jsxAttribute, context)!,
             node => new JsxAttribute(node.Name, node.Value));
     }
 
-    public override object? VisitJsxElement(JsxElement jsxElement)
+    public override object? VisitJsxElement(JsxElement jsxElement, object? context)
     {
-        return ForceNewObjectByControlType((JsxElement) base.VisitJsxElement(jsxElement)!,
+        return ForceNewObjectByControlType((JsxElement) base.VisitJsxElement(jsxElement, context)!,
             node => new JsxElement(node.OpeningElement, node.Children, node.ClosingElement));
     }
 
-    public override object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier)
+    public override object? VisitJsxIdentifier(JsxIdentifier jsxIdentifier, object? context)
     {
-        return ForceNewObjectByControlType((JsxIdentifier) base.VisitJsxIdentifier(jsxIdentifier)!,
+        return ForceNewObjectByControlType((JsxIdentifier) base.VisitJsxIdentifier(jsxIdentifier, context)!,
             node => new JsxIdentifier(node.Name));
     }
 
-    public override object? VisitJsxText(JsxText jsxText)
+    public override object? VisitJsxText(JsxText jsxText, object? context)
     {
-        return ForceNewObjectByControlType((JsxText) base.VisitJsxText(jsxText)!,
+        return ForceNewObjectByControlType((JsxText) base.VisitJsxText(jsxText, context)!,
             node => new JsxText(node.Value, node.Raw));
     }
 
-    public override object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement)
+    public override object? VisitJsxClosingElement(JsxClosingElement jsxClosingElement, object? context)
     {
-        return ForceNewObjectByControlType((JsxClosingElement) base.VisitJsxClosingElement(jsxClosingElement)!,
+        return ForceNewObjectByControlType((JsxClosingElement) base.VisitJsxClosingElement(jsxClosingElement, context)!,
             node => new JsxClosingElement(node.Name));
     }
 
-    public override object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment)
+    public override object? VisitJsxClosingFragment(JsxClosingFragment jsxClosingFragment, object? context)
     {
-        return ForceNewObjectByControlType((JsxClosingFragment) base.VisitJsxClosingFragment(jsxClosingFragment)!,
+        return ForceNewObjectByControlType((JsxClosingFragment) base.VisitJsxClosingFragment(jsxClosingFragment, context)!,
             node => new JsxClosingFragment());
     }
 
-    public override object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression)
+    public override object? VisitJsxEmptyExpression(JsxEmptyExpression jsxEmptyExpression, object? context)
     {
-        return ForceNewObjectByControlType((JsxEmptyExpression) base.VisitJsxEmptyExpression(jsxEmptyExpression)!,
+        return ForceNewObjectByControlType((JsxEmptyExpression) base.VisitJsxEmptyExpression(jsxEmptyExpression, context)!,
             node => new JsxEmptyExpression());
     }
 
-    public override object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer)
+    public override object? VisitJsxExpressionContainer(JsxExpressionContainer jsxExpressionContainer, object? context)
     {
-        return ForceNewObjectByControlType((JsxExpressionContainer) base.VisitJsxExpressionContainer(jsxExpressionContainer)!,
+        return ForceNewObjectByControlType((JsxExpressionContainer) base.VisitJsxExpressionContainer(jsxExpressionContainer, context)!,
             node => new JsxExpressionContainer(node.Expression));
     }
 
-    public override object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression)
+    public override object? VisitJsxMemberExpression(JsxMemberExpression jsxMemberExpression, object? context)
     {
-        return ForceNewObjectByControlType((JsxMemberExpression) base.VisitJsxMemberExpression(jsxMemberExpression)!,
+        return ForceNewObjectByControlType((JsxMemberExpression) base.VisitJsxMemberExpression(jsxMemberExpression, context)!,
             node => new JsxMemberExpression(node.Object, node.Property));
     }
 
-    public override object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName)
+    public override object? VisitJsxNamespacedName(JsxNamespacedName jsxNamespacedName, object? context)
     {
-        return ForceNewObjectByControlType((JsxNamespacedName) base.VisitJsxNamespacedName(jsxNamespacedName)!,
+        return ForceNewObjectByControlType((JsxNamespacedName) base.VisitJsxNamespacedName(jsxNamespacedName, context)!,
             node => new JsxNamespacedName(node.Namespace, node.Name));
     }
 
-    public override object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement)
+    public override object? VisitJsxOpeningElement(JsxOpeningElement jsxOpeningElement, object? context)
     {
-        return ForceNewObjectByControlType((JsxOpeningElement) base.VisitJsxOpeningElement(jsxOpeningElement)!,
+        return ForceNewObjectByControlType((JsxOpeningElement) base.VisitJsxOpeningElement(jsxOpeningElement, context)!,
             node => new JsxOpeningElement(node.Name, node.SelfClosing, node.Attributes));
     }
 
-    public override object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment)
+    public override object? VisitJsxOpeningFragment(JsxOpeningFragment jsxOpeningFragment, object? context)
     {
-        return ForceNewObjectByControlType((JsxOpeningFragment) base.VisitJsxOpeningFragment(jsxOpeningFragment)!,
+        return ForceNewObjectByControlType((JsxOpeningFragment) base.VisitJsxOpeningFragment(jsxOpeningFragment, context)!,
             node => new JsxOpeningFragment(node.SelfClosing));
     }
 
-    public override object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute)
+    public override object? VisitJsxSpreadAttribute(JsxSpreadAttribute jsxSpreadAttribute, object? context)
     {
-        return ForceNewObjectByControlType((JsxSpreadAttribute) base.VisitJsxSpreadAttribute(jsxSpreadAttribute)!,
+        return ForceNewObjectByControlType((JsxSpreadAttribute) base.VisitJsxSpreadAttribute(jsxSpreadAttribute, context)!,
             node => new JsxSpreadAttribute(node.Argument));
     }
 }


### PR DESCRIPTION
A possible solution to the problem of maintaining contextual information during visitation. See also [this discussion](https://github.com/sebastienros/esprima-dotnet/issues/275#issuecomment-1160704010).