### PR TITLE
Add a fallback to binary operator enum parser for rewriting

### DIFF
--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -77,7 +77,7 @@ namespace Esprima.Ast
                 "||" => BinaryOperator.LogicalOr,
                 "**" => BinaryOperator.Exponentiation,
                 "??" => BinaryOperator.NullishCoalescing,
-                _ => ThrowArgumentOutOfRangeException<BinaryOperator>(nameof(op), "Invalid binary operator: " + op)
+                _ => Enum.TryParse<BinaryOperator>(op, true, out var bo) ? bo : ThrowArgumentOutOfRangeException<BinaryOperator>(nameof(op), "Invalid binary operator: " + op)
             };
         }
 


### PR DESCRIPTION
Consider an ast rewriter that attempts to rewrite a binary expression like this:
```csharp
        if (node is BinaryExpression be)
        {
            var leftNew = be.Left;

            var rightNew = be.Right;
            if (be.Left is Identifier idToResolveLeft) leftNew = ResolveFromCurrentScope(idToResolveLeft) ?? leftNew;

            if (be.Right is Identifier idToResolveRight) rightNew = ResolveFromCurrentScope(idToResolveRight) ?? rightNew;

            if (be.Left != leftNew || be.Right != rightNew)
                return new BinaryExpression(be.Operator.ToString(), leftNew, rightNew) { Location = be.Location };
        }

```

Currently, that won't work as the `ParseBinaryOperator` function assumes it's the string from the tokens. It will not accept a string like `Plus`, which you'd get from `be.Operator.ToString()`. This makes a binary expression impossible to rewrite cleanly.

This CL changes it so that the `ParseBinaryOperator` will fall back to trying to parse the op string as the enum before throwing.

I couldn't find an appropriate place to add in a test, as it doesn't seem like there are unit tests for this kind of thing. I could create a new `BinaryExpressionTests.cs`, but not sure if that'd be appropriate. Do let me know, and I'll add it in. 