### PR TITLE
 Add a general purpose field for associating additional data/context with Node

### DIFF
--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -15,6 +15,11 @@ namespace Esprima.Ast
         public Range Range;
         public Location Location;
 
+        /// <summary>
+        /// A general purpose field for associating additional, user-defined data or context with <see cref="Node"/>.
+        /// </summary>
+        public object? Data;
+
         public abstract NodeCollection ChildNodes { get; }
 
         protected internal abstract object? Accept(AstVisitor visitor);

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -70,7 +70,6 @@ namespace Esprima
         private protected readonly IErrorHandler _errorHandler;
         private protected readonly ParserOptions _config;
         private protected bool _hasLineTerminator;
-        private protected readonly Action<Node>? _action;
 
         private protected readonly List<Token> _tokens = new();
 
@@ -114,17 +113,7 @@ namespace Esprima
         /// <param name="code">The JavaScript code to parse.</param>
         /// <param name="options">The parser options.</param>
         /// <returns></returns>
-        public JavaScriptParser(string code, ParserOptions options) : this(code, options, null)
-        {
-        }
-
-        /// <summary>
-        /// Creates a new <see cref="JavaScriptParser" /> instance.
-        /// </summary>
-        /// <param name="code">The JavaScript code to parse.</param>
-        /// <param name="options">The parser options.</param>
-        /// <param name="action">Action to execute on each parsed node.</param>
-        public JavaScriptParser(string code, ParserOptions options, Action<Node>? action)
+        public JavaScriptParser(string code, ParserOptions options)
         {
             if (code == null)
             {
@@ -153,7 +142,6 @@ namespace Esprima
             parseAsyncArgument = ParseAsyncArgument;
 
             _config = options;
-            _action = action;
             _errorHandler = _config.ErrorHandler;
             _errorHandler.Tolerant = _config.Tolerant;
             _scanner = new Scanner(code, _config);
@@ -357,7 +345,7 @@ namespace Esprima
 
             node.Location = new Location(start, end, _errorHandler.Source);
 
-            _action?.Invoke(node);
+            _config.OnNodeCreated?.Invoke(node);
 
             return node;
         }

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -296,10 +296,6 @@ public class JsxParser : JavaScriptParser
     {
     }
 
-    public JsxParser(string code, JsxParserOptions options, Action<Node>? action) : base(code, options, action)
-    {
-    }
-
     private protected override Expression ParsePrimaryExpression()
     {
         return Match("<") ? ParseJsxRoot() : base.ParsePrimaryExpression();

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima
+﻿using Esprima.Ast;
+
+namespace Esprima
 {
     /// <summary>
     /// Parser options.
@@ -58,5 +60,26 @@
         /// Default timeout for created regexes, defaults to 10 seconds.
         /// </summary>
         public TimeSpan RegexTimeout { get; set; } = TimeSpan.FromSeconds(10);
+
+        /// <summary>
+        /// Action to execute on each parsed node.
+        /// </summary>
+        /// <remarks>
+        /// This callback allows you to make changes to the nodes created by the parser.
+        /// E.g. you can use it to initialize <see cref="Node.Data"/> with a reference to the parent node:
+        /// <code>
+        /// options.OnNodeCreated = node => 
+        /// { 
+        ///    foreach (var child in node.ChildNodes)
+        ///    {
+        ///        if (child is not null)
+        ///        {
+        ///            child.Data = node;
+        ///        }
+        ///    }
+        /// };
+        /// </code>
+        /// </remarks>
+        public Action<Node>? OnNodeCreated { get; set; }
     }
 }

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -232,6 +232,45 @@ namespace Esprima.Test
             return root ?? "";
         }
 
+        private sealed class ParentNodeChecker : AstVisitor
+        {
+            public void Check(Node node)
+            {
+                Assert.Null(node.Data);
+
+                base.Visit(node);
+            }
+
+            public override object? Visit(Node node)
+            {
+                var parent = (Node?) node.Data;
+                Assert.NotNull(parent);
+                Assert.Contains(node, parent!.ChildNodes);
+
+                return base.Visit(node);
+            }
+        }
+
+        [Fact]
+        public void NodeDataCanBeSetToParentNode()
+        {
+            Action<Node> action = node =>
+            {
+                foreach (var child in node.ChildNodes)
+                {
+                    if (child is not null)
+                    {
+                        child.Data = node;
+                    }
+                }
+            };
+
+            var parser = new JavaScriptParser("function add(a, b) { return a + b; }", new ParserOptions { OnNodeCreated = action });
+            var script = parser.ParseScript();
+
+            new ParentNodeChecker().Check(script);
+        }
+
         [Fact]
         public void CommentsAreParsed()
         {

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -237,7 +237,7 @@ namespace Esprima.Test
         {
             var count = 0;
             Action<Node> action = node => count++;
-            var parser = new JavaScriptParser("// this is a comment", new ParserOptions(), action);
+            var parser = new JavaScriptParser("// this is a comment", new ParserOptions { OnNodeCreated = action });
             parser.ParseScript();
 
             Assert.Equal(1, count);


### PR DESCRIPTION
The idea was discussed [here](https://github.com/sebastienros/esprima-dotnet/issues/275#issuecomment-1167181520)

The PR also proposes a simplification in the parser API. See https://github.com/sebastienros/esprima-dotnet/commit/fc0d9683281db5523d078393b52c0e2dd4310749. This is however a BC, so we might as well skip this change.

But since we have this callback one way or the other, I think it's not worth introducing an out-of-the-box way to set `Node.Data` to the parent node. This callback can be used for that as pointed out in the XML comments. Do you agree or would you rather have a dedicated option for parent nodes?