### PR TITLE
Rewrite ChildNodesEnumerationHelpersGenerator into incremental generator to improve performance

### DIFF
--- a/src/Esprima.SourceGenerators/Helpers/StructuralEqualityWrapper.cs
+++ b/src/Esprima.SourceGenerators/Helpers/StructuralEqualityWrapper.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections;
+
+namespace Esprima.SourceGenerators.Helpers
+{
+    internal struct StructuralEqualityWrapper<TTarget> : IEquatable<StructuralEqualityWrapper<TTarget>>
+        where TTarget : IStructuralEquatable
+    {
+        public static implicit operator StructuralEqualityWrapper<TTarget>(TTarget target) => new StructuralEqualityWrapper<TTarget>(target);
+
+        public StructuralEqualityWrapper(TTarget target)
+        {
+            Target = target;
+        }
+
+        public TTarget Target { get; }
+
+        public override bool Equals(object? obj) => obj is StructuralEqualityWrapper<TTarget> wrapper && Equals(wrapper);
+
+        public bool Equals(StructuralEqualityWrapper<TTarget> other) => StructuralComparisons.StructuralEqualityComparer.Equals(Target, other.Target);
+
+        public override int GetHashCode() => StructuralComparisons.StructuralEqualityComparer.GetHashCode(Target);
+
+        public override string ToString() => Target.ToString();
+    }
+}


### PR DESCRIPTION
The original source generator implementation is kind of naive: it's practically re-run on every key press when editing any source file in the IDE. Luckily, as I've learned, there's a newer approach ([incremental generators](https://github.com/dotnet/roslyn/blob/main/docs/features/incremental-generators.md)) to mitigate this problem.