### PR TITLE
Clean up comment parsing and implement comment writing

### DIFF
--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -264,6 +264,11 @@ internal struct ArrayList<T> : IReadOnlyList<T>
         return list;
     }
 
+    /// <remarks>
+    /// Items should not be added or removed from the <see cref="ArrayList{T}"/> while the returned <see cref="Span{T}"/> is in use!
+    /// </remarks>
+    public Span<T> AsSpan() => new Span<T>(_items, 0, _count);
+
     public Enumerator GetEnumerator()
     {
         AssertUnchanged();

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -61,7 +61,7 @@ public abstract class Node
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
 
-    public override string ToString() => this.ToJavascriptString(beautify: true);
+    public override string ToString() => this.ToJavascriptString(format: true);
 
     private string GetDebuggerDisplay()
     {

--- a/src/Esprima/Comment.cs
+++ b/src/Esprima/Comment.cs
@@ -1,4 +1,6 @@
-﻿namespace Esprima;
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima;
 
 public enum CommentType
 {
@@ -6,14 +8,22 @@ public enum CommentType
     Line
 }
 
-public sealed class Comment
+public class Comment
 {
     public CommentType Type;
-    public string? Value;
 
-    public bool MultiLine;
-    public int[] Slice = Array.Empty<int>();
+    public string Value = string.Empty;
+    public Range Slice;
+
     public int Start;
     public int End;
-    public SourceLocation? Loc;
+
+    public Range Range
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => new Range(Start, End);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => value.Deconstruct(out Start, out End);
+    }
+    public Location Location;
 }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -197,26 +197,20 @@ public partial class JavaScriptParser
     {
         if (!_config.Comment)
         {
-            _scanner.ScanCommentsInternal();
+            _scanner.ScanComments();
         }
         else
         {
-            var comments = _scanner.ScanCommentsInternal();
+            var comments = _scanner.ScanComments();
 
-            if (comments.Count > 0)
+            for (var i = 0; i < comments.Length; ++i)
             {
-                for (var i = 0; i < comments.Count; ++i)
-                {
-                    var e = comments[i];
-                    var node = new Comment();
-                    node.Type = e.MultiLine ? CommentType.Block : CommentType.Line;
-                    node.Value = _scanner.Source.Slice(e.Slice[0], e.Slice[1]);
-                    node.Start = e.Start;
-                    node.End = e.End;
-                    node.Loc = e.Loc;
+                var e = comments[i];
 
-                    _comments.Add(node);
-                }
+                e.Value = _scanner.Source.Slice(e.Slice.Start, e.Slice.End);
+                e.Location = new Location(e.Location.Start, e.Location.End, _errorHandler.Source);
+
+                _comments.Add(e);
             }
         }
     }
@@ -331,7 +325,7 @@ public partial class JavaScriptParser
 
     private protected T Finalize<T>(Marker marker, T node) where T : Node
     {
-        node.Range = new Esprima.Ast.Range(marker.Index, _lastMarker.Index);
+        node.Range = new Range(marker.Index, _lastMarker.Index);
 
         var start = new Position(marker.Line, marker.Column);
         var end = new Position(_lastMarker.Line, _lastMarker.Column);

--- a/src/Esprima/Range.cs
+++ b/src/Esprima/Range.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace Esprima.Ast;
+namespace Esprima;
 
 public readonly struct Range : IEquatable<Range>
 {
@@ -41,5 +41,11 @@ public readonly struct Range : IEquatable<Range>
     public static bool operator !=(Range left, Range right)
     {
         return !left.Equals(right);
+    }
+
+    public void Deconstruct(out int start, out int end)
+    {
+        start = Start;
+        end = End;
     }
 }

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 
 namespace Esprima;
@@ -30,6 +31,13 @@ public class Token
     public int LineNumber;
     public int LineStart;
 
+    public Range Range
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => new Range(Start, End);
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => value.Deconstruct(out Start, out End);
+    }
     public Location Location;
 
     // For NumericLiteral

--- a/src/Esprima/Utils/AstToJavascript.cs
+++ b/src/Esprima/Utils/AstToJavascript.cs
@@ -16,14 +16,14 @@ public static class AstToJavascript
         return ToJavascriptString(node, JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
     }
 
-    public static string ToJavascriptString(this Node node, KnRJavascriptTextWriterOptions formattingOptions)
+    public static string ToJavascriptString(this Node node, KnRJavascriptTextFormatterOptions formattingOptions)
     {
         return ToJavascriptString(node, formattingOptions, AstToJavascriptOptions.Default);
     }
 
-    public static string ToJavascriptString(this Node node, bool beautify)
+    public static string ToJavascriptString(this Node node, bool format)
     {
-        return ToJavascriptString(node, beautify ? KnRJavascriptTextWriterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        return ToJavascriptString(node, format ? KnRJavascriptTextFormatterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
     }
 
     public static string ToJavascriptString(this Node node, JavascriptTextWriterOptions writerOptions, AstToJavascriptOptions options)
@@ -40,14 +40,14 @@ public static class AstToJavascript
         WriteJavascript(node, writer, JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer, KnRJavascriptTextWriterOptions formattingOptions)
+    public static void WriteJavascript(this Node node, TextWriter writer, KnRJavascriptTextFormatterOptions formattingOptions)
     {
         WriteJavascript(node, writer, formattingOptions, AstToJavascriptOptions.Default);
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer, bool beautify)
+    public static void WriteJavascript(this Node node, TextWriter writer, bool format)
     {
-        WriteJavascript(node, writer, beautify ? KnRJavascriptTextWriterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        WriteJavascript(node, writer, format ? KnRJavascriptTextFormatterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
     }
 
     public static void WriteJavascript(this Node node, TextWriter writer, JavascriptTextWriterOptions writerOptions, AstToJavascriptOptions options)

--- a/src/Esprima/Utils/AstToJavascriptConverter.cs
+++ b/src/Esprima/Utils/AstToJavascriptConverter.cs
@@ -47,6 +47,8 @@ public partial class AstToJavascriptConverter : AstVisitor
         _currentAuxiliaryNodeContext = null;
 
         Visit(node ?? throw new ArgumentNullException(nameof(node)));
+
+        Writer.Finish();
     }
 
     public override object? Visit(Node node)
@@ -513,7 +515,7 @@ public partial class AstToJavascriptConverter : AstVisitor
         _writeContext.SetNodeProperty(nameof(decorator.Expression), static node => node.As<Decorator>().Expression);
         VisitRootExpression(decorator.Expression, LeftHandSideRootExpressionFlags(needsBrackets: false));
 
-        Writer.WriteEpsilon(TokenFlags.TrailingSpaceRecommended, ref _writeContext);
+        Writer.SpaceRecommendedAfterLastToken();
 
         return decorator;
     }
@@ -648,8 +650,9 @@ public partial class AstToJavascriptConverter : AstVisitor
 
     protected internal override object? VisitExpressionStatement(ExpressionStatement expressionStatement)
     {
+        Writer.SpaceRecommendedAfterLastToken();
+
         _writeContext.SetNodeProperty(nameof(expressionStatement.Expression), static node => node.As<ExpressionStatement>().Expression);
-        Writer.WriteEpsilon(TokenFlags.LeadingSpaceRecommended, ref _writeContext);
         VisitRootExpression(expressionStatement.Expression, ExpressionFlags.IsInsideStatementExpression | RootExpressionFlags(needsBrackets: false));
 
         StatementNeedsSemicolon();
@@ -869,7 +872,7 @@ public partial class AstToJavascriptConverter : AstVisitor
             {
                 if (keyIsFirstToken && !property.Computed)
                 {
-                    Writer.WriteEpsilon(TokenFlags.LeadingSpaceRecommended, ref _writeContext);
+                    Writer.SpaceRecommendedAfterLastToken();
                 }
 
                 VisitPropertyKey(property.Key, property.Computed, leadingBracketFlags: keyIsFirstToken.ToFlag(TokenFlags.LeadingSpaceRecommended));
@@ -1077,8 +1080,9 @@ WriteSource:
 
     protected internal override object? VisitLabeledStatement(LabeledStatement labeledStatement)
     {
+        Writer.SpaceRecommendedAfterLastToken();
+
         _writeContext.SetNodeProperty(nameof(labeledStatement.Label), static node => node.As<LabeledStatement>().Label);
-        Writer.WriteEpsilon(TokenFlags.LeadingSpaceRecommended, ref _writeContext);
         VisitAuxiliaryNode(labeledStatement.Label);
 
         Writer.WritePunctuator(":", TokenFlags.Trailing | TokenFlags.TrailingSpaceRecommended, ref _writeContext);
@@ -1351,6 +1355,10 @@ WriteSource:
         {
             _writeContext.SetNodeProperty(nameof(propertyDefinition.Static), static node => node.As<PropertyDefinition>().Static);
             Writer.WriteKeyword("static", TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
+        }
+        else
+        {
+            Writer.SpaceRecommendedAfterLastToken();
         }
 
         _writeContext.SetNodeProperty(nameof(propertyDefinition.Key), static node => node.As<PropertyDefinition>().Key);

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -635,7 +635,7 @@ public class AstToJsonConverter : AstVisitor
             var callee = new ImportCompat
             {
                 Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
-                Range = new Ast.Range(import.Range.Start, import.Range.Start + importToken.Length)
+                Range = new Range(import.Range.Start, import.Range.Start + importToken.Length)
             };
             var args = new NodeList<Expression>(new Expression[] { import.Source });
             var callExpression = new CallExpression(callee, args, optional: false)

--- a/src/Esprima/Utils/EnumHelper.cs
+++ b/src/Esprima/Utils/EnumHelper.cs
@@ -26,6 +26,12 @@ internal static class EnumHelper
     public static bool HasFlagFast(this AstToJavascriptConverter.ExpressionFlags flags, AstToJavascriptConverter.ExpressionFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasFlagFast(this JavascriptTextWriter.TriviaType flags, JavascriptTextWriter.TriviaType flag) => (flags & flag) == flag;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool HasFlagFast(this JavascriptTextWriter.TriviaFlags flags, JavascriptTextWriter.TriviaFlags flag) => (flags & flag) == flag;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool HasFlagFast(this JavascriptTextWriter.TokenFlags flags, JavascriptTextWriter.TokenFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Esprima/Utils/JavascriptTextWriter.Enums.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.Enums.cs
@@ -4,6 +4,41 @@ namespace Esprima.Utils;
 
 partial class JavascriptTextWriter
 {
+    private protected const TriviaType WhiteSpaceTriviaFlag = (TriviaType) (1 << 1);
+    private protected const TriviaType CommentTriviaFlag = (TriviaType) (1 << 2);
+
+    protected internal enum TriviaType
+    {
+        None = 0,
+
+        WhiteSpace = WhiteSpaceTriviaFlag | 0,
+        EndOfLine = WhiteSpaceTriviaFlag | 1,
+
+        LineComment = CommentTriviaFlag | 0,
+        BlockComment = CommentTriviaFlag | 1,
+    }
+
+    [Flags]
+    public enum TriviaFlags
+    {
+        None = 0,
+
+        // Whitespace hints for non-whitespace trivia (i.e. comments)
+
+        /// <summary>
+        /// A leading new line is required for the current trivia (i.e. it must start in a new line).
+        /// </summary>
+        LeadingNewLineRequired = 1 << 0,
+        /// <summary>
+        /// A trailing new line is required for the current trivia (i.e. it must be followed by a new line).
+        /// </summary>
+        TrailingNewLineRequired = 1 << 1,
+        /// <summary>
+        /// Surrounding new lines are required for the current trivia.
+        /// </summary>
+        SurroundingNewLineRequired = LeadingNewLineRequired | TrailingNewLineRequired,
+    }
+
     [Flags]
     public enum TokenFlags
     {

--- a/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
@@ -4,6 +4,10 @@ using static Esprima.EsprimaExceptionHelper;
 
 namespace Esprima.Utils;
 
+public delegate object? NodePropertyValueAccessor(Node node);
+
+public delegate ref readonly NodeList<T> NodePropertyListValueAccessor<T>(Node node) where T : Node?;
+
 partial class JavascriptTextWriter
 {
     public struct WriteContext

--- a/src/Esprima/Utils/KnRJavascriptTextFormatter.cs
+++ b/src/Esprima/Utils/KnRJavascriptTextFormatter.cs
@@ -1,0 +1,61 @@
+﻿using System.Runtime.CompilerServices;
+using Esprima.Ast;
+
+namespace Esprima.Utils;
+
+public record class KnRJavascriptTextFormatterOptions : JavascriptTextFormatterOptions
+{
+    public static new readonly KnRJavascriptTextFormatterOptions Default = new();
+
+    public KnRJavascriptTextFormatterOptions()
+    {
+        KeepEmptyBlockBodyInLine = true;
+    }
+
+    public bool UseEgyptianBraces { get; init; } = true;
+
+    protected override JavascriptTextFormatter CreateFormatter(TextWriter writer) => new KnRJavascriptTextFormatter(writer, this);
+}
+
+/// <summary>
+/// Javascript code formatter which implements the most common <see href="https://en.wikipedia.org/wiki/Indentation_style#K&amp;R_style">K&amp;R style</see>.
+/// </summary>
+public class KnRJavascriptTextFormatter : JavascriptTextFormatter
+{
+    public KnRJavascriptTextFormatter(TextWriter writer, KnRJavascriptTextFormatterOptions options) : base(writer, options)
+    {
+        UseEgyptianBraces = options.UseEgyptianBraces;
+    }
+
+    protected bool UseEgyptianBraces { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    protected override void WriteWhiteSpaceBetweenTokenAndKeyword(string value, TokenFlags flags, ref WriteContext context)
+    {
+        if (flags.HasFlagFast(TokenFlags.FollowsStatementBody))
+        {
+            if (UseEgyptianBraces && CanUseEgyptianBraces(ref context))
+            {
+                WriteSpace();
+            }
+            else
+            {
+                WriteLine();
+            }
+        }
+        else if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+        {
+            WriteSpace();
+        }
+        else
+        {
+            WriteRequiredSpaceBetweenTokenAndKeyword();
+        }
+    }
+
+    protected virtual bool CanUseEgyptianBraces(ref WriteContext context)
+    {
+        return KeepEmptyBlockBodyInLine
+            ? RetrieveStatementBodyFromContext(ref context) is BlockStatement blockStatement && blockStatement.Body.Count > 0
+            : RetrieveStatementBodyFromContext(ref context).Type == Nodes.BlockStatement;
+    }
+}

--- a/src/Esprima/Utils/KnRJavascriptTextWriter.cs
+++ b/src/Esprima/Utils/KnRJavascriptTextWriter.cs
@@ -82,96 +82,125 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
         }
     }
 
-    public override void WriteEpsilon(TokenFlags flags, ref WriteContext context)
+    protected override void WriteLine()
     {
-        if (WhiteSpaceWrittenSinceLastToken)
-        {
-            return;
-        }
-
-        if ((flags & (TokenFlags.LeadingSpaceRecommended | TokenFlags.TrailingSpaceRecommended)) != 0)
-        {
-            ForceRecommendedSpace();
-        }
+        WriteEndOfLine();
+        WriteIndent();
     }
 
-    protected override void StartKeyword(string value, TokenFlags flags, ref WriteContext context)
+    protected override void WriteLineCommentCore(TextWriter writer, string line, TriviaFlags flags)
     {
-        if (WhiteSpaceWrittenSinceLastToken)
+        if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
         {
-            return;
+            WriteSpace();
         }
 
-        if (flags.HasFlagFast(TokenFlags.FollowsStatementBody))
+        base.WriteLineCommentCore(writer, line, flags);
+    }
+
+    protected override void WriteBlockCommentLine(TextWriter writer, string line, bool isFirst)
+    {
+        if (!isFirst)
         {
-            if (UseEgyptianBraces && CanUseEgyptianBraces(ref context))
+            for (var n = _indentionLevel; n > 0; n--)
+            {
+                writer.Write(_indent);
+            }
+        }
+
+        base.WriteBlockCommentLine(writer, line, isFirst);
+    }
+
+    protected override void WriteBlockCommentCore(TextWriter writer, IEnumerable<string> lines, TriviaFlags flags)
+    {
+        if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
+        {
+            WriteSpace();
+        }
+
+        base.WriteBlockCommentCore(writer, lines, flags);
+    }
+
+    protected override void StartIdentifier(string value, TokenFlags flags, ref WriteContext context)
+    {
+        if (LastTriviaType == TriviaType.None)
+        {
+            if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
             {
                 WriteSpace();
             }
             else
             {
-                WriteLine();
-                WriteIndent();
+                WriteRequiredSpaceBetweenTokenAndIdentifier();
             }
         }
-        else if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+        else if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
         {
             WriteSpace();
-        }
-        else
-        {
-            base.StartKeyword(value, flags, ref context);
         }
     }
 
-    protected override void StartIdentifier(string value, TokenFlags flags, ref WriteContext context)
+    protected override void StartKeyword(string value, TokenFlags flags, ref WriteContext context)
     {
-        if (WhiteSpaceWrittenSinceLastToken)
+        if (LastTriviaType == TriviaType.None)
         {
-            return;
+            if (flags.HasFlagFast(TokenFlags.FollowsStatementBody))
+            {
+                if (UseEgyptianBraces && CanUseEgyptianBraces(ref context))
+                {
+                    WriteSpace();
+                }
+                else
+                {
+                    WriteLine();
+                }
+            }
+            else if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+            {
+                WriteSpace();
+            }
+            else
+            {
+                WriteRequiredSpaceBetweenTokenAndKeyword();
+            }
         }
-
-        if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+        else if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
         {
             WriteSpace();
-        }
-        else
-        {
-            base.StartIdentifier(value, flags, ref context);
         }
     }
 
     protected override void StartLiteral(string value, TokenType type, TokenFlags flags, ref WriteContext context)
     {
-        if (WhiteSpaceWrittenSinceLastToken)
+        if (LastTriviaType == TriviaType.None)
         {
-            return;
+            if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+            {
+                WriteSpace();
+            }
+            else
+            {
+                WriteRequiredSpaceBetweenTokenAndLiteral(type);
+            }
         }
-
-        if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+        else if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
         {
             WriteSpace();
-        }
-        else
-        {
-            base.StartLiteral(value, type, flags, ref context);
         }
     }
 
     protected override void StartPunctuator(string value, TokenFlags flags, ref WriteContext context)
     {
-        if (WhiteSpaceWrittenSinceLastToken)
+        if (LastTriviaType == TriviaType.None)
         {
-            return;
+            if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+            {
+                WriteSpace();
+            }
         }
-
-        if (flags.HasFlagFast(TokenFlags.LeadingSpaceRecommended) || LastTokenFlags.HasFlagFast(TokenFlags.TrailingSpaceRecommended))
+        else if (!LastTriviaType.HasFlag(WhiteSpaceTriviaFlag))
         {
             WriteSpace();
-        }
-        else
-        {
-            base.StartPunctuator(value, flags, ref context);
         }
     }
 
@@ -179,16 +208,16 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
     {
         base.StartArray(elementCount, ref context);
 
-        if (context.Node.Type == Nodes.ArrayExpression && elementCount >= MultiLineArrayLiteralThreshold)
+        if (!CanKeepArrayInLine(elementCount, ref context))
         {
-            WriteLine();
+            WriteEndOfLine();
             IncreaseIndent();
         }
     }
 
     public override void EndArray(int elementCount, ref WriteContext context)
     {
-        if (context.Node.Type == Nodes.ArrayExpression && elementCount >= MultiLineArrayLiteralThreshold)
+        if (!CanKeepArrayInLine(elementCount, ref context))
         {
             DecreaseIndent();
             WriteIndent();
@@ -197,20 +226,25 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
         base.EndArray(elementCount, ref context);
     }
 
+    protected virtual bool CanKeepArrayInLine(int elementCount, ref WriteContext context)
+    {
+        return context.Node.Type != Nodes.ArrayExpression || elementCount < MultiLineArrayLiteralThreshold;
+    }
+
     public override void StartObject(int propertyCount, ref WriteContext context)
     {
         base.StartObject(propertyCount, ref context);
 
-        if (context.Node.Type == Nodes.ObjectExpression && propertyCount >= MultiLineObjectLiteralThreshold)
+        if (!CanKeepObjectInLine(propertyCount, ref context))
         {
-            WriteLine();
+            WriteEndOfLine();
             IncreaseIndent();
         }
     }
 
     public override void EndObject(int propertyCount, ref WriteContext context)
     {
-        if (context.Node.Type == Nodes.ObjectExpression && propertyCount >= MultiLineObjectLiteralThreshold)
+        if (!CanKeepObjectInLine(propertyCount, ref context))
         {
             DecreaseIndent();
             WriteIndent();
@@ -219,26 +253,36 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
         base.EndObject(propertyCount, ref context);
     }
 
+    protected virtual bool CanKeepObjectInLine(int propertyCount, ref WriteContext context)
+    {
+        return context.Node.Type != Nodes.ObjectExpression || propertyCount < MultiLineObjectLiteralThreshold;
+    }
+
     public override void StartBlock(int statementCount, ref WriteContext context)
     {
         base.StartBlock(statementCount, ref context);
 
-        if (statementCount > 0 || !KeepEmptyBlockBodyInLine)
+        if (!CanKeepBlockInLine(statementCount, ref context))
         {
-            WriteLine();
+            WriteEndOfLine();
             IncreaseIndent();
         }
     }
 
     public override void EndBlock(int statementCount, ref WriteContext context)
     {
-        if (statementCount > 0 || !KeepEmptyBlockBodyInLine)
+        if (!CanKeepBlockInLine(statementCount, ref context))
         {
             DecreaseIndent();
             WriteIndent();
         }
 
         base.EndBlock(statementCount, ref context);
+    }
+
+    protected virtual bool CanKeepBlockInLine(int statementCount, ref WriteContext context)
+    {
+        return statementCount == 0 && KeepEmptyBlockBodyInLine;
     }
 
     protected void StoreStatementBodyIntoContext(Statement statement, ref WriteContext context)
@@ -261,13 +305,13 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
             // Is single statement body?
             if (statement.Type != Nodes.BlockStatement)
             {
-                if (CanInlineSingleStatementBody(statement, flags, ref context))
+                if (CanKeepSingleStatementBodyInLine(statement, flags, ref context))
                 {
                     WriteSpace();
                 }
                 else
                 {
-                    WriteLine();
+                    WriteEndOfLine();
                     IncreaseIndent();
                     WriteIndent();
                 }
@@ -284,7 +328,7 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
             // Is single statement body?
             if (statement.Type != Nodes.BlockStatement)
             {
-                if (!CanInlineSingleStatementBody(statement, flags, ref context))
+                if (!CanKeepSingleStatementBodyInLine(statement, flags, ref context))
                 {
                     DecreaseIndent();
                 }
@@ -307,7 +351,7 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
             }
             else
             {
-                WriteLine();
+                WriteEndOfLine();
                 IncreaseIndent();
             }
         }
@@ -333,7 +377,7 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
             WritePunctuator(";", TokenFlags.Trailing | TokenFlags.TrailingSpaceRecommended, ref context);
         }
 
-        WriteLine();
+        WriteEndOfLine();
     }
 
     public override void EndStatementList(int count, ref WriteContext context)
@@ -354,7 +398,7 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
             : RetrieveStatementBodyFromContext(ref context).Type == Nodes.BlockStatement;
     }
 
-    protected virtual bool CanInlineSingleStatementBody(Statement statement, StatementFlags flags, ref WriteContext context)
+    protected virtual bool CanKeepSingleStatementBodyInLine(Statement statement, StatementFlags flags, ref WriteContext context)
     {
         return statement.Type switch
         {
@@ -425,7 +469,7 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
 
         if (context.Node.Type == Nodes.ArrayExpression && count >= MultiLineArrayLiteralThreshold)
         {
-            WriteLine();
+            WriteEndOfLine();
         }
     }
 
@@ -446,12 +490,21 @@ public class KnRJavascriptTextWriter : JavascriptTextWriter
         if (context.Node.Type is Nodes.ClassBody ||
             context.Node.Type == Nodes.ObjectExpression && count >= MultiLineObjectLiteralThreshold)
         {
-            WriteLine();
+            WriteEndOfLine();
         }
         else if (typeof(T) == typeof(Decorator))
         {
             WriteLine();
-            WriteIndent();
         }
+    }
+
+    public override void Finish()
+    {
+        if (LastTriviaType != TriviaType.EndOfLine)
+        {
+            WriteEndOfLine();
+        }
+
+        base.Finish();
     }
 }

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -43,7 +43,7 @@ public class AstToJavascriptTests
     }
 
     private static readonly CustomCompactJavascriptTextWriterOptions s_customCompactWriterOptions = new();
-    private static readonly KnRJavascriptTextWriterOptions s_indentedWriterOptions = new()
+    private static readonly KnRJavascriptTextFormatterOptions s_formattingOptions = new()
     {
         Indent = "    ",
         KeepEmptyBlockBodyInLine = false,
@@ -173,7 +173,7 @@ export function checkSecurityAnswerCodeDirect(result) {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
 
         var expected = @"import { MccDialog } from '../mccDialogHandler';
 import { commonClient, bb as f } from '../commonClient/commonClient';
@@ -254,7 +254,7 @@ aa({});
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
 
         var expected = @"(function() {
     'use strict';
@@ -409,7 +409,7 @@ if (e.IsWebService)
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
 
         var expected = @"function tt(t, r) {
     var n, e, i = b(t), s = b(r);
@@ -560,7 +560,7 @@ class A {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
 
         var expected = @"class A {
     *[Symbol.iterator]() {
@@ -591,7 +591,7 @@ class A {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
 
         var expected = @"var i = function e(i) {
     var r = n[i];
@@ -626,7 +626,7 @@ if (b == 2) {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_indentedWriterOptions);
+        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
         Assert.Equal(source, code);
     }
 
@@ -737,7 +737,7 @@ if (b == 2) {
         // TODO: more detailed comparison.
         Assert.Equal(expectedAst.DescendantNodesAndSelf(), actualAst.DescendantNodesAndSelf(), NodeTypeEqualityComparer.Default);
 
-        generatedScript = expectedAst.ToJavascriptString(beautify: true);
+        generatedScript = expectedAst.ToJavascriptString(format: true);
 
         actualAst = Parse(sourceType, generatedScript, parserOptions, parserFactory);
 

--- a/test/Esprima.Tests/JavascriptTextWriterTests.cs
+++ b/test/Esprima.Tests/JavascriptTextWriterTests.cs
@@ -1,0 +1,437 @@
+﻿using Esprima.Ast;
+using Esprima.Utils;
+
+namespace Esprima.Tests;
+
+public class JavascriptTextWriterTests
+{
+    public record class TestCase(Action<JavascriptTextWriter> Write, string ExpectedUnformatted, string ExpectedFormatted) { }
+
+    private static readonly Program s_dummyAst = new Script(
+        NodeList.Create<Statement>(new[]
+        {
+            new BlockStatement(NodeList.Create<Statement>(new[]
+            {
+                new FunctionDeclaration(new Identifier("func"), default, new BlockStatement(default), false, false, false)
+            }))
+        }),
+        false);
+
+    private static readonly Dictionary<string, TestCase> s_testCaseDictionary = new()
+    {
+        ["TwoLineCommentsAtBeginning"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"//abc
+// def",
+            ExpectedFormatted: @"//abc
+// def
+"
+        ),
+
+        ["TwoBlockCommentsAtBeginning_1"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*//* def */",
+            ExpectedFormatted: @"/*abc*/ /* def */
+"
+        ),
+
+        ["TwoBlockCommentsAtBeginning_2"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*/
+/* def */",
+            ExpectedFormatted: @"/*abc*/
+/* def */
+"
+        ),
+
+        ["TwoBlockCommentsAtBeginning_3"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*/
+/* def */",
+            ExpectedFormatted: @"/*abc*/
+/* def */
+"
+        ),
+
+        ["MultiLineBlockAndBlockCommentsAtBeginning_1"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*!
+ * abc
+ *//* def */",
+            ExpectedFormatted: @"/*!
+ * abc
+ */ /* def */
+"
+        ),
+
+        ["MultiLineBlockAndBlockCommentsAtBeginning_2"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*!
+ * abc
+ */
+/* def */",
+            ExpectedFormatted: @"/*!
+ * abc
+ */
+/* def */
+"
+        ),
+
+        ["LineAndBlockCommentsAtBeginning"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"//abc
+/* def */",
+            ExpectedFormatted: @"//abc
+/* def */
+"
+        ),
+
+        ["BlockAndLineCommentsAtBeginning_1"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*/// def",
+            ExpectedFormatted: @"/*abc*/ // def
+"
+        ),
+
+        ["BlockAndLineCommentsAtBeginning_2"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*/
+// def",
+            ExpectedFormatted: @"/*abc*/
+// def
+"
+        ),
+
+        ["BlockAndLineCommentsAtBeginning_3"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"/*abc*/
+// def",
+            ExpectedFormatted: @"/*abc*/
+// def
+"
+        ),
+
+        ["LineCommentBetweenTokens_1"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function//abc
+func",
+            ExpectedFormatted: @"function //abc
+func
+"
+        ),
+
+        ["LineCommentBetweenTokens_2"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function
+//abc
+func",
+            ExpectedFormatted: @"function
+//abc
+func
+"
+        ),
+
+        ["LineCommentBetweenTokens_3"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                writer.StartBlock(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"{//abc
+function",
+            ExpectedFormatted: @"{
+  //abc
+  function
+"
+        ),
+
+        ["LineCommentBetweenTokens_4"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                writer.StartBlock(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"{
+//abc
+function",
+            ExpectedFormatted: @"{
+  //abc
+  function
+"
+        ),
+
+
+        ["BlockCommentBetweenTokens_1"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function/*abc*/func",
+            ExpectedFormatted: @"function /*abc*/ func
+"
+        ),
+
+        ["BlockCommentBetweenTokens_2a"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function
+/*abc*/func",
+            ExpectedFormatted: @"function
+/*abc*/ func
+"
+        ),
+
+        ["BlockCommentBetweenTokens_2b"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function/*abc*/
+func",
+            ExpectedFormatted: @"function /*abc*/
+func
+"
+        ),
+
+        ["BlockCommentBetweenTokens_2c"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+
+                var identifier = functionDeclaration.Id!;
+                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
+                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"function
+/*abc*/
+func",
+            ExpectedFormatted: @"function
+/*abc*/
+func
+"
+        ),
+
+        ["BlockCommentBetweenTokens_3"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                writer.StartBlock(0, ref writeContext);
+
+                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+
+                writer.StartStatementList(0, ref writeContext);
+                writer.EndStatementList(0, ref writeContext);
+                writer.EndBlock(blockStatement.Body.Count, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"{/*abc*/}",
+            ExpectedFormatted: @"{ /*abc*/ }
+"
+        ),
+
+        ["BlockCommentBetweenTokens_4"] = new TestCase(
+            Write: static (JavascriptTextWriter writer) =>
+            {
+                var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
+                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                writer.StartBlock(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+
+                var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
+                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteBlockComment(new[] { "", " * abc", " " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+
+                writer.Finish();
+            },
+            ExpectedUnformatted: @"{
+/*
+ * abc
+ */
+function",
+            ExpectedFormatted: @"{
+  /*
+   * abc
+   */
+  function
+"
+        ),
+    };
+
+    public static IEnumerable<object[]> TestCases => s_testCaseDictionary.Keys.Select(key => new object[] { key });
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void ExecuteTestCase_Unformatted(string testCaseName)
+    {
+        var testCase = s_testCaseDictionary[testCaseName];
+
+        var stringWriter = new StringWriter();
+        var writer = new JavascriptTextWriter(stringWriter, JavascriptTextWriterOptions.Default);
+        testCase.Write(writer);
+
+        Assert.Equal(testCase.ExpectedUnformatted, stringWriter.ToString());
+    }
+
+    [Theory]
+    [MemberData(nameof(TestCases))]
+    public void ExecuteTestCase_Formatted(string testCaseName)
+    {
+        var testCase = s_testCaseDictionary[testCaseName];
+
+        var stringWriter = new StringWriter();
+        var writer = new KnRJavascriptTextWriter(stringWriter, KnRJavascriptTextWriterOptions.Default);
+        testCase.Write(writer);
+
+        Assert.Equal(testCase.ExpectedFormatted, stringWriter.ToString());
+    }
+}

--- a/test/Esprima.Tests/JavascriptTextWriterTests.cs
+++ b/test/Esprima.Tests/JavascriptTextWriterTests.cs
@@ -429,7 +429,7 @@ function",
         var testCase = s_testCaseDictionary[testCaseName];
 
         var stringWriter = new StringWriter();
-        var writer = new KnRJavascriptTextWriter(stringWriter, KnRJavascriptTextWriterOptions.Default);
+        var writer = new KnRJavascriptTextFormatter(stringWriter, KnRJavascriptTextFormatterOptions.Default);
         testCase.Write(writer);
 
         Assert.Equal(testCase.ExpectedFormatted, stringWriter.ToString());


### PR DESCRIPTION
Addresses one of the points listed in https://github.com/sebastienros/esprima-dotnet/issues/300

Besides some clean-up, adds basic support for writing comments. Also, does some refactor around `KnRJavascriptTextWriter` to improve extensibility for inheritors.