### PR TITLE
Make letter casing of "JavaScript" consistent in code

### DIFF
--- a/src/Esprima/Ast/Jsx/JsxExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpression.cs
@@ -23,8 +23,8 @@ public abstract class JsxExpression : Expression
         return visitor is IJsxAstVisitor jsxVisitor ? Accept(jsxVisitor) : AcceptAsExtension(visitor);
     }
 
-    private static readonly AstToJavascriptOptions s_toStringOptions = JsxAstToJavascriptOptions.Default with { IgnoreExtensions = true };
-    public override string ToString() => this.ToJavascriptString(KnRJavascriptTextFormatterOptions.Default, s_toStringOptions);
+    private static readonly AstToJavaScriptOptions s_toStringOptions = JsxAstToJavaScriptOptions.Default with { IgnoreExtensions = true };
+    public override string ToString() => this.ToJavaScriptString(KnRJavaScriptTextFormatterOptions.Default, s_toStringOptions);
 
     private protected override string GetDebuggerDisplay()
     {

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -61,8 +61,8 @@ public abstract class Node
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
 
-    private static readonly AstToJavascriptOptions s_toStringOptions = AstToJavascriptOptions.Default with { IgnoreExtensions = true };
-    public override string ToString() => this.ToJavascriptString(KnRJavascriptTextFormatterOptions.Default, s_toStringOptions);
+    private static readonly AstToJavaScriptOptions s_toStringOptions = AstToJavaScriptOptions.Default with { IgnoreExtensions = true };
+    public override string ToString() => this.ToJavaScriptString(KnRJavaScriptTextFormatterOptions.Default, s_toStringOptions);
 
     private protected virtual string GetDebuggerDisplay()
     {

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -877,7 +877,7 @@ public sealed partial class Scanner
             if (ch == 'n')
             {
                 Index++;
-                return ScanBigIntLiteral(start, number, JavascriptNumberStyle.Hex);
+                return ScanBigIntLiteral(start, number, JavaScriptNumberStyle.Hex);
             }
             ThrowUnexpectedToken();
         }
@@ -930,7 +930,7 @@ public sealed partial class Scanner
         };
     }
 
-    private enum JavascriptNumberStyle
+    private enum JavaScriptNumberStyle
     {
         Binary,
         Hex,
@@ -938,10 +938,10 @@ public sealed partial class Scanner
         Integer
     }
 
-    private Token ScanBigIntLiteral(int start, ReadOnlySpan<char> number, JavascriptNumberStyle style)
+    private Token ScanBigIntLiteral(int start, ReadOnlySpan<char> number, JavaScriptNumberStyle style)
     {
         BigInteger bigInt = 0;
-        if (style == JavascriptNumberStyle.Binary)
+        if (style == JavaScriptNumberStyle.Binary)
         {
             // binary
             foreach (var c in number)
@@ -952,7 +952,7 @@ public sealed partial class Scanner
         }
         else
         {
-            if (style == JavascriptNumberStyle.Hex)
+            if (style == JavaScriptNumberStyle.Hex)
             {
                 var c = number[0];
                 if (c > '7' && Character.IsHexDigit(c))
@@ -964,8 +964,8 @@ public sealed partial class Scanner
 
             var parseStyle = style switch
             {
-                JavascriptNumberStyle.Integer => NumberStyles.Integer,
-                JavascriptNumberStyle.Hex => NumberStyles.HexNumber,
+                JavaScriptNumberStyle.Integer => NumberStyles.Integer,
+                JavaScriptNumberStyle.Hex => NumberStyles.HexNumber,
                 _ => NumberStyles.None
             };
 #if HAS_SPAN_PARSE
@@ -1003,7 +1003,7 @@ public sealed partial class Scanner
             if (ch == 'n')
             {
                 Index++;
-                return ScanBigIntLiteral(start, number, JavascriptNumberStyle.Binary);
+                return ScanBigIntLiteral(start, number, JavaScriptNumberStyle.Binary);
             }
 
             if (Character.IsIdentifierStart(ch) || Character.IsDecimalDigit(ch))
@@ -1061,7 +1061,7 @@ public sealed partial class Scanner
             }
 
             Index++;
-            return ScanBigIntLiteral(start, number.AsSpan(), JavascriptNumberStyle.Octal);
+            return ScanBigIntLiteral(start, number.AsSpan(), JavaScriptNumberStyle.Octal);
         }
 
         if (Character.IsIdentifierStart(ch) || Character.IsDecimalDigit(ch))
@@ -1267,7 +1267,7 @@ public sealed partial class Scanner
             }
 
             Index++;
-            return ScanBigIntLiteral(start, sb.ToString().AsSpan(), JavascriptNumberStyle.Integer);
+            return ScanBigIntLiteral(start, sb.ToString().AsSpan(), JavaScriptNumberStyle.Integer);
         }
 
         if (Character.IsIdentifierStart(Source.CharCodeAt(Index)))

--- a/src/Esprima/Utils/AstToJavascript.cs
+++ b/src/Esprima/Utils/AstToJavascript.cs
@@ -2,67 +2,67 @@
 
 namespace Esprima.Utils;
 
-public record class AstToJavascriptOptions
+public record class AstToJavaScriptOptions
 {
-    public static readonly AstToJavascriptOptions Default = new();
+    public static readonly AstToJavaScriptOptions Default = new();
 
     internal bool IgnoreExtensions { get; init; }
 
-    protected internal virtual AstToJavascriptConverter CreateConverter(JavascriptTextWriter writer) => new AstToJavascriptConverter(writer, this);
+    protected internal virtual AstToJavaScriptConverter CreateConverter(JavaScriptTextWriter writer) => new AstToJavaScriptConverter(writer, this);
 }
 
-public static class AstToJavascript
+public static class AstToJavaScript
 {
-    public static string ToJavascriptString(this Node node)
+    public static string ToJavaScriptString(this Node node)
     {
-        return ToJavascriptString(node, JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        return ToJavaScriptString(node, JavaScriptTextWriterOptions.Default, AstToJavaScriptOptions.Default);
     }
 
-    public static string ToJavascriptString(this Node node, KnRJavascriptTextFormatterOptions formattingOptions)
+    public static string ToJavaScriptString(this Node node, KnRJavaScriptTextFormatterOptions formattingOptions)
     {
-        return ToJavascriptString(node, formattingOptions, AstToJavascriptOptions.Default);
+        return ToJavaScriptString(node, formattingOptions, AstToJavaScriptOptions.Default);
     }
 
-    public static string ToJavascriptString(this Node node, bool format)
+    public static string ToJavaScriptString(this Node node, bool format)
     {
-        return ToJavascriptString(node, format ? KnRJavascriptTextFormatterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        return ToJavaScriptString(node, format ? KnRJavaScriptTextFormatterOptions.Default : JavaScriptTextWriterOptions.Default, AstToJavaScriptOptions.Default);
     }
 
-    public static string ToJavascriptString(this Node node, JavascriptTextWriterOptions writerOptions, AstToJavascriptOptions options)
+    public static string ToJavaScriptString(this Node node, JavaScriptTextWriterOptions writerOptions, AstToJavaScriptOptions options)
     {
         using (var writer = new StringWriter())
         {
-            WriteJavascript(node, writer, writerOptions, options);
+            WriteJavaScript(node, writer, writerOptions, options);
             return writer.ToString();
         }
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer)
+    public static void WriteJavaScript(this Node node, TextWriter writer)
     {
-        WriteJavascript(node, writer, JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        WriteJavaScript(node, writer, JavaScriptTextWriterOptions.Default, AstToJavaScriptOptions.Default);
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer, KnRJavascriptTextFormatterOptions formattingOptions)
+    public static void WriteJavaScript(this Node node, TextWriter writer, KnRJavaScriptTextFormatterOptions formattingOptions)
     {
-        WriteJavascript(node, writer, formattingOptions, AstToJavascriptOptions.Default);
+        WriteJavaScript(node, writer, formattingOptions, AstToJavaScriptOptions.Default);
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer, bool format)
+    public static void WriteJavaScript(this Node node, TextWriter writer, bool format)
     {
-        WriteJavascript(node, writer, format ? KnRJavascriptTextFormatterOptions.Default : JavascriptTextWriterOptions.Default, AstToJavascriptOptions.Default);
+        WriteJavaScript(node, writer, format ? KnRJavaScriptTextFormatterOptions.Default : JavaScriptTextWriterOptions.Default, AstToJavaScriptOptions.Default);
     }
 
-    public static void WriteJavascript(this Node node, TextWriter writer, JavascriptTextWriterOptions writerOptions, AstToJavascriptOptions options)
+    public static void WriteJavaScript(this Node node, TextWriter writer, JavaScriptTextWriterOptions writerOptions, AstToJavaScriptOptions options)
     {
         if (writerOptions is null)
         {
             throw new ArgumentNullException(nameof(writerOptions));
         }
 
-        WriteJavascript(node, writerOptions.CreateWriter(writer), options);
+        WriteJavaScript(node, writerOptions.CreateWriter(writer), options);
     }
 
-    public static void WriteJavascript(this Node node, JavascriptTextWriter writer, AstToJavascriptOptions options)
+    public static void WriteJavaScript(this Node node, JavaScriptTextWriter writer, AstToJavaScriptOptions options)
     {
         if (options is null)
         {

--- a/src/Esprima/Utils/AstToJavascriptConverter.Enums.cs
+++ b/src/Esprima/Utils/AstToJavascriptConverter.Enums.cs
@@ -1,6 +1,6 @@
 ﻿namespace Esprima.Utils;
 
-partial class AstToJavascriptConverter
+partial class AstToJavaScriptConverter
 {
     [Flags]
     protected internal enum BinaryOperationFlags
@@ -16,10 +16,10 @@ partial class AstToJavascriptConverter
     {
         None = 0,
 
-        NeedsSemicolon = JavascriptTextWriter.StatementFlags.NeedsSemicolon,
-        MayOmitRightMostSemicolon = JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon,
-        IsRightMost = JavascriptTextWriter.StatementFlags.IsRightMost,
-        IsStatementBody = JavascriptTextWriter.StatementFlags.IsStatementBody,
+        NeedsSemicolon = JavaScriptTextWriter.StatementFlags.NeedsSemicolon,
+        MayOmitRightMostSemicolon = JavaScriptTextWriter.StatementFlags.MayOmitRightMostSemicolon,
+        IsRightMost = JavaScriptTextWriter.StatementFlags.IsRightMost,
+        IsStatementBody = JavaScriptTextWriter.StatementFlags.IsStatementBody,
 
         NestedVariableDeclaration = 1 << 16,
     }
@@ -29,12 +29,12 @@ partial class AstToJavascriptConverter
     {
         None = 0,
 
-        NeedsBrackets = JavascriptTextWriter.ExpressionFlags.NeedsBrackets,
-        IsLeftMost = JavascriptTextWriter.ExpressionFlags.IsLeftMost,
+        NeedsBrackets = JavaScriptTextWriter.ExpressionFlags.NeedsBrackets,
+        IsLeftMost = JavaScriptTextWriter.ExpressionFlags.IsLeftMost,
 
-        SpaceBeforeBracketsRecommended = JavascriptTextWriter.ExpressionFlags.SpaceBeforeBracketsRecommended,
-        SpaceAfterBracketsRecommended = JavascriptTextWriter.ExpressionFlags.SpaceAfterBracketsRecommended,
-        SpaceAroundBracketsRecommended = JavascriptTextWriter.ExpressionFlags.SpaceAroundBracketsRecommended,
+        SpaceBeforeBracketsRecommended = JavaScriptTextWriter.ExpressionFlags.SpaceBeforeBracketsRecommended,
+        SpaceAfterBracketsRecommended = JavaScriptTextWriter.ExpressionFlags.SpaceAfterBracketsRecommended,
+        SpaceAroundBracketsRecommended = JavaScriptTextWriter.ExpressionFlags.SpaceAroundBracketsRecommended,
 
         IsMethod = 1 << 16,
 

--- a/src/Esprima/Utils/AstToJavascriptConverter.Helpers.cs
+++ b/src/Esprima/Utils/AstToJavascriptConverter.Helpers.cs
@@ -1,11 +1,11 @@
 ﻿using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
-using static Esprima.Utils.JavascriptTextWriter;
+using static Esprima.Utils.JavaScriptTextWriter;
 
 namespace Esprima.Utils;
 
-partial class AstToJavascriptConverter
+partial class AstToJavaScriptConverter
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private protected static StatementFlags StatementBodyFlags(bool isRightMost)
@@ -36,7 +36,7 @@ partial class AstToJavascriptConverter
         return flags;
     }
 
-    private protected static readonly Func<AstToJavascriptConverter, Statement, StatementFlags, StatementFlags> s_getCombinedStatementFlags = static (@this, statement, flags) =>
+    private protected static readonly Func<AstToJavaScriptConverter, Statement, StatementFlags, StatementFlags> s_getCombinedStatementFlags = static (@this, statement, flags) =>
         @this.PropagateStatementFlags(flags);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -45,14 +45,14 @@ partial class AstToJavascriptConverter
         VisitStatement(statement, flags, s_getCombinedStatementFlags);
     }
 
-    protected void VisitStatement(Statement statement, StatementFlags flags, Func<AstToJavascriptConverter, Statement, StatementFlags, StatementFlags> getCombinedFlags)
+    protected void VisitStatement(Statement statement, StatementFlags flags, Func<AstToJavaScriptConverter, Statement, StatementFlags, StatementFlags> getCombinedFlags)
     {
         var originalStatementFlags = _currentStatementFlags;
         _currentStatementFlags = getCombinedFlags(this, statement, flags);
 
-        Writer.StartStatement((JavascriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
+        Writer.StartStatement((JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
         Visit(statement);
-        Writer.EndStatement((JavascriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
+        Writer.EndStatement((JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
 
         _currentStatementFlags = originalStatementFlags;
     }
@@ -64,7 +64,7 @@ partial class AstToJavascriptConverter
             (index == count - 1).ToFlag(StatementFlags.IsRightMost | StatementFlags.MayOmitRightMostSemicolon));
     }
 
-    protected void VisitStatementList(in NodeList<Statement> statementList, Func<AstToJavascriptConverter, Statement, int, int, StatementFlags> getCombinedItemFlags)
+    protected void VisitStatementList(in NodeList<Statement> statementList, Func<AstToJavaScriptConverter, Statement, int, int, StatementFlags> getCombinedItemFlags)
     {
         Writer.StartStatementList(statementList.Count, ref _writeContext);
 
@@ -76,14 +76,14 @@ partial class AstToJavascriptConverter
         Writer.EndStatementList(statementList.Count, ref _writeContext);
     }
 
-    protected void VisitStatementListItem(Statement statement, int index, int count, Func<AstToJavascriptConverter, Statement, int, int, StatementFlags> getCombinedFlags)
+    protected void VisitStatementListItem(Statement statement, int index, int count, Func<AstToJavaScriptConverter, Statement, int, int, StatementFlags> getCombinedFlags)
     {
         var originalStatementFlags = _currentStatementFlags;
         _currentStatementFlags = getCombinedFlags(this, statement, index, count);
 
-        Writer.StartStatementListItem(index, count, (JavascriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
+        Writer.StartStatementListItem(index, count, (JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
         Visit(statement);
-        Writer.EndStatementListItem(index, count, (JavascriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
+        Writer.EndStatementListItem(index, count, (JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
 
         _currentStatementFlags = originalStatementFlags;
     }
@@ -160,7 +160,7 @@ partial class AstToJavascriptConverter
         return flags;
     }
 
-    private protected static readonly Func<AstToJavascriptConverter, Expression, ExpressionFlags, ExpressionFlags> s_getCombinedRootExpressionFlags = static (@this, expression, flags) =>
+    private protected static readonly Func<AstToJavaScriptConverter, Expression, ExpressionFlags, ExpressionFlags> s_getCombinedRootExpressionFlags = static (@this, expression, flags) =>
         @this.DisambiguateExpression(expression, flags);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -169,7 +169,7 @@ partial class AstToJavascriptConverter
         VisitExpression(expression, flags, s_getCombinedRootExpressionFlags);
     }
 
-    private protected static readonly Func<AstToJavascriptConverter, Expression, ExpressionFlags, ExpressionFlags> s_getCombinedSubExpressionFlags = static (@this, expression, flags) =>
+    private protected static readonly Func<AstToJavaScriptConverter, Expression, ExpressionFlags, ExpressionFlags> s_getCombinedSubExpressionFlags = static (@this, expression, flags) =>
         @this.DisambiguateExpression(expression, @this.PropagateExpressionFlags(flags));
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -178,14 +178,14 @@ partial class AstToJavascriptConverter
         VisitExpression(expression, flags, s_getCombinedSubExpressionFlags);
     }
 
-    protected void VisitExpression(Expression expression, ExpressionFlags flags, Func<AstToJavascriptConverter, Expression, ExpressionFlags, ExpressionFlags> getCombinedFlags)
+    protected void VisitExpression(Expression expression, ExpressionFlags flags, Func<AstToJavaScriptConverter, Expression, ExpressionFlags, ExpressionFlags> getCombinedFlags)
     {
         var originalExpressionFlags = _currentExpressionFlags;
         _currentExpressionFlags = getCombinedFlags(this, expression, flags);
 
-        Writer.StartExpression((JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+        Writer.StartExpression((JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
         Visit(expression);
-        Writer.EndExpression((JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+        Writer.EndExpression((JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
 
         _currentExpressionFlags = originalExpressionFlags;
     }
@@ -197,7 +197,7 @@ partial class AstToJavascriptConverter
             s_getCombinedSubExpressionFlags(@this, expression, SubExpressionFlags(@this.ExpressionNeedsBracketsInList(expression), isLeftMost: false)));
     }
 
-    protected void VisitExpressionList(in NodeList<Expression> expressionList, Func<AstToJavascriptConverter, Expression, int, int, ExpressionFlags> getCombinedItemFlags)
+    protected void VisitExpressionList(in NodeList<Expression> expressionList, Func<AstToJavaScriptConverter, Expression, int, int, ExpressionFlags> getCombinedItemFlags)
     {
         Writer.StartExpressionList(expressionList.Count, ref _writeContext);
 
@@ -209,14 +209,14 @@ partial class AstToJavascriptConverter
         Writer.EndExpressionList(expressionList.Count, ref _writeContext);
     }
 
-    protected void VisitExpressionListItem(Expression expression, int index, int count, Func<AstToJavascriptConverter, Expression, int, int, ExpressionFlags> getCombinedFlags)
+    protected void VisitExpressionListItem(Expression expression, int index, int count, Func<AstToJavaScriptConverter, Expression, int, int, ExpressionFlags> getCombinedFlags)
     {
         var originalExpressionFlags = _currentExpressionFlags;
         _currentExpressionFlags = getCombinedFlags(this, expression, index, count);
 
-        Writer.StartExpressionListItem(index, count, (JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+        Writer.StartExpressionListItem(index, count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
         Visit(expression);
-        Writer.EndExpressionListItem(index, count, (JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+        Writer.EndExpressionListItem(index, count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
 
         _currentExpressionFlags = originalExpressionFlags;
     }
@@ -378,7 +378,7 @@ partial class AstToJavascriptConverter
         VisitAuxiliaryNode(node, static delegate { return null; });
     }
 
-    protected void VisitAuxiliaryNode(Node node, Func<AstToJavascriptConverter, Node, object?> getNodeContext)
+    protected void VisitAuxiliaryNode(Node node, Func<AstToJavaScriptConverter, Node, object?> getNodeContext)
     {
         var originalAuxiliaryNodeContext = _currentAuxiliaryNodeContext;
         _currentAuxiliaryNodeContext = getNodeContext(this, node);
@@ -397,7 +397,7 @@ partial class AstToJavascriptConverter
         VisitAuxiliaryNodeList(in nodeList, separator, static delegate { return null; });
     }
 
-    protected void VisitAuxiliaryNodeList<TNode>(in NodeList<TNode> nodeList, string separator, Func<AstToJavascriptConverter, Node?, int, int, object?> getNodeContext)
+    protected void VisitAuxiliaryNodeList<TNode>(in NodeList<TNode> nodeList, string separator, Func<AstToJavaScriptConverter, Node?, int, int, object?> getNodeContext)
         where TNode : Node
     {
         Writer.StartAuxiliaryNodeList<TNode>(nodeList.Count, ref _writeContext);
@@ -410,7 +410,7 @@ partial class AstToJavascriptConverter
         Writer.EndAuxiliaryNodeList<TNode>(nodeList.Count, ref _writeContext);
     }
 
-    protected void VisitAuxiliaryNodeListItem<TNode>(TNode node, int index, int count, string separator, Func<AstToJavascriptConverter, Node?, int, int, object?> getNodeContext)
+    protected void VisitAuxiliaryNodeListItem<TNode>(TNode node, int index, int count, string separator, Func<AstToJavaScriptConverter, Node?, int, int, object?> getNodeContext)
         where TNode : Node
     {
         var originalAuxiliaryNodeContext = _currentAuxiliaryNodeContext;

--- a/src/Esprima/Utils/AstToJavascriptConverter.cs
+++ b/src/Esprima/Utils/AstToJavascriptConverter.cs
@@ -1,10 +1,10 @@
 ﻿using System.Runtime.CompilerServices;
 using Esprima.Ast;
-using static Esprima.Utils.JavascriptTextWriter;
+using static Esprima.Utils.JavaScriptTextWriter;
 
 namespace Esprima.Utils;
 
-public partial class AstToJavascriptConverter : AstVisitor
+public partial class AstToJavaScriptConverter : AstVisitor
 {
     // Notes for maintainers:
     // Don't visit nodes directly (by calling Visit) unless it's necessary for some special reason (but in that case you'll need to setup the context of the visitation manually!)
@@ -25,7 +25,7 @@ public partial class AstToJavascriptConverter : AstVisitor
     private ExpressionFlags _currentExpressionFlags;
     private object? _currentAuxiliaryNodeContext;
 
-    public AstToJavascriptConverter(JavascriptTextWriter writer, AstToJavascriptOptions options)
+    public AstToJavaScriptConverter(JavaScriptTextWriter writer, AstToJavaScriptOptions options)
     {
         Writer = writer ?? throw new ArgumentNullException(nameof(writer));
 
@@ -37,7 +37,7 @@ public partial class AstToJavascriptConverter : AstVisitor
         _ignoreExtensions = options.IgnoreExtensions;
     }
 
-    public JavascriptTextWriter Writer { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public JavaScriptTextWriter Writer { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     protected ref WriteContext WriteContext { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _writeContext; }
 
@@ -91,8 +91,8 @@ public partial class AstToJavascriptConverter : AstVisitor
                 var originalExpressionFlags = _currentExpressionFlags;
                 _currentExpressionFlags = PropagateExpressionFlags(SubExpressionFlags(needsBrackets: false, isLeftMost: false));
 
-                Writer.StartExpressionListItem(i, arrayExpression.Elements.Count, (JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
-                Writer.EndExpressionListItem(i, arrayExpression.Elements.Count, (JavascriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+                Writer.StartExpressionListItem(i, arrayExpression.Elements.Count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
+                Writer.EndExpressionListItem(i, arrayExpression.Elements.Count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
 
                 _currentExpressionFlags = originalExpressionFlags;
             }
@@ -1006,7 +1006,7 @@ public partial class AstToJavascriptConverter : AstVisitor
         }
 
         var index = 0;
-        Func<AstToJavascriptConverter, Node?, int, int, object?> getNodeContext = static delegate { return null; };
+        Func<AstToJavaScriptConverter, Node?, int, int, object?> getNodeContext = static delegate { return null; };
 
         if (importDeclaration.Specifiers[index].Type == Nodes.ImportDefaultSpecifier)
         {

--- a/src/Esprima/Utils/EnumHelper.cs
+++ b/src/Esprima/Utils/EnumHelper.cs
@@ -17,26 +17,26 @@ internal static class EnumHelper
     // In case System.Runtime.CompilerServices.Unsafe becomes available, these methods should be replaced with a generic implementation.
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this AstToJavascriptConverter.BinaryOperationFlags flags, AstToJavascriptConverter.BinaryOperationFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this AstToJavaScriptConverter.BinaryOperationFlags flags, AstToJavaScriptConverter.BinaryOperationFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this AstToJavascriptConverter.StatementFlags flags, AstToJavascriptConverter.StatementFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this AstToJavaScriptConverter.StatementFlags flags, AstToJavaScriptConverter.StatementFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this AstToJavascriptConverter.ExpressionFlags flags, AstToJavascriptConverter.ExpressionFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this AstToJavaScriptConverter.ExpressionFlags flags, AstToJavaScriptConverter.ExpressionFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this JavascriptTextWriter.TriviaType flags, JavascriptTextWriter.TriviaType flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this JavaScriptTextWriter.TriviaType flags, JavaScriptTextWriter.TriviaType flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this JavascriptTextWriter.TriviaFlags flags, JavascriptTextWriter.TriviaFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this JavaScriptTextWriter.TriviaFlags flags, JavaScriptTextWriter.TriviaFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this JavascriptTextWriter.TokenFlags flags, JavascriptTextWriter.TokenFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this JavaScriptTextWriter.TokenFlags flags, JavaScriptTextWriter.TokenFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this JavascriptTextWriter.StatementFlags flags, JavascriptTextWriter.StatementFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this JavaScriptTextWriter.StatementFlags flags, JavaScriptTextWriter.StatementFlags flag) => (flags & flag) == flag;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static bool HasFlagFast(this JavascriptTextWriter.ExpressionFlags flags, JavascriptTextWriter.ExpressionFlags flag) => (flags & flag) == flag;
+    public static bool HasFlagFast(this JavaScriptTextWriter.ExpressionFlags flags, JavaScriptTextWriter.ExpressionFlags flag) => (flags & flag) == flag;
 }

--- a/src/Esprima/Utils/JavascriptTextFormatter.cs
+++ b/src/Esprima/Utils/JavascriptTextFormatter.cs
@@ -3,7 +3,7 @@ using Esprima.Ast;
 
 namespace Esprima.Utils;
 
-public abstract record class JavascriptTextFormatterOptions : JavascriptTextWriterOptions
+public abstract record class JavaScriptTextFormatterOptions : JavaScriptTextWriterOptions
 {
     public string? Indent { get; init; }
     public bool KeepSingleStatementBodyInLine { get; init; }
@@ -11,20 +11,20 @@ public abstract record class JavascriptTextFormatterOptions : JavascriptTextWrit
     public int MultiLineArrayLiteralThreshold { get; init; } = 7;
     public int MultiLineObjectLiteralThreshold { get; init; } = 3;
 
-    protected abstract JavascriptTextFormatter CreateFormatter(TextWriter writer);
+    protected abstract JavaScriptTextFormatter CreateFormatter(TextWriter writer);
 
-    protected internal sealed override JavascriptTextWriter CreateWriter(TextWriter writer) => CreateFormatter(writer);
+    protected internal sealed override JavaScriptTextWriter CreateWriter(TextWriter writer) => CreateFormatter(writer);
 }
 
 /// <summary>
-/// Base class for Javascript code formatters.
+/// Base class for JavaScript code formatters.
 /// </summary>
-public abstract class JavascriptTextFormatter : JavascriptTextWriter
+public abstract class JavaScriptTextFormatter : JavaScriptTextWriter
 {
     private readonly string _indent;
     private int _indentionLevel;
 
-    public JavascriptTextFormatter(TextWriter writer, JavascriptTextFormatterOptions options) : base(writer, options)
+    public JavaScriptTextFormatter(TextWriter writer, JavaScriptTextFormatterOptions options) : base(writer, options)
     {
         if (!string.IsNullOrWhiteSpace(options.Indent))
         {

--- a/src/Esprima/Utils/JavascriptTextWriter.Enums.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.Enums.cs
@@ -2,7 +2,7 @@
 
 namespace Esprima.Utils;
 
-partial class JavascriptTextWriter
+partial class JavaScriptTextWriter
 {
     private protected const TriviaType WhiteSpaceTriviaFlag = (TriviaType) (1 << 1);
     private protected const TriviaType CommentTriviaFlag = (TriviaType) (1 << 2);
@@ -72,14 +72,14 @@ partial class JavascriptTextWriter
         /// A leading space is recommended for the current token (unless other white-space precedes it).
         /// </summary>
         /// <remarks>
-        /// May or may not be respected. (It is decided by the actual <see cref="JavascriptTextWriter"/> implementation.)
+        /// May or may not be respected. (It is decided by the actual <see cref="JavaScriptTextWriter"/> implementation.)
         /// </remarks>
         LeadingSpaceRecommended = 1 << 14,
         /// <summary>
         /// A trailing space is recommended for the current token (unless other white-space follows it).
         /// </summary>
         /// <remarks>
-        /// May or may not be respected. (It is decided by the actual <see cref="JavascriptTextWriter"/> implementation.)
+        /// May or may not be respected. (It is decided by the actual <see cref="JavaScriptTextWriter"/> implementation.)
         /// </remarks>
         TrailingSpaceRecommended = 1 << 15,
 
@@ -87,7 +87,7 @@ partial class JavascriptTextWriter
         /// Surrounding spaces are recommended for the current token (unless other white-spaces surround it).
         /// </summary>
         /// <remarks>
-        /// May or may not be respected. (It is decided by the actual <see cref="JavascriptTextWriter"/> implementation.)
+        /// May or may not be respected. (It is decided by the actual <see cref="JavaScriptTextWriter"/> implementation.)
         /// </remarks>
         SurroundingSpaceRecommended = LeadingSpaceRecommended | TrailingSpaceRecommended,
     }
@@ -96,7 +96,7 @@ partial class JavascriptTextWriter
     public enum StatementFlags
     {
         // Notes for maintainers:
-        // Don't use the high-order word as it's reserved for internal use (see AstToJavascriptConverter.StatementFlags)
+        // Don't use the high-order word as it's reserved for internal use (see AstToJavaScriptConverter.StatementFlags)
 
         None = 0,
         /// <summary>
@@ -108,14 +108,14 @@ partial class JavascriptTextWriter
         /// </summary>
         /// <remarks>
         /// Automatically propagated to child statements, should be set directly only for statement list items.
-        /// Whether the semicolon is omitted or not is decided by the actual <see cref="JavascriptTextWriter"/> implementation.
+        /// Whether the semicolon is omitted or not is decided by the actual <see cref="JavaScriptTextWriter"/> implementation.
         /// </remarks>
         MayOmitRightMostSemicolon = 1 << 1,
         /// <summary>
         /// The statement comes last in the current statement list (more precisely, it is the right-most part in the textual representation of the current statement list).
         /// </summary>
         /// <remarks>
-        /// In the the visitation handlers of <see cref="AstToJavascriptConverter"/> the flag is interpreted differently: it indicates that the statement comes last in the parent statement.
+        /// In the the visitation handlers of <see cref="AstToJavaScriptConverter"/> the flag is interpreted differently: it indicates that the statement comes last in the parent statement.
         /// (Upon visiting a statement, this flag of the parent and child statement gets combined to determine its effective value for the current statement list.)
         /// </remarks>
         IsRightMost = 1 << 2,
@@ -129,7 +129,7 @@ partial class JavascriptTextWriter
     public enum ExpressionFlags
     {
         // Notes for maintainers:
-        // Don't use the high-order word as it's reserved for internal use (see AstToJavascriptConverter.ExpressionFlags)
+        // Don't use the high-order word as it's reserved for internal use (see AstToJavaScriptConverter.ExpressionFlags)
 
         None = 0,
         /// <summary>
@@ -140,7 +140,7 @@ partial class JavascriptTextWriter
         /// The expression comes first in the current expression tree, more precisely, it is the left-most part in the textual representation of the currently visited expression tree (incl. brackets).
         /// </summary>
         /// <remarks>
-        /// In the the visitation handlers of <see cref="AstToJavascriptConverter"/> the flag is interpreted differently: it indicates that the expression comes first in the parent expression.
+        /// In the the visitation handlers of <see cref="AstToJavaScriptConverter"/> the flag is interpreted differently: it indicates that the expression comes first in the parent expression.
         /// (Upon visiting an expression, this flag of the parent and child expression gets combined to determine its effective value for the expression tree.)
         /// </remarks>
         IsLeftMost = 1 << 1,

--- a/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
@@ -8,7 +8,7 @@ public delegate object? NodePropertyValueAccessor(Node node);
 
 public delegate ref readonly NodeList<T> NodePropertyListValueAccessor<T>(Node node) where T : Node?;
 
-partial class JavascriptTextWriter
+partial class JavaScriptTextWriter
 {
     public struct WriteContext
     {

--- a/src/Esprima/Utils/JavascriptTextWriter.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.cs
@@ -3,21 +3,21 @@ using Esprima.Ast;
 
 namespace Esprima.Utils;
 
-public record class JavascriptTextWriterOptions
+public record class JavaScriptTextWriterOptions
 {
-    public static readonly JavascriptTextWriterOptions Default = new();
+    public static readonly JavaScriptTextWriterOptions Default = new();
 
-    protected internal virtual JavascriptTextWriter CreateWriter(TextWriter writer) => new JavascriptTextWriter(writer, this);
+    protected internal virtual JavaScriptTextWriter CreateWriter(TextWriter writer) => new JavaScriptTextWriter(writer, this);
 }
 
 /// <summary>
-/// Base Javascript text writer (code formatter) which uses the most compact possible (i.e. minimal) format.
+/// Base JavaScript text writer (code formatter) which uses the most compact possible (i.e. minimal) format.
 /// </summary>
-public partial class JavascriptTextWriter
+public partial class JavaScriptTextWriter
 {
     private readonly TextWriter _writer;
 
-    public JavascriptTextWriter(TextWriter writer, JavascriptTextWriterOptions options)
+    public JavaScriptTextWriter(TextWriter writer, JavaScriptTextWriterOptions options)
     {
         _writer = writer ?? throw new ArgumentNullException(nameof(writer));
 

--- a/src/Esprima/Utils/Jsx/JsxAstToJavascriptConverter.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstToJavascriptConverter.cs
@@ -1,20 +1,20 @@
 ﻿using Esprima.Ast;
 using Esprima.Ast.Jsx;
-using static Esprima.Utils.JavascriptTextWriter;
+using static Esprima.Utils.JavaScriptTextWriter;
 
 namespace Esprima.Utils.Jsx;
 
-public record class JsxAstToJavascriptOptions : AstToJavascriptOptions
+public record class JsxAstToJavaScriptOptions : AstToJavaScriptOptions
 {
-    public static new readonly JsxAstToJavascriptOptions Default = new();
+    public static new readonly JsxAstToJavaScriptOptions Default = new();
 
-    protected internal override AstToJavascriptConverter CreateConverter(JavascriptTextWriter writer) => new JsxAstToJavascriptConverter(writer, this);
+    protected internal override AstToJavaScriptConverter CreateConverter(JavaScriptTextWriter writer) => new JsxAstToJavaScriptConverter(writer, this);
 }
 
 // JSX spec: https://facebook.github.io/jsx/
-public class JsxAstToJavascriptConverter : AstToJavascriptConverter, IJsxAstVisitor
+public class JsxAstToJavaScriptConverter : AstToJavaScriptConverter, IJsxAstVisitor
 {
-    public JsxAstToJavascriptConverter(JavascriptTextWriter writer, JsxAstToJavascriptOptions options) : base(writer, options)
+    public JsxAstToJavaScriptConverter(JavaScriptTextWriter writer, JsxAstToJavaScriptOptions options) : base(writer, options)
     {
     }
 

--- a/src/Esprima/Utils/KnRJavascriptTextFormatter.cs
+++ b/src/Esprima/Utils/KnRJavascriptTextFormatter.cs
@@ -3,26 +3,26 @@ using Esprima.Ast;
 
 namespace Esprima.Utils;
 
-public record class KnRJavascriptTextFormatterOptions : JavascriptTextFormatterOptions
+public record class KnRJavaScriptTextFormatterOptions : JavaScriptTextFormatterOptions
 {
-    public static new readonly KnRJavascriptTextFormatterOptions Default = new();
+    public static new readonly KnRJavaScriptTextFormatterOptions Default = new();
 
-    public KnRJavascriptTextFormatterOptions()
+    public KnRJavaScriptTextFormatterOptions()
     {
         KeepEmptyBlockBodyInLine = true;
     }
 
     public bool UseEgyptianBraces { get; init; } = true;
 
-    protected override JavascriptTextFormatter CreateFormatter(TextWriter writer) => new KnRJavascriptTextFormatter(writer, this);
+    protected override JavaScriptTextFormatter CreateFormatter(TextWriter writer) => new KnRJavaScriptTextFormatter(writer, this);
 }
 
 /// <summary>
-/// Javascript code formatter which implements the most common <see href="https://en.wikipedia.org/wiki/Indentation_style#K&amp;R_style">K&amp;R style</see>.
+/// JavaScript code formatter which implements the most common <see href="https://en.wikipedia.org/wiki/Indentation_style#K&amp;R_style">K&amp;R style</see>.
 /// </summary>
-public class KnRJavascriptTextFormatter : JavascriptTextFormatter
+public class KnRJavaScriptTextFormatter : JavaScriptTextFormatter
 {
-    public KnRJavascriptTextFormatter(TextWriter writer, KnRJavascriptTextFormatterOptions options) : base(writer, options)
+    public KnRJavaScriptTextFormatter(TextWriter writer, KnRJavaScriptTextFormatterOptions options) : base(writer, options)
     {
         UseEgyptianBraces = options.UseEgyptianBraces;
     }

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -6,16 +6,16 @@ using Esprima.Utils.Jsx;
 
 namespace Esprima.Tests;
 
-public class AstToJavascriptTests
+public class AstToJavaScriptTests
 {
-    private record class CustomCompactJavascriptTextWriterOptions : JavascriptTextWriterOptions
+    private record class CustomCompactJavaScriptTextWriterOptions : JavaScriptTextWriterOptions
     {
-        protected internal override JavascriptTextWriter CreateWriter(TextWriter writer) => new CustomCompactJavascriptTextWriter(writer, this);
+        protected internal override JavaScriptTextWriter CreateWriter(TextWriter writer) => new CustomCompactJavaScriptTextWriter(writer, this);
     }
 
-    private sealed class CustomCompactJavascriptTextWriter : JavascriptTextWriter
+    private sealed class CustomCompactJavaScriptTextWriter : JavaScriptTextWriter
     {
-        public CustomCompactJavascriptTextWriter(TextWriter writer, CustomCompactJavascriptTextWriterOptions options) : base(writer, options) { }
+        public CustomCompactJavaScriptTextWriter(TextWriter writer, CustomCompactJavaScriptTextWriterOptions options) : base(writer, options) { }
 
         public override void EndStatement(StatementFlags flags, ref WriteContext context)
         {
@@ -43,8 +43,8 @@ public class AstToJavascriptTests
         }
     }
 
-    private static readonly CustomCompactJavascriptTextWriterOptions s_customCompactWriterOptions = new();
-    private static readonly KnRJavascriptTextFormatterOptions s_formattingOptions = new()
+    private static readonly CustomCompactJavaScriptTextWriterOptions s_customCompactWriterOptions = new();
+    private static readonly KnRJavaScriptTextFormatterOptions s_formattingOptions = new()
     {
         Indent = "    ",
         KeepEmptyBlockBodyInLine = false,
@@ -52,7 +52,7 @@ public class AstToJavascriptTests
     };
 
     [Fact]
-    public void ToJavascriptTest1()
+    public void ToJavaScriptTest1()
     {
         var parser = new JavaScriptParser(@"if (true) { p(); }
 switch(foo) {
@@ -70,13 +70,13 @@ for (var elem of list) { }
 ");
         var program = parser.ParseScript();
 
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
 
         Assert.Equal("if(true){p();}switch(foo){case'A':p();break;}switch(foo){default:p();break;}for(var a=[];;){}for(var elem of list){}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest2()
+    public void ToJavaScriptTest2()
     {
         var parser = new JavaScriptParser(@"let tips = [
   ""Click on any AST node with a '+' to expand it"",
@@ -92,12 +92,12 @@ for (var elem of list) { }
                 tips.forEach((tip, i) => console.log(`Tip ${ i}:` +tip));
         }");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("let tips=[\"Click on any AST node with a '+' to expand it\",\"Hovering over a node highlights the \\\r\n   corresponding location in the source code\",\"Shift click on an AST node to expand the whole subtree\"];function printTips(){tips.forEach((tip,i)=>console.log(`Tip ${i}:`+tip));}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest3()
+    public void ToJavaScriptTest3()
     {
         var parser = new JavaScriptParser(@"export class aa extends HTMLElement{
     constructor(a, b)
@@ -110,12 +110,12 @@ for (var elem of list) { }
     }
 }");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("export class aa extends HTMLElement{constructor(a,b){super(a);this._div=document.createElement('div');}static get is(){return'aa';}}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest4()
+    public void ToJavaScriptTest4()
     {
         var source = @"import { MccDialog } from '../mccDialogHandler';
 import { commonClient, bb as f } from '../commonClient/commonClient';
@@ -174,7 +174,7 @@ export function checkSecurityAnswerCodeDirect(result) {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
 
         var expected = @"import { MccDialog } from '../mccDialogHandler';
 import { commonClient, bb as f } from '../commonClient/commonClient';
@@ -231,7 +231,7 @@ export function checkSecurityAnswerCodeDirect(result) {
     }
 
     [Fact]
-    public void ToJavascriptTest5()
+    public void ToJavaScriptTest5()
     {
         var source = @"(function () {
   'use strict';
@@ -255,7 +255,7 @@ aa({});
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
 
         var expected = @"(function() {
     'use strict';
@@ -276,7 +276,7 @@ aa({ });
     }
 
     [Fact]
-    public void ToJavascriptTest6()
+    public void ToJavaScriptTest6()
     {
         var source = @"function _createClass(Constructor, protoProps, staticProps) {
     if (protoProps) _defineProperties(Constructor.prototype, protoProps);
@@ -286,23 +286,23 @@ aa({ });
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("function _createClass(Constructor,protoProps,staticProps){if(protoProps)_defineProperties(Constructor.prototype,protoProps);if(staticProps)_defineProperties(Constructor,staticProps);return Constructor;}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest7()
+    public void ToJavaScriptTest7()
     {
         var parser = new JavaScriptParser(@"if ((x ? a.nodeName.toLowerCase() === f : 1 === a.nodeType) && ++d && (p && ((i = (o = a[S] || (a[S] = {}))[a.uniqueID] || (o[a.uniqueID] = {}))[h] = [k, d]), a === e))
 {
 }");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("if((x?a.nodeName.toLowerCase()===f:1===a.nodeType)&&++d&&(p&&((i=(o=a[S]||(a[S]={}))[a.uniqueID]||(o[a.uniqueID]={}))[h]=[k,d]),a===e)){}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest8()
+    public void ToJavaScriptTest8()
     {
         var parser = new JavaScriptParser(@"
 class a extends b {
@@ -316,34 +316,34 @@ class a extends b {
 }
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("class a extends b{constructor(){super();this.g=1;}q=1;r='cc';}", code);
     }
 
     [Fact]
-    public void ToJavascriptTest9()
+    public void ToJavaScriptTest9()
     {
         var parser = new JavaScriptParser(@"
 d = (s = (r = (i = (o = (a = c)[S] || (a[S] = {}))[a.uniqueID] || (o[a.uniqueID] = {}))[h] || [])[0] === k && r[1]) && r[2], a = s && c.childNodes[s];
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("d=(s=(r=(i=(o=(a=c)[S]||(a[S]={}))[a.uniqueID]||(o[a.uniqueID]={}))[h]||[])[0]===k&&r[1])&&r[2],a=s&&c.childNodes[s];", code);
     }
 
     [Fact]
-    public void ToJavascriptTest10()
+    public void ToJavaScriptTest10()
     {
         var parser = new JavaScriptParser(@"
 m = (z.document, !!v.documentElement && !!v.head && 'function' == typeof v.addEventListener && v.createElement, ~a.indexOf('MSIE') || a.indexOf('Trident/'), '___FONT_AWESOME___')
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("m=(z.document,!!v.documentElement&&!!v.head&&'function'==typeof v.addEventListener&&v.createElement,~a.indexOf('MSIE')||a.indexOf('Trident/'),'___FONT_AWESOME___');", code);
     }
 
     [Fact]
-    public void ToJavascriptTest11()
+    public void ToJavaScriptTest11()
     {
         var parser = new JavaScriptParser(@"
  var h = (c.navigator || {}).userAgent,
@@ -360,12 +360,12 @@ m = (z.document, !!v.documentElement && !!v.head && 'function' == typeof v.addEv
         }();
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("var h=(c.navigator||{}).userAgent,a=void 0===h?'':h,z=c,v=l,m=(z.document,!!v.documentElement&&!!v.head&&'function'==typeof v.addEventListener&&v.createElement,~a.indexOf('MSIE')||a.indexOf('Trident/'),'___FONT_AWESOME___'),e=function(){try{return!0;}catch(c){return!1;}}();", code);
     }
 
     [Fact]
-    public void ToJavascriptTest12()
+    public void ToJavaScriptTest12()
     {
         var parser = new JavaScriptParser(@"
 var a = {
@@ -373,12 +373,12 @@ children: (b = O, 'g' === b.tag ? b.children : [b])
 }
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("var a={children:(b=O,'g'===b.tag?b.children:[b])};", code);
     }
 
     [Fact]
-    public void ToJavascriptTest13()
+    public void ToJavaScriptTest13()
     {
         var parser = new JavaScriptParser(@"
 if (e.IsWebService)
@@ -390,12 +390,12 @@ if (e.IsWebService)
 	} else h = e.HttpRequest.responseText;
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("if(e.IsWebService)if(h=e.HttpRequest.responseXML,'undefined'==typeof h)Trace.Write('Error: '+e.UniqueId+' data has no properties!'),m=!0;else try{h.setProperty('SelectionLanguage','XPath');}catch(l){Trace.Write('Error: data.setProperty(',SelectionLanguage,', ',XPath,') because '+l.message);}else h=e.HttpRequest.responseText;", code);
     }
 
     [Fact]
-    public void ToJavascriptTest14()
+    public void ToJavaScriptTest14()
     {
         var source = @"function tt(t, r) {
   var n, e, i = b(t),
@@ -410,7 +410,7 @@ if (e.IsWebService)
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
 
         var expected = @"function tt(t, r) {
     var n, e, i = b(t), s = b(r);
@@ -430,18 +430,18 @@ if (e.IsWebService)
     }
 
     [Fact]
-    public void ToJavascriptTest15()
+    public void ToJavaScriptTest15()
     {
         var parser = new JavaScriptParser(@"
 h='M'+(+new Date).toString(36)
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("h='M'+(+new Date).toString(36);", code);
     }
 
     [Fact]
-    public void ToJavascriptTest16()
+    public void ToJavaScriptTest16()
     {
         var parser = new JavaScriptParser(@"
 input.onchange = async (e) => {
@@ -451,56 +451,56 @@ input.onchange = async (e) => {
         };
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("input.onchange=async e=>{const files=await readFiles(input.files,readMode);document.body.removeChild(input);resolve(files);};", code);
     }
 
     [Fact]
-    public void ToJavascriptTest17()
+    public void ToJavaScriptTest17()
     {
         var parser = new JavaScriptParser(@"
 export const Base = LegacyElementMixin(HTMLElement).prototype;
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("export const Base=LegacyElementMixin(HTMLElement).prototype;", code);
     }
 
     [Fact]
-    public void ToJavascriptTest18()
+    public void ToJavaScriptTest18()
     {
         var parser = new JavaScriptParser(@"
 let {is} = getIsExtends(element);
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("let{is}=getIsExtends(element);", code);
     }
 
     [Fact]
-    public void ToJavascriptTest19()
+    public void ToJavaScriptTest19()
     {
         var parser = new JavaScriptParser(@"
 export const wrap =
   (window['ShadyDOM'] && window['ShadyDOM']['wrap']) || (node => node);
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("export const wrap=window['ShadyDOM']&&window['ShadyDOM']['wrap']||(node=>node);", code);
     }
 
     [Fact]
-    public void ToJavascriptTest20()
+    public void ToJavaScriptTest20()
     {
         var parser = new JavaScriptParser(@"
 export {}");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("export{};", code);
     }
 
     [Fact]
-    public void ToJavascriptTest21()
+    public void ToJavaScriptTest21()
     {
         var parser = new JavaScriptParser(@"
 (() => {
@@ -508,12 +508,12 @@ export {}");
 })();
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("(()=>{mutablePropertyChange=MutableData._mutablePropertyChange;})();", code);
     }
 
     [Fact]
-    public void ToJavascriptTest22()
+    public void ToJavaScriptTest22()
     {
         var parser = new JavaScriptParser(@"
 var Ol, jl = new (function() {
@@ -522,12 +522,12 @@ var Ol, jl = new (function() {
     }())
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("var Ol,jl=new(function(){var l,h,z;return l=c;}());", code);
     }
 
     [Fact]
-    public void ToJavascriptTest23()
+    public void ToJavaScriptTest23()
     {
         var parser = new JavaScriptParser(@"
 
@@ -539,12 +539,12 @@ var Ol, jl = new (function() {
         
 ");
         var program = parser.ParseScript();
-        var code = program.ToJavascriptString(s_customCompactWriterOptions, AstToJavascriptOptions.Default);
+        var code = program.ToJavaScriptString(s_customCompactWriterOptions, AstToJavaScriptOptions.Default);
         Assert.Equal("[y,{[Symbol.iterator](){return b;},a:5}];", code);
     }
 
     [Fact]
-    public void ToJavascriptTest24()
+    public void ToJavaScriptTest24()
     {
         var source = @"
 
@@ -561,7 +561,7 @@ class A {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
 
         var expected = @"class A {
     *[Symbol.iterator]() {
@@ -576,7 +576,7 @@ class A {
     }
 
     [Fact]
-    public void ToJavascriptTest25()
+    public void ToJavaScriptTest25()
     {
         var source = @"var i = function e(i) {
             var r = n[i];
@@ -592,7 +592,7 @@ class A {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
 
         var expected = @"var i = function e(i) {
     var r = n[i];
@@ -609,7 +609,7 @@ class A {
     }
 
     [Fact]
-    public void ToJavascriptTest26()
+    public void ToJavaScriptTest26()
     {
         var source = @"class A {
     aa() {
@@ -627,7 +627,7 @@ if (b == 2) {
         source = Regex.Replace(source, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         var parser = new JavaScriptParser(source);
         var program = parser.ParseScript();
-        var code = AstToJavascript.ToJavascriptString(program, s_formattingOptions);
+        var code = AstToJavaScript.ToJavaScriptString(program, s_formattingOptions);
         Assert.Equal(source, code);
     }
 
@@ -642,7 +642,7 @@ if (b == 2) {
     {
         var parser = new JsxParser(source);
         Node ast = isExpression ? parser.ParseExpression() : parser.ParseScript();
-        var actual = AstToJavascript.ToJavascriptString(ast, JavascriptTextWriterOptions.Default, JsxAstToJavascriptOptions.Default);
+        var actual = AstToJavaScript.ToJavaScriptString(ast, JavaScriptTextWriterOptions.Default, JsxAstToJavaScriptOptions.Default);
 
         expected = Regex.Replace(expected, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         Assert.Equal(expected, actual);
@@ -660,7 +660,7 @@ if (b == 2) {
     {
         var parser = new JsxParser(source);
         Node ast = isExpression ? parser.ParseExpression() : parser.ParseScript();
-        var actual = AstToJavascript.ToJavascriptString(ast, KnRJavascriptTextFormatterOptions.Default, JsxAstToJavascriptOptions.Default);
+        var actual = AstToJavaScript.ToJavaScriptString(ast, KnRJavaScriptTextFormatterOptions.Default, JsxAstToJavaScriptOptions.Default);
 
         expected = Regex.Replace(expected, @"\r\n|\n\r|\n|\r", Environment.NewLine);
         Assert.Equal(expected, actual);
@@ -765,7 +765,7 @@ if (b == 2) {
         try { expectedAst = Parse(sourceType, script, parserOptions, parserFactory); }
         catch (ParserException) { return; }
 
-        var generatedScript = expectedAst.ToJavascriptString();
+        var generatedScript = expectedAst.ToJavaScriptString();
 
         var actualAst = Parse(sourceType, generatedScript, parserOptions, parserFactory);
 
@@ -773,7 +773,7 @@ if (b == 2) {
         // TODO: more detailed comparison.
         Assert.Equal(expectedAst.DescendantNodesAndSelf(), actualAst.DescendantNodesAndSelf(), NodeTypeEqualityComparer.Default);
 
-        generatedScript = expectedAst.ToJavascriptString(format: true);
+        generatedScript = expectedAst.ToJavaScriptString(format: true);
 
         actualAst = Parse(sourceType, generatedScript, parserOptions, parserFactory);
 

--- a/test/Esprima.Tests/JavascriptTextWriterTests.cs
+++ b/test/Esprima.Tests/JavascriptTextWriterTests.cs
@@ -4,9 +4,9 @@ using Esprima.Utils;
 
 namespace Esprima.Tests;
 
-public class JavascriptTextWriterTests
+public class JavaScriptTextWriterTests
 {
-    public record class TestCase(Action<JavascriptTextWriter> Write, string ExpectedUnformatted, string ExpectedFormatted) { }
+    public record class TestCase(Action<JavaScriptTextWriter> Write, string ExpectedUnformatted, string ExpectedFormatted) { }
 
     private static readonly Program s_dummyAst = new Script(
         NodeList.Create<Statement>(new[]
@@ -21,10 +21,10 @@ public class JavascriptTextWriterTests
     private static readonly Dictionary<string, TestCase> s_testCaseDictionary = new()
     {
         ["TwoLineCommentsAtBeginning"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
-                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteLineComment(" def", JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"//abc
@@ -35,10 +35,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["TwoBlockCommentsAtBeginning_1"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*//* def */",
@@ -47,10 +47,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["TwoBlockCommentsAtBeginning_2"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*/
@@ -61,10 +61,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["TwoBlockCommentsAtBeginning_3"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*/
@@ -75,10 +75,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["MultiLineBlockAndBlockCommentsAtBeginning_1"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*!
@@ -91,10 +91,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["MultiLineBlockAndBlockCommentsAtBeginning_2"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteBlockComment(new[] { "!", " * abc", " " }, JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*!
@@ -109,10 +109,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["LineAndBlockCommentsAtBeginning"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteBlockComment(new[] { " def " }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { " def " }, JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"//abc
@@ -123,10 +123,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["BlockAndLineCommentsAtBeginning_1"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment(" def", JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*/// def",
@@ -135,10 +135,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["BlockAndLineCommentsAtBeginning_2"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
-                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+                writer.WriteLineComment(" def", JavaScriptTextWriter.TriviaFlags.None);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*/
@@ -149,10 +149,10 @@ public class JavascriptTextWriterTests
         ),
 
         ["BlockAndLineCommentsAtBeginning_3"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteLineComment(" def", JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment(" def", JavaScriptTextWriter.TriviaFlags.LeadingNewLineRequired);
                 writer.Finish();
             },
             ExpectedUnformatted: @"/*abc*/
@@ -163,19 +163,19 @@ public class JavascriptTextWriterTests
         ),
 
         ["LineCommentBetweenTokens_1"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.None);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -186,19 +186,19 @@ func"
         ),
 
         ["LineCommentBetweenTokens_2"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -211,18 +211,18 @@ func"
         ),
 
         ["LineCommentBetweenTokens_3"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
-                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                var writeContext = new JavaScriptTextWriter.WriteContext(s_dummyAst, blockStatement);
                 writer.StartBlock(blockStatement.Body.Count, ref writeContext);
                 writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
-                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavaScriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavaScriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
 
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.None);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.None);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -234,18 +234,18 @@ function",
         ),
 
         ["LineCommentBetweenTokens_4"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
-                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                var writeContext = new JavaScriptTextWriter.WriteContext(s_dummyAst, blockStatement);
                 writer.StartBlock(blockStatement.Body.Count, ref writeContext);
                 writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
-                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavaScriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavaScriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
 
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteLineComment("abc", JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteLineComment("abc", JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -259,19 +259,19 @@ function",
 
 
         ["BlockCommentBetweenTokens_1"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.None);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -280,19 +280,19 @@ function",
         ),
 
         ["BlockCommentBetweenTokens_2a"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.LeadingNewLineRequired);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.LeadingNewLineRequired);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -303,19 +303,19 @@ function",
         ),
 
         ["BlockCommentBetweenTokens_2b"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.TrailingNewLineRequired);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.TrailingNewLineRequired);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -326,19 +326,19 @@ func"
         ),
 
         ["BlockCommentBetweenTokens_2c"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                var writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                var writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
 
                 var identifier = functionDeclaration.Id!;
-                writeContext = new JavascriptTextWriter.WriteContext(functionDeclaration, identifier);
+                writeContext = new JavaScriptTextWriter.WriteContext(functionDeclaration, identifier);
                 writeContext.SetNodeProperty(nameof(identifier.Name), node => node.As<Identifier>().Name);
-                writer.WriteIdentifier(identifier.Name, JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writer.WriteIdentifier(identifier.Name, JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -351,13 +351,13 @@ func"
         ),
 
         ["BlockCommentBetweenTokens_3"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
-                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                var writeContext = new JavaScriptTextWriter.WriteContext(s_dummyAst, blockStatement);
                 writer.StartBlock(0, ref writeContext);
 
-                writer.WriteBlockComment(new[] { "abc" }, JavascriptTextWriter.TriviaFlags.None);
+                writer.WriteBlockComment(new[] { "abc" }, JavaScriptTextWriter.TriviaFlags.None);
 
                 writer.StartStatementList(0, ref writeContext);
                 writer.EndStatementList(0, ref writeContext);
@@ -370,18 +370,18 @@ func"
         ),
 
         ["BlockCommentBetweenTokens_4"] = new TestCase(
-            Write: static (JavascriptTextWriter writer) =>
+            Write: static (JavaScriptTextWriter writer) =>
             {
                 var blockStatement = s_dummyAst.Body[0].As<BlockStatement>();
-                var writeContext = new JavascriptTextWriter.WriteContext(s_dummyAst, blockStatement);
+                var writeContext = new JavaScriptTextWriter.WriteContext(s_dummyAst, blockStatement);
                 writer.StartBlock(blockStatement.Body.Count, ref writeContext);
                 writer.StartStatementList(blockStatement.Body.Count, ref writeContext);
-                writer.StartStatementListItem(0, 1, JavascriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavascriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
+                writer.StartStatementListItem(0, 1, JavaScriptTextWriter.StatementFlags.MayOmitRightMostSemicolon | JavaScriptTextWriter.StatementFlags.IsRightMost, ref writeContext);
 
                 var functionDeclaration = blockStatement.Body[0].As<FunctionDeclaration>();
-                writeContext = new JavascriptTextWriter.WriteContext(blockStatement, functionDeclaration);
-                writer.WriteBlockComment(new[] { "", " * abc", " " }, JavascriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
-                writer.WriteKeyword("function", JavascriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
+                writeContext = new JavaScriptTextWriter.WriteContext(blockStatement, functionDeclaration);
+                writer.WriteBlockComment(new[] { "", " * abc", " " }, JavaScriptTextWriter.TriviaFlags.SurroundingNewLineRequired);
+                writer.WriteKeyword("function", JavaScriptTextWriter.TokenFlags.LeadingSpaceRecommended, ref writeContext);
 
                 writer.Finish();
             },
@@ -407,7 +407,7 @@ function",
         var testCase = s_testCaseDictionary[testCaseName];
 
         var stringWriter = new StringWriter();
-        var writer = new JavascriptTextWriter(stringWriter, JavascriptTextWriterOptions.Default);
+        var writer = new JavaScriptTextWriter(stringWriter, JavaScriptTextWriterOptions.Default);
         testCase.Write(writer);
 
         var expected = Regex.Replace(testCase.ExpectedUnformatted, @"\r\n|\n\r|\n|\r", Environment.NewLine);
@@ -421,7 +421,7 @@ function",
         var testCase = s_testCaseDictionary[testCaseName];
 
         var stringWriter = new StringWriter();
-        var writer = new KnRJavascriptTextFormatter(stringWriter, KnRJavascriptTextFormatterOptions.Default);
+        var writer = new KnRJavaScriptTextFormatter(stringWriter, KnRJavaScriptTextFormatterOptions.Default);
         testCase.Write(writer);
 
         var expected = Regex.Replace(testCase.ExpectedFormatted, @"\r\n|\n\r|\n|\r", Environment.NewLine);


### PR DESCRIPTION
Addresses one of the points listed in https://github.com/sebastienros/esprima-dotnet/issues/303