### PR TITLE
Change FileParsingBenchmark to use parsing defaults

### DIFF
--- a/samples/Esprima.Benchmark/FileParsingBenchmark.cs
+++ b/samples/Esprima.Benchmark/FileParsingBenchmark.cs
@@ -19,8 +19,6 @@ public class FileParsingBenchmark
         { "angular-1.2.5", null }
     };
 
-    private static readonly ParserOptions parserOptions = new() { Comment = true, Tokens = true };
-
     [GlobalSetup]
     public void Setup()
     {
@@ -43,7 +41,7 @@ public class FileParsingBenchmark
     [Benchmark]
     public void ParseProgram()
     {
-        var parser = new JavaScriptParser(files[FileName], parserOptions);
+        var parser = new JavaScriptParser(files[FileName]);
         parser.ParseScript();
     }
 }


### PR DESCRIPTION
Collecting comments and tokens is just noise for the benchmark and specific use case that can be benchmarked separately, if needed.