### PR TITLE
Remove invalid hash addition to private identifier name

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1400,7 +1400,9 @@ public partial class JavaScriptParser
             return ThrowUnexpectedToken<Identifier>(token);
         }
 
-        return isPrivateField ? Finalize(node, new PrivateIdentifier('#' + (string?) token.Value)) : Finalize(node, new Identifier((string?) token.Value!));
+        return isPrivateField
+            ? Finalize(node, new PrivateIdentifier((string) token.Value!))
+            : Finalize(node, new Identifier((string) token.Value!));
     }
 
     private Expression ParseNewExpression()


### PR DESCRIPTION
In other places the private identifier doesn't include the original `#` as name prefix, but `ParseIdentifierOrPrivateIdentifierName()` adds it for some odd reason. The `PrivateIdentifier` container already tells us that this is... a private identifier.