### PR TITLE
Refinements around tokens and comments

### DIFF
--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -49,18 +49,10 @@ public sealed class Literal : Expression
     public RegexValue? Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? (string) Value! : null; }
-    public bool BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral && ReferenceEquals(Value, s_boxedTrue); }
-    public double NumericValue
-    {
-        get => TokenType switch
-        {
-            TokenType.NumericLiteral => (double) Value!,
-            TokenType.BooleanLiteral => ReferenceEquals(Value, s_boxedTrue) ? 1 : 0,
-            _ => default
-        };
-    }
+    public bool? BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral ? ReferenceEquals(Value, s_boxedTrue) : null; }
+    public double? NumericValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.NumericLiteral ? (double) Value! : null; }
     public Regex? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.RegularExpression ? (Regex?) Value : null; }
-    public BigInteger BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger) Value! : default; }
+    public BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger) Value! : null; }
 
     internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => null;
 

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -7,33 +7,26 @@ namespace Esprima.Ast;
 
 public sealed class Literal : Expression
 {
-    private static readonly object _boxedTrue = true;
-    private static readonly object _boxedFalse = false;
+    private static readonly object s_boxedTrue = true;
+    private static readonly object s_boxedFalse = false;
 
     internal Literal(TokenType tokenType, object? value, string raw) : base(Nodes.Literal)
     {
         TokenType = tokenType;
         Value = value;
         Raw = raw;
-
-        if (tokenType == TokenType.NumericLiteral)
-        {
-            NumericValue = (double) value!;
-        }
     }
 
-    public Literal(string? value, string raw) : this(TokenType.StringLiteral, value, raw)
+    public Literal(string value, string raw) : this(TokenType.StringLiteral, value, raw)
     {
     }
 
-    public Literal(bool value, string raw) : this(TokenType.BooleanLiteral, value ? _boxedTrue : _boxedFalse, raw)
+    public Literal(bool value, string raw) : this(TokenType.BooleanLiteral, value ? s_boxedTrue : s_boxedFalse, raw)
     {
-        NumericValue = value ? 1 : 0;
     }
 
     public Literal(double value, string raw) : this(TokenType.NumericLiteral, value, raw)
     {
-        NumericValue = value;
     }
 
     public Literal(BigInteger value, string raw) : this(TokenType.BigIntLiteral, value, raw)
@@ -55,11 +48,19 @@ public sealed class Literal : Expression
     public string Raw { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public RegexValue? Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-    public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? Value as string : null; }
-    public bool BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral && ReferenceEquals(Value, _boxedTrue); }
-    public double NumericValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? (string) Value! : null; }
+    public bool BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral && ReferenceEquals(Value, s_boxedTrue); }
+    public double NumericValue
+    {
+        get => TokenType switch
+        {
+            TokenType.NumericLiteral => (double) Value!,
+            TokenType.BooleanLiteral => ReferenceEquals(Value, s_boxedTrue) ? 1 : 0,
+            _ => default
+        };
+    }
     public Regex? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.RegularExpression ? (Regex?) Value : null; }
-    public BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger?) Value : null; }
+    public BigInteger BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger) Value! : default; }
 
     internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => null;
 

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -4,20 +4,14 @@ using Esprima.Utils;
 
 namespace Esprima.Ast;
 
-[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(), nq}}")]
-public abstract class Node
+public abstract class Node : SyntaxElement
 {
-    internal AdditionalDataContainer _additionalDataContainer;
-
     protected Node(Nodes type)
     {
         Type = type;
     }
 
     public Nodes Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-
-    public Range Range;
-    public Location Location;
 
     public ChildNodes ChildNodes => new ChildNodes(this);
 
@@ -43,28 +37,10 @@ public abstract class Node
         return visitor.VisitExtension(this);
     }
 
-    /// <summary>
-    /// Gets additional, user-defined data associated with the specified key.
-    /// </summary>
-    /// <remarks>
-    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public object? GetAdditionalData(object key) => _additionalDataContainer.GetData(key);
-
-    /// <summary>
-    /// Sets additional, user-defined data associated with the specified key.
-    /// </summary>
-    /// <remarks>
-    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
-
     private static readonly AstToJavaScriptOptions s_toStringOptions = AstToJavaScriptOptions.Default with { IgnoreExtensions = true };
     public override string ToString() => this.ToJavaScriptString(KnRJavaScriptTextFormatterOptions.Default, s_toStringOptions);
 
-    private protected virtual string GetDebuggerDisplay()
+    private protected override string GetDebuggerDisplay()
     {
         return $"/*{Type}*/  {this}";
     }

--- a/src/Esprima/Ast/SyntaxComment.cs
+++ b/src/Esprima/Ast/SyntaxComment.cs
@@ -8,7 +8,6 @@ public sealed class SyntaxComment : SyntaxElement
     public SyntaxComment(CommentType type, string value)
     {
         Type = type;
-
         Value = value;
     }
 

--- a/src/Esprima/Ast/SyntaxComment.cs
+++ b/src/Esprima/Ast/SyntaxComment.cs
@@ -1,0 +1,40 @@
+﻿using System.Runtime.CompilerServices;
+using Esprima.Utils;
+
+namespace Esprima.Ast;
+
+public sealed class SyntaxComment : SyntaxElement
+{
+    public SyntaxComment(CommentType type, string value)
+    {
+        Type = type;
+
+        Value = value;
+    }
+
+    public CommentType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public override string ToString()
+    {
+        using (var textWriter = new StringWriter())
+        {
+            var writer = new JavaScriptTextWriter(textWriter, JavaScriptTextWriterOptions.Default);
+            switch (Type)
+            {
+                case CommentType.Line:
+                    writer.WriteLineComment(Value, JavaScriptTextWriter.TriviaFlags.None);
+                    break;
+                case CommentType.Block:
+                    writer.WriteBlockComment(Value.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None), JavaScriptTextWriter.TriviaFlags.None);
+                    break;
+                default:
+                    throw new InvalidOperationException();
+            }
+            writer.Finish();
+
+            return textWriter.ToString();
+        }
+    }
+}

--- a/src/Esprima/Ast/SyntaxElement.cs
+++ b/src/Esprima/Ast/SyntaxElement.cs
@@ -7,7 +7,7 @@ namespace Esprima.Ast;
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(), nq}}")]
 public abstract class SyntaxElement
 {
-    internal AdditionalDataContainer _additionalDataContainer;
+    private protected AdditionalDataContainer _additionalDataContainer;
 
     /// <summary>
     /// Gets additional, user-defined data associated with the specified key.

--- a/src/Esprima/Ast/SyntaxElement.cs
+++ b/src/Esprima/Ast/SyntaxElement.cs
@@ -1,0 +1,34 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using Esprima.Utils;
+
+namespace Esprima.Ast;
+
+[DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(), nq}}")]
+public abstract class SyntaxElement
+{
+    internal AdditionalDataContainer _additionalDataContainer;
+
+    /// <summary>
+    /// Gets additional, user-defined data associated with the specified key.
+    /// </summary>
+    /// <remarks>
+    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public object? GetAdditionalData(object key) => _additionalDataContainer.GetData(key);
+
+    /// <summary>
+    /// Sets additional, user-defined data associated with the specified key.
+    /// </summary>
+    /// <remarks>
+    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
+
+    public Range Range;
+    public Location Location;
+
+    private protected virtual string GetDebuggerDisplay() => ToString();
+}

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -15,7 +15,13 @@ public sealed class SyntaxToken : SyntaxElement
     public TokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public RegexValue? RegexValue
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => (RegexValue?) _additionalDataContainer.InternalData;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private set => _additionalDataContainer.InternalData = value;
+    }
 
     public override string ToString() => Value;
 }

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -1,0 +1,21 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast;
+
+public sealed class SyntaxToken : SyntaxElement
+{
+    public SyntaxToken(TokenType type, string value, RegexValue? regexValue = null)
+    {
+        Type = type;
+
+        Value = value;
+        RegexValue = regexValue;
+    }
+
+    public TokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public override string ToString() => Value;
+}

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -15,6 +15,7 @@ public sealed class SyntaxToken : SyntaxElement
     public TokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
     public RegexValue? RegexValue
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Esprima/Comment.cs
+++ b/src/Esprima/Comment.cs
@@ -38,26 +38,3 @@ public readonly record struct Comment
     public readonly Position StartPosition;
     public readonly Position EndPosition;
 }
-
-public record class ParsedComment
-{
-    public ParsedComment(CommentType type, string value, in Range range, in Location location)
-    {
-        Type = type;
-
-        Value = value;
-
-        _range = range;
-        _location = location;
-    }
-
-    public CommentType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-
-    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-
-    private readonly Range _range;
-    public ref readonly Range Range { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _range; }
-
-    private readonly Location _location;
-    public ref readonly Location Location { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _location; }
-}

--- a/src/Esprima/Comment.cs
+++ b/src/Esprima/Comment.cs
@@ -1,4 +1,5 @@
 ﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Esprima;
 
@@ -8,22 +9,55 @@ public enum CommentType
     Line
 }
 
-public class Comment
+[StructLayout(LayoutKind.Auto)]
+public readonly record struct Comment
 {
-    public CommentType Type;
-
-    public string? Value;
-    public Range Slice;
-
-    public int Start;
-    public int End;
-
-    public Range Range
+    internal Comment(
+        CommentType type,
+        in Range slice,
+        int start,
+        int end,
+        in Position startPosition,
+        in Position endPosition)
     {
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => new Range(Start, End);
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => value.Deconstruct(out Start, out End);
+        Type = type;
+        Slice = slice;
+        Start = start;
+        End = end;
+        StartPosition = startPosition;
+        EndPosition = endPosition;
     }
-    public Location Location;
+
+    public readonly CommentType Type;
+
+    public readonly Range Slice;
+
+    public readonly int Start;
+    public readonly int End;
+
+    public readonly Position StartPosition;
+    public readonly Position EndPosition;
+}
+
+public record class ParsedComment
+{
+    public ParsedComment(CommentType type, string value, in Range range, in Location location)
+    {
+        Type = type;
+
+        Value = value;
+
+        _range = range;
+        _location = location;
+    }
+
+    public CommentType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    private readonly Range _range;
+    public ref readonly Range Range { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _range; }
+
+    private readonly Location _location;
+    public ref readonly Location Location { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _location; }
 }

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -2013,7 +2013,7 @@ public partial class JavaScriptParser
         var allowAndOr = true;
         var allowNullishCoalescing = true;
 
-        void UpdateNullishCoalescingRestrictions(in Token t)
+        static void UpdateNullishCoalescingRestrictions(in Token t, ref bool allowAndOr, ref bool allowNullishCoalescing)
         {
             var value = t.Value;
             if ("&&".Equals(value) || "||".Equals(value))
@@ -2031,7 +2031,7 @@ public partial class JavaScriptParser
         var prec = BinaryPrecedence(token);
         if (prec > 0)
         {
-            UpdateNullishCoalescingRestrictions(token);
+            UpdateNullishCoalescingRestrictions(token, ref allowAndOr, ref allowNullishCoalescing);
             NextToken();
 
             _context.IsAssignmentTarget = false;
@@ -2058,7 +2058,7 @@ public partial class JavaScriptParser
                     ThrowUnexpectedToken(_lookahead);
                 }
 
-                UpdateNullishCoalescingRestrictions(_lookahead);
+                UpdateNullishCoalescingRestrictions(_lookahead, ref allowAndOr, ref allowNullishCoalescing);
 
                 // Reduce: make a binary expression from the three topmost entries.
                 while (stack.Count > 2 && prec <= precedences.Peek())

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -830,7 +830,7 @@ public partial class JavaScriptParser
         {
             case TokenType.StringLiteral:
                 var raw = GetTokenRaw(token);
-                key = Finalize(node, new Literal((string?) token.Value, raw));
+                key = Finalize(node, new Literal((string) token.Value!, raw));
                 break;
 
             case TokenType.NumericLiteral:
@@ -4700,7 +4700,7 @@ public partial class JavaScriptParser
 
         var token = NextToken();
         var raw = GetTokenRaw(token);
-        return Finalize(node, new Literal((string?) token.Value, raw));
+        return Finalize(node, new Literal((string) token.Value!, raw));
     }
 
     private ArrayList<ImportAttribute> ParseImportAttributes()
@@ -4758,7 +4758,7 @@ public partial class JavaScriptParser
         NextToken();
         var literalToken = NextToken();
         var raw = GetTokenRaw(literalToken);
-        Literal value = Finalize(node, new Literal((string?) literalToken.Value, raw));
+        Literal value = Finalize(node, new Literal((string) literalToken.Value!, raw));
 
         return Finalize(node, new ImportAttribute(key, value));
     }

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -483,7 +483,7 @@ public class JsxParser : JavaScriptParser
             }
 
             var id = _scanner.Source.Slice(start, _scanner.Index);
-            return Token.Create(TokenType.JsxIdentifier, id, start, end: _scanner.Index, _scanner.LineNumber, _scanner.LineStart);
+            return JsxToken.CreateIdentifier(id, start, end: _scanner.Index, _scanner.LineNumber, _scanner.LineStart);
         }
 
         return this._scanner.Lex();
@@ -537,7 +537,7 @@ public class JsxParser : JavaScriptParser
 
         _lastMarker = _scanner.GetMarker();
 
-        var token = Token.Create(TokenType.JsxText, text, start, end: _scanner.Index, _scanner.LineNumber, _scanner.LineStart);
+        var token = JsxToken.CreateText(text, start, end: _scanner.Index, _scanner.LineNumber, _scanner.LineStart);
 
         if (text.Length > 0 && _config.Tokens)
         {
@@ -575,7 +575,7 @@ public class JsxParser : JavaScriptParser
     {
         var node = CreateJsxNode();
         var token = NextJsxToken();
-        if (token.Type != TokenType.JsxIdentifier)
+        if (token.JsxTokenType() != JsxTokenType.Identifier)
         {
             ThrowUnexpectedToken(token);
         }

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -640,7 +640,7 @@ public class JsxParser : JavaScriptParser
         }
 
         var raw = GetTokenRaw(token);
-        return Finalize(node, new Literal(token.Value as string, raw));
+        return Finalize(node, new Literal((string) token.Value!, raw));
     }
 
     private JsxExpressionContainer ParseJsxExpressionAttribute()

--- a/src/Esprima/JsxToken.cs
+++ b/src/Esprima/JsxToken.cs
@@ -7,7 +7,7 @@ public enum JsxTokenType
     Unknown,
     Identifier,
     Text
-};
+}
 
 public static class JsxToken
 {

--- a/src/Esprima/JsxToken.cs
+++ b/src/Esprima/JsxToken.cs
@@ -1,0 +1,31 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima;
+
+public enum JsxTokenType
+{
+    Unknown,
+    Identifier,
+    Text
+};
+
+public static class JsxToken
+{
+    private static readonly object s_boxedIdentifierTokenType = Esprima.JsxTokenType.Identifier;
+    private static readonly object s_boxedTextTokenType = Esprima.JsxTokenType.Text;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Token CreateIdentifier(string value, int start, int end, int lineNumber, int lineStart)
+    {
+        return new Token(TokenType.Extension, value, start, end, lineNumber, lineStart, customValue: s_boxedIdentifierTokenType);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static Token CreateText(string value, int start, int end, int lineNumber, int lineStart)
+    {
+        return new Token(TokenType.Extension, value, start, end, lineNumber, lineStart, customValue: s_boxedTextTokenType);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static JsxTokenType JsxTokenType(this Token token) => token.Type == TokenType.Extension && token._customValue is JsxTokenType type ? type : Esprima.JsxTokenType.Unknown;
+}

--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -5,11 +5,11 @@ namespace Esprima;
 [DebuggerDisplay("{ToString()}")]
 public readonly struct Location : IEquatable<Location>
 {
-    public Position Start { get; }
-    public Position End { get; }
-    public string? Source { get; }
+    public readonly Position Start;
+    public readonly Position End;
+    public readonly string? Source;
 
-    public Location(Position start, Position end) : this(start, end, null)
+    public Location(in Position start, in Position end) : this(start, end, null)
     {
     }
 

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -172,6 +172,7 @@ public sealed partial class Scanner
         var comments = new ArrayList<Comment>();
         var start = 0;
         Position startPosition = default, endPosition;
+        Esprima.Range slice;
 
         if (_trackComment)
         {
@@ -188,15 +189,16 @@ public sealed partial class Scanner
                 if (_trackComment)
                 {
                     endPosition = new Position(LineNumber, Index - LineStart - 1);
-
+                    slice = new Esprima.Range(start + offset, Index - 1);
                     var entry = new Comment
-                    {
-                        Type = CommentType.Line,
-                        Slice = new Esprima.Range(start + offset, Index - 1),
-                        Start = start,
-                        End = Index - 1,
-                        Location = new Location(startPosition, endPosition)
-                    };
+                    (
+                        type: CommentType.Line,
+                        slice: in slice,
+                        start: start,
+                        end: Index - 1,
+                        in startPosition,
+                        in endPosition
+                    );
 
                     comments.Add(entry);
                 }
@@ -215,14 +217,16 @@ public sealed partial class Scanner
         if (_trackComment)
         {
             endPosition = new Position(LineNumber, Index - LineStart);
+            slice = new Esprima.Range(start + offset, Index);
             var entry = new Comment
-            {
-                Type = CommentType.Line,
-                Slice = new Esprima.Range(start + offset, Index),
-                Start = start,
-                End = Index,
-                Location = new Location(startPosition, endPosition)
-            };
+            (
+                type: CommentType.Line,
+                slice: in slice,
+                start: start,
+                end: Index,
+                in startPosition,
+                in endPosition
+            );
 
             comments.Add(entry);
         }
@@ -235,6 +239,7 @@ public sealed partial class Scanner
         var comments = new ArrayList<Comment>();
         var start = 0;
         Position startPosition = default, endPosition;
+        Esprima.Range slice;
 
         if (_trackComment)
         {
@@ -265,14 +270,16 @@ public sealed partial class Scanner
                     if (_trackComment)
                     {
                         endPosition = new Position(LineNumber, Index - LineStart);
+                        slice = new Esprima.Range(start + 2, Index - 2);
                         var entry = new Comment
-                        {
-                            Type = CommentType.Block,
-                            Slice = new Esprima.Range(start + 2, Index - 2),
-                            Start = start,
-                            End = Index,
-                            Location = new Location(startPosition, endPosition)
-                        };
+                        (
+                            type: CommentType.Block,
+                            slice: in slice,
+                            start: start,
+                            end: Index,
+                            in startPosition,
+                            in endPosition
+                        );
                         comments.Add(entry);
                     }
 
@@ -291,14 +298,16 @@ public sealed partial class Scanner
         if (_trackComment)
         {
             endPosition = new Position(LineNumber, Index - LineStart);
+            slice = new Esprima.Range(start + 2, Index);
             var entry = new Comment
-            {
-                Type = CommentType.Block,
-                Slice = new Esprima.Range(start + 2, Index),
-                Start = start,
-                End = Index,
-                Location = new Location(startPosition, endPosition)
-            };
+            (
+                type: CommentType.Block,
+                slice: in slice,
+                start: start,
+                end: Index,
+                in startPosition,
+                in endPosition
+            );
             comments.Add(entry);
         }
 

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -498,7 +498,7 @@ public sealed partial class Scanner
         return true;
     }
 
-    public string? TryToScanUnicodeCodePointEscape()
+    private string? TryToScanUnicodeCodePointEscape()
     {
         var ch = Source[Index];
         var code = 0;
@@ -539,7 +539,7 @@ public sealed partial class Scanner
         return result!;
     }
 
-    public string GetIdentifier()
+    private string GetIdentifier()
     {
         var start = Index++;
         while (!Eof())
@@ -571,7 +571,7 @@ public sealed partial class Scanner
         return Source.Slice(start, Index);
     }
 
-    public string GetComplexIdentifier()
+    private string GetComplexIdentifier()
     {
         var cp = CodePointAt(Source, Index);
         var id = Character.FromCodePoint(cp);
@@ -1047,7 +1047,7 @@ public sealed partial class Scanner
         return Token.CreateNumericLiteral(numericValue, octal, start, end: Index, LineNumber, LineStart);
     }
 
-    public bool IsImplicitOctalLiteral()
+    private bool IsImplicitOctalLiteral()
     {
         // Implicit octal, unless there is a non-octal digit.
         // (Annex B.1.1 on Numeric Literals)

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -132,4 +132,27 @@ public readonly record struct Token
     }
 }
 
-public record ParsedToken(TokenType Type, string? Value, int Start, int End, in Location Location, RegexValue? RegexValue);
+public record class ParsedToken
+{
+    public ParsedToken(TokenType type, string value, RegexValue? regexValue, in Range range, in Location location)
+    {
+        Type = type;
+
+        Value = value;
+        RegexValue = regexValue;
+
+        _range = range;
+        _location = location;
+    }
+
+    public TokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+
+    private readonly Range _range;
+    public ref readonly Range Range { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _range; }
+
+    private readonly Location _location;
+    public ref readonly Location Location { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _location; }
+}

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -131,28 +131,3 @@ public readonly record struct Token
         return new Token(newType, Value, Start, End, LineNumber, LineStart, Octal, NotEscapeSequenceHead, Head, Tail, _customValue);
     }
 }
-
-public record class ParsedToken
-{
-    public ParsedToken(TokenType type, string value, RegexValue? regexValue, in Range range, in Location location)
-    {
-        Type = type;
-
-        Value = value;
-        RegexValue = regexValue;
-
-        _range = range;
-        _location = location;
-    }
-
-    public TokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-
-    public string Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-
-    private readonly Range _range;
-    public ref readonly Range Range { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _range; }
-
-    private readonly Location _location;
-    public ref readonly Location Location { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _location; }
-}

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -21,15 +21,13 @@ public enum TokenType : byte
     Template,
     BigIntLiteral,
 
-    JsxIdentifier,
-    JsxText,
-    Extension
+    Extension = byte.MaxValue
 }
 
 [StructLayout(LayoutKind.Auto)]
 public readonly record struct Token
 {
-    private Token(
+    internal Token(
         TokenType type,
         object? value,
         int start,
@@ -124,9 +122,9 @@ public readonly record struct Token
     public readonly bool Head;
     public readonly bool Tail;
 
-    private readonly object? _customValue;
-    public string? RawTemplate => this.Type == TokenType.Template ? (string?) _customValue : null;
-    public RegexValue? RegexValue => this.Type == TokenType.RegularExpression ? (RegexValue?) _customValue : null;
+    internal readonly object? _customValue;
+    public string? RawTemplate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Type == TokenType.Template ? (string?) _customValue : null; }
+    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Type == TokenType.RegularExpression ? (RegexValue?) _customValue : null; }
 
     internal Token ChangeType(TokenType newType)
     {

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -634,7 +634,7 @@ public class AstToJsonConverter : AstVisitor
 
             var callee = new ImportCompat
             {
-                Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
+                Location = new Location(in import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
                 Range = new Range(import.Range.Start, import.Range.Start + importToken.Length)
             };
             var args = new NodeList<Expression>(new Expression[] { import.Source });

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -12,7 +12,7 @@ public class LocationTests
     {
         var start = new Position(startLine, startColumn);
         var end = new Position(endLine, endColumn);
-        var (actualStart, actualEnd) = new Location(start, end);
+        var (actualStart, actualEnd) = new Location(in start, in end);
         Assert.Equal(start, actualStart);
         Assert.Equal(end, actualEnd);
     }
@@ -28,7 +28,7 @@ public class LocationTests
         var start = new Position(startLine, startColumn);
         var end = new Position(endLine, endColumn);
         var e = Assert.Throws<System.ArgumentOutOfRangeException>(() =>
-            new Location(start, end));
+            new Location(in start, in end));
         Assert.Equal("end", e.ParamName);
         Assert.Equal(end, e.ActualValue);
     }


### PR DESCRIPTION
Besides removing JSX-awareness from core parser, this PR also proposes moving `ParsedToken`/`ParsedComment` into the `Esprima.Ast` namespace and changing them into node-like types because the information contained by these types belongs to the AST (see e.g. the tree displayed in AST Explorer). Roslyn, for example, models tokens and comments similarly.