### PR TITLE
Reduce memory allocations in JavaScriptParser

### DIFF
--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -71,7 +71,7 @@ internal struct ArrayList<T> : IReadOnlyList<T>
 #if DEBUG
     private int[] _sharedVersion;
     private int _localVersion;
-#endif
+ #endif
 
     public ArrayList(int initialCapacity)
     {
@@ -108,24 +108,25 @@ internal struct ArrayList<T> : IReadOnlyList<T>
 #endif
     }
 
-    public ArrayList(NodeList<Node> initialData)
+    public static ArrayList<Node> FromNodeList(NodeList<Node> initialData)
     {
-        if (initialData._items is null)
+        if (initialData._count == 0)
         {
-            _items = null;
-            _count = 0;
-            return;
+            return new ArrayList<Node>();
         }
 
-        _items = new T[initialData.Count];
-        _count = initialData.Count;
-
-        Array.Copy(initialData._items!, 0, _items, 0, _count);
-
+        var items = new Node[initialData.Count];
+        Array.Copy(initialData._items!, 0, items, 0, initialData._count);
+        return new ArrayList<Node>
+        {
+            _items = items,
+            _count = initialData.Count,
 #if DEBUG
-        _localVersion = 0;
-        _sharedVersion = _count > 0 ? new[] { _localVersion } : null;
+            _localVersion = 0,
+            _sharedVersion = initialData._count > 0 ? new[] { 0 } : null
 #endif
+        };
+
     }
 
     private int Capacity => _items?.Length ?? 0;
@@ -187,13 +188,16 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     {
         AssertUnchanged();
 
-        if (this._items is not null)
+        if (this._count > 0)
         {
             Array.Clear(this._items, 0, this._count);
             this._count = 0;
         }
 
-        OnChanged();
+#if DEBUG
+        _sharedVersion = new [] { 0 };
+        _localVersion = 0;
+#endif
     }
 
     internal void Resize(int size)

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -3877,17 +3877,20 @@ public partial class JavaScriptParser
         return Finalize(node, new RestElement(arg));
     }
 
+    // pooled for ParseLexicalBinding calls
+    private ArrayList<Token> _parseFormalParameterParameters;
+
     private void ParseFormalParameter(ref ParsedParameters options)
     {
-        var parameters = new ArrayList<Token>();
+        _parseFormalParameterParameters.Clear();
 
         var param = Match("...")
-            ? ParseRestElement(ref parameters)
-            : ParsePatternWithDefault(ref parameters);
+            ? ParseRestElement(ref _parseFormalParameterParameters)
+            : ParsePatternWithDefault(ref _parseFormalParameterParameters);
 
-        for (var i = 0; i < parameters.Count; i++)
+        for (var i = 0; i < _parseFormalParameterParameters.Count; i++)
         {
-            ValidateParam2(ref options, parameters[i], (string?) parameters[i].Value);
+            ValidateParam2(ref options, _parseFormalParameterParameters[i], (string?) _parseFormalParameterParameters[i].Value);
         }
 
         options.Simple = options.Simple && param is Identifier;

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -271,7 +271,7 @@ public partial class JavaScriptParser
             _tokens.Add(ConvertToken(next));
         }
 
-        return token!;
+        return token;
     }
 
     private Token NextRegexToken()
@@ -338,7 +338,7 @@ public partial class JavaScriptParser
     private void Expect(string value)
     {
         var token = NextToken(allowIdentifierEscape: true);
-        if (token.Type != TokenType.Punctuator || !value.Equals(token.Value))
+        if (token.Type != TokenType.Punctuator || !value.Equals((string) token.Value!))
         {
             ThrowUnexpectedToken(token);
         }
@@ -380,7 +380,7 @@ public partial class JavaScriptParser
     private void ExpectKeyword(string keyword)
     {
         var token = NextToken();
-        if (token.Type != TokenType.Keyword || !keyword.Equals(token.Value))
+        if (token.Type != TokenType.Keyword || !keyword.Equals((string) token.Value!))
         {
             ThrowUnexpectedToken(token);
         }
@@ -392,7 +392,7 @@ public partial class JavaScriptParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private protected bool Match(string value)
     {
-        return _lookahead.Type == TokenType.Punctuator && value.Equals(_lookahead.Value);
+        return _lookahead.Type == TokenType.Punctuator && value.Equals((string) _lookahead.Value!);
     }
 
     /// <summary>
@@ -401,7 +401,7 @@ public partial class JavaScriptParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool MatchKeyword(string keyword)
     {
-        return _lookahead.Type == TokenType.Keyword && keyword.Equals(_lookahead.Value);
+        return _lookahead.Type == TokenType.Keyword && keyword.Equals((string) _lookahead.Value!);
     }
 
     // Return true if the next token matches the specified contextual keyword
@@ -410,7 +410,7 @@ public partial class JavaScriptParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool MatchContextualKeyword(string keyword)
     {
-        return _lookahead.Type == TokenType.Identifier && keyword.Equals(_lookahead.Value);
+        return _lookahead.Type == TokenType.Identifier && keyword.Equals((string) _lookahead.Value!);
     }
 
     // Return true if the next token is an assignment operator
@@ -418,13 +418,7 @@ public partial class JavaScriptParser
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private bool MatchAssign()
     {
-        if (_lookahead.Type != TokenType.Punctuator)
-        {
-            return false;
-        }
-
-        var op = (string?) _lookahead.Value;
-        return IsAssignmentOperator(op!);
+        return _lookahead.Type == TokenType.Punctuator && IsAssignmentOperator((string) _lookahead.Value!);
     }
 
     // Cover grammar support.


### PR DESCRIPTION
With this PR we are pretty much getting all the allocations from AST + strings. I do have a StringSegment/TextSpan branch somewhere though...

* allow clearing of and supplying initial data directly to ArrayList
* make ParsedParameters a struct
* pool data structures used by ParseBinaryExpression, ParseLexicalBinding and ParsePattern

Also Jint tests pass.