### PR TITLE
Implement string pooling in scanner/parser

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -208,7 +208,7 @@ public partial class JavaScriptParser
             {
                 var e = comments[i];
 
-                var comment = new SyntaxComment(e.Type, value: _scanner.Source.Slice(e.Slice.Start, e.Slice.End))
+                var comment = new SyntaxComment(e.Type, value: _scanner.Source.Slice(e.Slice.Start, e.Slice.End, ref _scanner._stringPool))
                 {
                     Range = new Range(e.Start, e.End),
                     Location = new Location(in e.StartPosition, in e.EndPosition, _errorHandler.Source)
@@ -224,7 +224,7 @@ public partial class JavaScriptParser
     /// </summary>
     private protected string GetTokenRaw(in Token token)
     {
-        return _scanner.Source.Slice(token.Start, token.End);
+        return _scanner.Source.Slice(token.Start, token.End, ref _scanner._stringPool);
     }
 
     private protected SyntaxToken ConvertToken(in Token token)
@@ -4165,7 +4165,7 @@ public partial class JavaScriptParser
         var expr = ParseExpression();
         if (expr.Type == Nodes.Literal)
         {
-            directive = _scanner.Source.Slice(token.Start + 1, token.End - 1);
+            directive = _scanner.Source.Slice(token.Start + 1, token.End - 1, ref _scanner._stringPool);
         }
 
         ConsumeSemicolon();

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -482,7 +482,7 @@ public class JsxParser : JavaScriptParser
                 }
             }
 
-            var id = _scanner.Source.Slice(start, _scanner.Index);
+            var id = _scanner.Source.Slice(start, _scanner.Index, ref _scanner._stringPool);
             return JsxToken.CreateIdentifier(id, start, end: _scanner.Index, _scanner.LineNumber, _scanner.LineStart);
         }
 

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -26,6 +26,13 @@ public static class ParserExtensions
             Scanner.TryGetInternedPunctuator(source);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static string Slice(this string source, int start, int end, ref StringPool stringPool)
+    {
+        var sourceSpan = source.AsSpan(start, end - start);
+        return TryGetInternedString(sourceSpan) ?? stringPool.GetOrCreate(sourceSpan);
+    }
+
     public static string Slice(this string source, int start, int end)
     {
         var len = source.Length;

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Esprima;
 
-public static class ParserExtensions
+internal static class ParserExtensions
 {
     private static readonly string[] s_charToString = new string[256];
 
@@ -33,24 +33,8 @@ public static class ParserExtensions
         return TryGetInternedString(sourceSpan) ?? stringPool.GetOrCreate(sourceSpan);
     }
 
-    public static string Slice(this string source, int start, int end)
-    {
-        var len = source.Length;
-        var from = start < 0 ? Math.Max(len + start, 0) : Math.Min(start, len);
-        var to = end < 0 ? Math.Max(len + end, 0) : Math.Min(end, len);
-        var span = Math.Max(to - from, 0);
-
-        if (span == 1)
-        {
-            return CharToString(source[from]);
-        }
-
-        var substring = TryGetInternedString(source.AsSpan(from, span)) ?? source.Substring(from, span);
-        return substring;
-    }
-
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static string CharToString(char c)
+    internal static string CharToString(char c)
     {
         if (c >= 0 && c < s_charToString.Length)
         {
@@ -61,7 +45,7 @@ public static class ParserExtensions
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static char CharCodeAt(this string source, int index)
+    internal static char CharCodeAt(this string source, int index)
     {
         if (index < 0 || index > source.Length - 1)
         {

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -48,6 +48,8 @@ public sealed partial class Scanner
     private List<string> _curlyStack;
     private readonly StringBuilder strb = new();
 
+    internal StringPool _stringPool;
+
     private static int HexValue(char ch)
     {
         if (ch >= 'A')
@@ -594,7 +596,7 @@ public sealed partial class Scanner
             }
         }
 
-        return Source.Slice(start, Index);
+        return Source.Slice(start, Index, ref _stringPool);
     }
 
     private string GetComplexIdentifier()
@@ -1574,7 +1576,7 @@ public sealed partial class Scanner
             _curlyStack.RemoveAt(_curlyStack.Count - 1);
         }
 
-        var rawTemplate = Source.Slice(start + 1, Index - rawOffset);
+        var rawTemplate = Source.Slice(start + 1, Index - rawOffset, ref _stringPool);
         var value = notEscapeSequenceHead == default ? cooked.ToString() : null;
 
         return Token.CreateTemplate(cooked: value, rawTemplate, head, tail, notEscapeSequenceHead, start, end: Index, LineNumber, LineStart);
@@ -2428,6 +2430,7 @@ public sealed partial class Scanner
             _curlyStack.Capacity = 0;
             strb.Clear();
             strb.Capacity = 0;
+            _stringPool = default;
 
             return Token.CreateEof(Index, LineNumber, LineStart);
         }

--- a/src/Esprima/StringPool.cs
+++ b/src/Esprima/StringPool.cs
@@ -3,6 +3,9 @@ using System.Runtime.CompilerServices;
 
 namespace Esprima;
 
+/// <summary>
+/// A heavily slimmed down version of <see cref="HashSet{String}"/> which can be used to reduce memory allocations when dissecting a string.
+/// </summary>
 // Based on:
 // * https://github.com/dotnet/runtime/blob/v6.0.8/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
 // * https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/v7.1.2/Microsoft.Toolkit.HighPerformance/Buffers/StringPool.cs
@@ -11,6 +14,8 @@ internal struct StringPool
     private int[]? _buckets;
     private Entry[]? _entries;
     private int _count;
+
+    public int Count { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _count; }
 
     /// <summary>
     /// Initializes buckets and slots arrays. Uses suggested capacity by finding next prime

--- a/src/Esprima/StringPool.cs
+++ b/src/Esprima/StringPool.cs
@@ -1,0 +1,196 @@
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
+
+namespace Esprima;
+
+// Based on:
+// * https://github.com/dotnet/runtime/blob/v6.0.8/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/HashSet.cs
+// * https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/v7.1.2/Microsoft.Toolkit.HighPerformance/Buffers/StringPool.cs
+internal struct StringPool
+{
+    private int[]? _buckets;
+    private Entry[]? _entries;
+    private int _count;
+
+    /// <summary>
+    /// Initializes buckets and slots arrays. Uses suggested capacity by finding next prime
+    /// greater than or equal to capacity.
+    /// </summary>
+    private int Initialize(int capacity)
+    {
+        int size = capacity;
+        var buckets = new int[size];
+        var entries = new Entry[size];
+
+        // Assign member variables after both arrays are allocated to guard against corruption from OOM if second fails.
+        _buckets = buckets;
+        _entries = entries;
+
+        return size;
+    }
+
+    private void Resize(int newSize)
+    {
+        Debug.Assert(_entries != null, "_entries should be non-null");
+        Debug.Assert(newSize >= _entries!.Length);
+
+        var entries = new Entry[newSize];
+
+        int count = _count;
+        Array.Copy(_entries, entries, count);
+
+        // Assign member variables after both arrays allocated to guard against corruption from OOM if second fails
+        _buckets = new int[newSize];
+
+        for (int i = 0; i < count; i++)
+        {
+            ref Entry entry = ref entries[i];
+            if (entry.Next >= -1)
+            {
+                ref int bucket = ref GetBucketRef(entry.HashCode);
+                entry.Next = bucket - 1; // Value in _buckets is 1-based
+                bucket = i + 1;
+            }
+        }
+
+        _entries = entries;
+    }
+
+    /// <summary>Gets a reference to the specified hashcode's bucket, containing an index into <see cref="_entries"/>.</summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private ref int GetBucketRef(int hashCode)
+    {
+        int[] buckets = _buckets!;
+        return ref buckets[(uint) hashCode % (uint) buckets.Length];
+    }
+
+    /// <summary>Adds the specified string to the <see cref="StringPool"/> object if it's not already contained.</summary>
+    /// <param name="value">The string to add.</param>
+    /// <returns>The stored string instance.</returns>
+    public string GetOrCreate(ReadOnlySpan<char> value)
+    {
+        if (_buckets is null)
+        {
+            Initialize(4);
+        }
+        Debug.Assert(_buckets is not null);
+
+        Entry[]? entries = _entries;
+        Debug.Assert(entries is not null, "expected entries to be non-null");
+
+        uint collisionCount = 0;
+
+        int hashCode = GetHashCode(value);
+        ref int bucket = ref GetBucketRef(hashCode);
+        int i = bucket - 1; // Value in _buckets is 1-based
+
+        while (i >= 0)
+        {
+            ref Entry entry = ref entries![i];
+            if (entry.HashCode == hashCode && entry.Value.AsSpan().SequenceEqual(value))
+            {
+                return entry.Value;
+            }
+            i = entry.Next;
+
+            collisionCount++;
+            if (collisionCount > (uint) entries.Length)
+            {
+                // The chain of entries forms a loop, which means a concurrent update has happened.
+                throw new InvalidOperationException("A concurrent update was performed on this object and corrupted its state.");
+            }
+        }
+
+        int index;
+        {
+            int count = _count;
+            if (count == entries!.Length)
+            {
+                Resize(checked(_count + _count / 2));
+                bucket = ref GetBucketRef(hashCode);
+            }
+            index = count;
+            _count = count + 1;
+            entries = _entries;
+        }
+
+        {
+            ref Entry entry = ref entries![index];
+            entry.HashCode = hashCode;
+            entry.Next = bucket - 1; // Value in _buckets is 1-based
+            entry.Value = value.ToString();
+            bucket = index + 1;
+
+            return entry.Value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the (positive) hashcode for a given <see cref="ReadOnlySpan{T}"/> instance.
+    /// </summary>
+    /// <param name="span">The input <see cref="ReadOnlySpan{T}"/> instance.</param>
+    /// <returns>The hashcode for <paramref name="span"/>.</returns>
+    private static int GetHashCode(ReadOnlySpan<char> span)
+    {
+        // This can be further optimized as shown here:
+        // https://github.com/CommunityToolkit/WindowsCommunityToolkit/blob/v7.1.2/Microsoft.Toolkit.HighPerformance/Helpers/Internals/SpanHelper.Hash.cs#L87
+
+        int hash = 5381;
+
+        while (span.Length >= 8)
+        {
+            // Doing a left shift by 5 and adding is equivalent to multiplying by 33.
+            // This is preferred for performance reasons, as when working with integer
+            // values most CPUs have higher latency for multiplication operations
+            // compared to a simple shift and add. For more info on this, see the
+            // details for imul, shl, add: https://gmplib.org/~tege/x86-timing.pdf.
+            hash = unchecked(((hash << 5) + hash) ^ span[0].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[1].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[2].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[3].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[4].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[5].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[6].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[7].GetHashCode());
+
+            span = span.Slice(8);
+        }
+
+        if (span.Length >= 4)
+        {
+            hash = unchecked(((hash << 5) + hash) ^ span[0].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[1].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[2].GetHashCode());
+            hash = unchecked(((hash << 5) + hash) ^ span[3].GetHashCode());
+
+            span = span.Slice(4);
+        }
+
+        if (span.Length > 0)
+        {
+            hash = unchecked(((hash << 5) + hash) ^ span[0].GetHashCode());
+            if (span.Length > 1)
+            {
+                hash = unchecked(((hash << 5) + hash) ^ span[1].GetHashCode());
+                if (span.Length > 2)
+                {
+                    hash = unchecked(((hash << 5) + hash) ^ span[2].GetHashCode());
+                }
+            }
+        }
+
+        return hash;
+    }
+
+    private struct Entry
+    {
+        public int HashCode;
+        /// <summary>
+        /// 0-based index of next entry in chain: -1 means end of chain
+        /// also encodes whether this entry _itself_ is part of the free list by changing sign and subtracting 3,
+        /// so -2 means end of free list, -3 means index 0 but on free list, -4 means index 1 but on free list, etc.
+        /// </summary>
+        public int Next;
+        public string Value;
+    }
+}

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -453,4 +453,122 @@ block comment", comment.Value);
 
         Assert.Equal(1, count);
     }
+
+    [Theory]
+    [InlineData("&&")]
+    [InlineData("||")]
+    [InlineData("==")]
+    [InlineData("!=")]
+    [InlineData("+=")]
+    [InlineData("-=")]
+    [InlineData("*=")]
+    [InlineData("/=")]
+    [InlineData("++")]
+    [InlineData("--")]
+    [InlineData("<<")]
+    [InlineData(">>")]
+    [InlineData("&=")]
+    [InlineData("|=")]
+    [InlineData("^=")]
+    [InlineData("%=")]
+    [InlineData("<=")]
+    [InlineData(">=")]
+    [InlineData("=>")]
+    [InlineData("**")]
+    [InlineData("??")]
+    [InlineData("?.")]
+    [InlineData("===")]
+    [InlineData("!==")]
+    [InlineData(">>>")]
+    [InlineData("<<=")]
+    [InlineData(">>=")]
+    [InlineData("**=")]
+    [InlineData("&&=")]
+    [InlineData("||=")]
+    [InlineData("??=")]
+    [InlineData("...")]
+    [InlineData(">>>=")]
+    [InlineData("as")]
+    [InlineData("do")]
+    [InlineData("if")]
+    [InlineData("in")]
+    [InlineData("of")]
+    [InlineData("for")]
+    [InlineData("get")]
+    [InlineData("let")]
+    [InlineData("new")]
+    [InlineData("set")]
+    [InlineData("try")]
+    [InlineData("var")]
+    [InlineData("case")]
+    [InlineData("else")]
+    [InlineData("enum")]
+    [InlineData("eval")]
+    [InlineData("from")]
+    [InlineData("null")]
+    [InlineData("this")]
+    [InlineData("true")]
+    [InlineData("void")]
+    [InlineData("with")]
+    [InlineData("async")]
+    [InlineData("await")]
+    [InlineData("break")]
+    [InlineData("catch")]
+    [InlineData("class")]
+    [InlineData("const")]
+    [InlineData("false")]
+    [InlineData("super")]
+    [InlineData("throw")]
+    [InlineData("while")]
+    [InlineData("yield")]
+    [InlineData("delete")]
+    [InlineData("export")]
+    [InlineData("import")]
+    [InlineData("public")]
+    [InlineData("return")]
+    [InlineData("static")]
+    [InlineData("switch")]
+    [InlineData("typeof")]
+    [InlineData("default")]
+    [InlineData("extends")]
+    [InlineData("finally")]
+    [InlineData("package")]
+    [InlineData("private")]
+    [InlineData("continue")]
+    [InlineData("debugger")]
+    [InlineData("function")]
+    [InlineData("arguments")]
+    [InlineData("interface")]
+    [InlineData("protected")]
+    [InlineData("implements")]
+    [InlineData("instanceof")]
+    [InlineData("constructor")]
+    public void UsesInternedInstancesForWellKnownTokens(string token)
+    {
+        var stringPool = new StringPool();
+
+        var nonInternedToken = new string(token.ToCharArray());
+        var slicedToken = nonInternedToken.Slice(0, nonInternedToken.Length, ref stringPool);
+        Assert.Equal(token, slicedToken);
+
+        Assert.NotNull(string.IsInterned(slicedToken));
+        Assert.Equal(0, stringPool.Count);
+    }
+
+    [Fact]
+    public void UsesPooledInstancesForNotWellKnownTokens()
+    {
+        var stringPool = new StringPool();
+
+        var token = "pow2";
+        var slicedToken1 = "pow2".Slice(0, token.Length, ref stringPool);
+        Assert.Equal(token, slicedToken1);
+
+        var source = "async function pow2(x) { return x ** 2; }";
+        var slicedToken2 = source.Slice(15, 15 + token.Length, ref stringPool);
+        Assert.Equal(token, slicedToken2);
+
+        Assert.Same(slicedToken1, slicedToken2);
+        Assert.Equal(1, stringPool.Count);
+    }
 }


### PR DESCRIPTION
Motivation:

> BTW, [this benchmark](https://github.com/sebastienros/esprima-dotnet/pull/313#issuecomment-1215379293) of yours showing that `string` and `Identifier` are sitting on the top of the list gave me an idea how we might push this even further:
> 
> Let's suppose we have the following input:
> 
> ```js
> let abc;
> abc = 0;
> ```
> 
> We declare something, then later we reference that using its name. Pretty common stuff. When we parse this, we end up with an AST containing two identical `Identifier`s (well, not completely identical because of metadata like location, range, etc.) However, the `Name` property of these identifiers will be exactly the same strings. I mean they'll contain the same characters. They won't currently be the same _instance_ (apart from some special cases covered by `ParserExtensions.Slice`) though. But they could be and this is where I see a room for improvement.
> 
> It looks possible to introduce some kind of a string pooling by means of which we could make sure that `Scanner` won't allocate the same string multiple times. We may borrow some ideas from [here](https://docs.microsoft.com/en-us/windows/communitytoolkit/high-performance/stringpool) as it looks to do exactly what I'm talking about.

First results:

## Esprima.Benchmark.FileParsingBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |ParseProgram|angular-1.2.5|21.162 ms|0.4196 ms|1000.0000|468.7500|-|5,744 KB|
| **New** |	|	| **20.491 ms (-3%)** | **1.2497 ms** | **937.5000 (-6%)** | **437.5000 (-7%)** | **-** | **5,553 KB (-3%)** |
| Old |ParseProgram|backbone-1.1.0|2.609 ms|0.4331 ms|160.1563|70.3125|-|888 KB|
| **New** |	|	| **2.706 ms (+4%)** | **0.0774 ms** | **148.4375 (-7%)** | **66.4063 (-6%)** | **-** | **867 KB (-2%)** |
| Old |ParseProgram|jquery-1.9.1|15.677 ms|1.6023 ms|812.5000|375.0000|-|4,991 KB|
| **New** |	|	| **16.503 ms (+5%)** | **2.2575 ms** | **812.5000 (0%)** | **375.0000 (0%)** | **-** | **4,854 KB (-3%)** |
| Old |ParseProgram|jquery.mobile-1.4.2|27.572 ms|29.7640 ms|1250.0000|625.0000|93.7500|7,677 KB|
| **New** |	|	| **25.710 ms (-7%)** | **5.6449 ms** | **1218.7500 (-3%)** | **593.7500 (-5%)** | **31.2500 (-67%)** | **7,349 KB (-4%)** |
| Old |ParseProgram|mootools-1.4.5|12.870 ms|1.5982 ms|703.1250|312.5000|-|4,028 KB|
| **New** |	|	| **13.191 ms (+2%)** | **0.9527 ms** | **671.8750 (-4%)** | **312.5000 (0%)** | **-** | **3,936 KB (-2%)** |
| Old |ParseProgram|underscore-1.5.2|2.197 ms|0.1964 ms|140.6250|62.5000|-|748 KB|
| **New** |	|	| **2.251 ms (+2%)** | **0.1881 ms** | **140.6250 (0%)** | **62.5000 (0%)** | **-** | **739 KB (-1%)** |
| Old |ParseProgram|yui-3.12.0|11.652 ms|0.8847 ms|656.2500|281.2500|-|3,789 KB|
| **New** |	|	| **11.899 ms (+2%)** | **0.6330 ms** | **609.3750 (-7%)** | **296.8750 (+6%)** | **-** | **3,620 KB (-4%)** |

These results are not as good as I expected. But there are some parameters to tweak (string pool initial buffer size, buffer growth rate, etc) and the hash algorithm can be optimized further as well. We'll see if it can get any better.