### PR TITLE
Improve Token layout and reduce stack frame size for hot paths

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -2005,24 +2005,12 @@ public partial class JavaScriptParser
         return Finalize(node, new AwaitExpression(argument));
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private Expression ParseUnaryExpression()
     {
         Expression expr;
         if (Match('+', '-', '~', '!') || _lookahead.Type == TokenType.Keyword && MatchUnaryKeyword((string) _lookahead.Value!))
         {
-            var node = StartNode(_lookahead);
-            var token = NextToken();
-            expr = InheritCoverGrammar(parseUnaryExpression);
-            expr = Finalize(node, new UnaryExpression((string)token.Value!, expr));
-            var unaryExpr = expr.As<UnaryExpression>();
-            if (_context.Strict && unaryExpr.Operator == UnaryOperator.Delete && unaryExpr.Argument.Type == Nodes.Identifier)
-            {
-                TolerateError(Messages.StrictDelete);
-            }
-
-            _context.IsAssignmentTarget = false;
-            _context.IsBindingElement = false;
+            expr = ParseBasicUnaryExpression();
         }
         else if (_context.IsAsync && MatchContextualKeyword("await"))
         {
@@ -2033,6 +2021,24 @@ public partial class JavaScriptParser
             expr = ParseUpdateExpression();
         }
 
+        return expr;
+    }
+
+    private Expression ParseBasicUnaryExpression()
+    {
+        Expression expr;
+        var node = StartNode(_lookahead);
+        var token = NextToken();
+        expr = InheritCoverGrammar(parseUnaryExpression);
+        expr = Finalize(node, new UnaryExpression((string) token.Value!, expr));
+        var unaryExpr = expr.As<UnaryExpression>();
+        if (_context.Strict && unaryExpr.Operator == UnaryOperator.Delete && unaryExpr.Argument.Type == Nodes.Identifier)
+        {
+            TolerateError(Messages.StrictDelete);
+        }
+
+        _context.IsAssignmentTarget = false;
+        _context.IsBindingElement = false;
         return expr;
     }
 

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -558,8 +558,9 @@ public class JsxParser : JavaScriptParser
 
     private void ExpectJsx(string value)
     {
-        var token = this.NextJsxToken();
-        if (token.Type != TokenType.Punctuator || token.Value is string val && val != value)
+        var token = NextJsxToken();
+        if (token.Type != TokenType.Punctuator
+            || (token.Value is string s && s != value || token.Value is JsxToken.JsxHolder holder && holder.Value != value))
         {
             ThrowUnexpectedToken(token);
         }
@@ -567,8 +568,9 @@ public class JsxParser : JavaScriptParser
 
     private bool MatchJsx(string value)
     {
-        var next = this.PeekJsxToken();
-        return next.Type == TokenType.Punctuator && next.Value is string val && val == value;
+        var next = PeekJsxToken();
+        return next.Type == TokenType.Punctuator
+               && (next.Value is string s && s == value || next.Value is JsxToken.JsxHolder holder && holder.Value == value);
     }
 
     private JsxIdentifier ParseJsxIdentifier()
@@ -580,7 +582,8 @@ public class JsxParser : JavaScriptParser
             ThrowUnexpectedToken(token);
         }
 
-        return Finalize(node, new JsxIdentifier((string) token.Value!));
+        var holder = (JsxToken.JsxHolder) token.Value!;
+        return Finalize(node, new JsxIdentifier(holder.Value));
     }
 
     private JsxExpression ParseJsxElementName()
@@ -804,7 +807,7 @@ public class JsxParser : JavaScriptParser
             if (token.Start < token.End)
             {
                 var raw = GetTokenRaw(token);
-                var child = Finalize(node, new JsxText(token.Value as string, raw));
+                var child = Finalize(node, new JsxText(((JsxToken.JsxHolder) token.Value!).Value, raw));
                 children.Add(child);
             }
 

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -559,8 +559,7 @@ public class JsxParser : JavaScriptParser
     private void ExpectJsx(string value)
     {
         var token = NextJsxToken();
-        if (token.Type != TokenType.Punctuator
-            || (token.Value is string s && s != value || token.Value is JsxToken.JsxHolder holder && holder.Value != value))
+        if (token.Type != TokenType.Punctuator || token.Value is string s && s != value)
         {
             ThrowUnexpectedToken(token);
         }
@@ -569,8 +568,7 @@ public class JsxParser : JavaScriptParser
     private bool MatchJsx(string value)
     {
         var next = PeekJsxToken();
-        return next.Type == TokenType.Punctuator
-               && (next.Value is string s && s == value || next.Value is JsxToken.JsxHolder holder && holder.Value == value);
+        return next.Type == TokenType.Punctuator && next.Value is string s && s == value;
     }
 
     private JsxIdentifier ParseJsxIdentifier()

--- a/src/Esprima/JsxToken.cs
+++ b/src/Esprima/JsxToken.cs
@@ -11,21 +11,20 @@ public enum JsxTokenType
 
 public static class JsxToken
 {
-    private static readonly object s_boxedIdentifierTokenType = Esprima.JsxTokenType.Identifier;
-    private static readonly object s_boxedTextTokenType = Esprima.JsxTokenType.Text;
+    internal sealed record JsxHolder(JsxTokenType Type, string Value);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Token CreateIdentifier(string value, int start, int end, int lineNumber, int lineStart)
     {
-        return new Token(TokenType.Extension, value, start, end, lineNumber, lineStart, customValue: s_boxedIdentifierTokenType);
+        return new Token(TokenType.Extension, new JsxHolder(Esprima.JsxTokenType.Identifier, value), start, end, lineNumber, lineStart);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Token CreateText(string value, int start, int end, int lineNumber, int lineStart)
     {
-        return new Token(TokenType.Extension, value, start, end, lineNumber, lineStart, customValue: s_boxedTextTokenType);
+        return new Token(TokenType.Extension, new JsxHolder(Esprima.JsxTokenType.Text, value), start, end, lineNumber, lineStart);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static JsxTokenType JsxTokenType(this Token token) => token.Type == TokenType.Extension && token._customValue is JsxTokenType type ? type : Esprima.JsxTokenType.Unknown;
+    public static JsxTokenType JsxTokenType(this Token token) => token.Type == TokenType.Extension && token.Value is JsxHolder holder ? holder.Type : Esprima.JsxTokenType.Unknown;
 }

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -1,6 +1,4 @@
-﻿using static Esprima.EsprimaExceptionHelper;
-
-namespace Esprima;
+﻿namespace Esprima;
 
 public sealed class ParseError
 {

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -33,6 +33,7 @@ internal static partial class ParserExtensions
         "undefined", "length", "object", "Object", "obj", "Array", "Math", "data", "done", "args", "arguments", "Symbol", "prototype",
         "options", "value", "name", "self", "key", "\"use strict\"", "use strict"
     )]
+    [MethodImpl((MethodImplOptions) 512)]
     internal static partial string? TryGetInternedString(ReadOnlySpan<char> source);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -1,10 +1,12 @@
-﻿using System.Diagnostics;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 
 namespace Esprima;
 
 internal static partial class ParserExtensions
 {
+    // old framework doesn't know this flag
+    private const int MethodImplOptionsAggressiveOptimization = 512;
+
     private static readonly string[] s_charToString = new string[256];
 
     static ParserExtensions()
@@ -33,7 +35,7 @@ internal static partial class ParserExtensions
         "undefined", "length", "object", "Object", "obj", "Array", "Math", "data", "done", "args", "arguments", "Symbol", "prototype",
         "options", "value", "name", "self", "key", "\"use strict\"", "use strict"
     )]
-    [MethodImpl((MethodImplOptions) 512)]
+    [MethodImpl((MethodImplOptions) MethodImplOptionsAggressiveOptimization)]
     internal static partial string? TryGetInternedString(ReadOnlySpan<char> source);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -2483,7 +2483,7 @@ public sealed partial class Scanner
 
     public Token Lex() => Lex(new LexOptions());
 
-    internal Token Lex(LexOptions options)
+    internal Token Lex(in LexOptions options)
     {
         if (Eof())
         {

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -43,7 +43,7 @@ public readonly record struct Token
 
         Octal = octal;
         Start = start;
-        Length = (ushort) (end - start);
+        End = end;
         LineNumber = lineNumber;
         LineStart = lineStart;
     }
@@ -112,8 +112,7 @@ public readonly record struct Token
     public readonly bool Octal;
 
     public readonly int Start; // Range[0]
-    internal readonly ushort Length;
-    public int End => Start + Length; // Range[1]
+    public readonly int End; // Range[1]
     public readonly int LineNumber;
     public readonly int LineStart;
 

--- a/src/Esprima/Token.cs
+++ b/src/Esprima/Token.cs
@@ -27,6 +27,8 @@ public enum TokenType : byte
 [StructLayout(LayoutKind.Auto)]
 public readonly record struct Token
 {
+    private readonly object? _value;
+
     internal Token(
         TokenType type,
         object? value,
@@ -34,23 +36,16 @@ public readonly record struct Token
         int end,
         int lineNumber,
         int lineStart,
-        bool octal = false,
-        char notEscapeSequenceHead = (char) 0,
-        bool head = false,
-        bool tail = false,
-        object? customValue = null)
+        bool octal = false)
     {
         Type = type;
+        _value = value;
+
         Octal = octal;
         Start = start;
-        End = end;
+        Length = (ushort) (end - start);
         LineNumber = lineNumber;
         LineStart = lineStart;
-        Value = value;
-        NotEscapeSequenceHead = notEscapeSequenceHead;
-        Head = head;
-        Tail = tail;
-        _customValue = customValue;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -65,10 +60,12 @@ public readonly record struct Token
         return new Token(TokenType.StringLiteral, str, start, end, lineNumber, lineStart, octal);
     }
 
+    private sealed record RegexHolder(Regex? Value, RegexValue RegexValue);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Token CreateRegexLiteral(Regex? value, RegexValue regexValue, int start, int end, int lineNumber, int lineStart)
     {
-        return new Token(TokenType.RegularExpression, value, start, end, lineNumber, lineStart, customValue: regexValue);
+        return new Token(TokenType.RegularExpression, new RegexHolder(value, regexValue), start, end, lineNumber, lineStart);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -93,6 +90,8 @@ public readonly record struct Token
         return new Token(TokenType.Punctuator, str, start, end, lineNumber, lineStart);
     }
 
+    private sealed record TemplateHolder(string? Cooked, string RawTemplate, char NotEscapeSequenceHead, bool Head, bool Tail);
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static Token CreateTemplate(
         string? cooked,
@@ -105,29 +104,44 @@ public readonly record struct Token
         int lineNumber,
         int lineStart)
     {
-        return new Token(TokenType.Template, cooked, start, end, lineNumber, lineStart, notEscapeSequenceHead: notEscapeSequenceHead, customValue: rawTemplate, head: head, tail: tail);
+        var value = new TemplateHolder(cooked, rawTemplate, notEscapeSequenceHead, head, tail);
+        return new Token(TokenType.Template, value, start, end, lineNumber, lineStart);
     }
 
     public readonly TokenType Type;
     public readonly bool Octal;
 
     public readonly int Start; // Range[0]
-    public readonly int End; // Range[1]
+    internal readonly ushort Length;
+    public int End => Start + Length; // Range[1]
     public readonly int LineNumber;
     public readonly int LineStart;
 
-    public readonly object? Value;
+    public object? Value => Type switch
+    {
+        TokenType.Template => ((TemplateHolder) _value!).Cooked,
+        TokenType.RegularExpression => ((RegexHolder) _value!).Value,
+        _ => _value
+    };
 
-    public readonly char NotEscapeSequenceHead;
-    public readonly bool Head;
-    public readonly bool Tail;
+    internal char NotEscapeSequenceHead => Type == TokenType.Template ? ((TemplateHolder) _value!).NotEscapeSequenceHead : char.MinValue;
+    public bool Head => Type == TokenType.Template && ((TemplateHolder) _value!).Head;
+    public bool Tail => Type == TokenType.Template && ((TemplateHolder) _value!).Tail;
 
-    internal readonly object? _customValue;
-    public string? RawTemplate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Type == TokenType.Template ? (string?) _customValue : null; }
-    public RegexValue? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => Type == TokenType.RegularExpression ? (RegexValue?) _customValue : null; }
+    public string? RawTemplate
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Type == TokenType.Template ? ((TemplateHolder) _value!).RawTemplate : null;
+    }
+
+    public RegexValue? RegexValue
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => Type == TokenType.RegularExpression ? ((RegexHolder) _value!).RegexValue : null;
+    }
 
     internal Token ChangeType(TokenType newType)
     {
-        return new Token(newType, Value, Start, End, LineNumber, LineStart, Octal, NotEscapeSequenceHead, Head, Tail, _customValue);
+        return new Token(newType, _value, Start, End, LineNumber, LineStart, Octal);
     }
 }

--- a/src/Esprima/Utils/JsonTextWriter.cs
+++ b/src/Esprima/Utils/JsonTextWriter.cs
@@ -19,7 +19,6 @@
 using System.Collections;
 using System.Diagnostics;
 using System.Globalization;
-using static Esprima.EsprimaExceptionHelper;
 using SysArray = System.Array;
 
 namespace Esprima.Utils;

--- a/test/Esprima.Tests.SourceGenerators/Snapshots/StringMatcherGeneratorTests.ScannerStringMatchingGeneration.01StringMatchers.g.verified.cs
+++ b/test/Esprima.Tests.SourceGenerators/Snapshots/StringMatcherGeneratorTests.ScannerStringMatchingGeneration.01StringMatchers.g.verified.cs
@@ -50,6 +50,28 @@ public partial class JavaScriptParser
         }
     }
 
+    private partial bool MatchUnaryKeyword(string input)
+    {
+        switch (input.Length)
+        {
+            case 4:
+            {
+                return input == "void";
+            }
+            case 6:
+            {
+                return input[0] switch
+                {
+                    'd' => input == "delete",
+                    't' => input == "typeof",
+                    _ => false
+                };
+            }
+            default:
+                return false;
+        }
+    }
+
     private static partial bool IsPunctuatorExpressionStart(string input)
     {
         switch (input.Length)

--- a/test/Esprima.Tests/JavaScriptParserTests.cs
+++ b/test/Esprima.Tests/JavaScriptParserTests.cs
@@ -12,9 +12,9 @@ public class JavaScriptParserTests
     {
         var parser = new JavaScriptParser(new ParserOptions { MaxAssignmentDepth = 1000 });
 #if DEBUG
-        const int Depth = 220;
+        const int Depth = 210;
 #else
-        const int Depth = 500;
+        const int Depth = 460;
 #endif
         var input = $"if ({new string('(', Depth)}true{new string(')', Depth)}) {{ }}";
         parser.ParseScript(input);

--- a/test/Esprima.Tests/JavaScriptParserTests.cs
+++ b/test/Esprima.Tests/JavaScriptParserTests.cs
@@ -1,0 +1,24 @@
+namespace Esprima.Tests;
+
+#if !NETFRAMEWORK
+
+public class JavaScriptParserTests
+{
+    /// <summary>
+    /// Ensures that we don't regress in stack handling, only test in modern runtime for now
+    /// </summary>
+    [Fact]
+    public void CanHandleDeepNestingWithoutStackOverflow()
+    {
+        var parser = new JavaScriptParser(new ParserOptions { MaxAssignmentDepth = 1000 });
+#if DEBUG
+        const int Depth = 220;
+#else
+        const int Depth = 500;
+#endif
+        var input = $"if ({new string('(', Depth)}true{new string(')', Depth)}) {{ }}";
+        parser.ParseScript(input);
+    }
+}
+
+#endif

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -1,8 +1,6 @@
-﻿using System.Xml.Linq;
-using Esprima.Ast;
+﻿using Esprima.Ast;
 using Esprima.Test;
 using Esprima.Utils;
-using Newtonsoft.Json.Linq;
 
 namespace Esprima.Tests;
 

--- a/test/Esprima.Tests/PositionTests.cs
+++ b/test/Esprima.Tests/PositionTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Data.Common;
-
-namespace Esprima.Tests;
+﻿namespace Esprima.Tests;
 
 public class PositionTests
 {


### PR DESCRIPTION
This might the initial cure for #326 , future improvements also possible. Addin some progress here with some steps.

* changed  `FirstCoverInitializedNameError` to object so when frequently referenced, only object pointer required
* slimmed down Token size by using special types for rarely used member encapsulation
* going through some recursive methods and reducing work done in "usual cases" where no complex parsing is needed, splitting methods to smaller units etc

Using a test program how recursive we can get:

```c#
var parser = new JavaScriptParser(new ParserOptions { MaxAssignmentDepth = 1000 });
var depth = 1;
for (depth = 180; depth < 600; ++depth)
{
    var input = $"if ({new string('(', depth)}true{new string(')', depth)}) {{ }}";
    parser.ParseScript(input);
    Console.WriteLine("OK: " + depth);
}
```

Starting point for depth before stack overflow is `253` (Release mode).

fixes #326