### PR TITLE
A few additional minor corrections

### DIFF
--- a/src/Esprima/Ast/Jsx/JsxSyntaxToken.cs
+++ b/src/Esprima/Ast/Jsx/JsxSyntaxToken.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast.Jsx;
+
+public sealed class JsxSyntaxToken : SyntaxToken
+{
+    public JsxSyntaxToken(JsxTokenType type, string value) : base(TokenType.Extension, value)
+    {
+        Type = type;
+    }
+
+    public new JsxTokenType Type { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+}

--- a/src/Esprima/Ast/SourceType.cs
+++ b/src/Esprima/Ast/SourceType.cs
@@ -1,4 +1,4 @@
-﻿namespace Esprima;
+﻿namespace Esprima.Ast;
 
 public enum SourceType
 {

--- a/src/Esprima/Ast/SyntaxComment.cs
+++ b/src/Esprima/Ast/SyntaxComment.cs
@@ -3,7 +3,7 @@ using Esprima.Utils;
 
 namespace Esprima.Ast;
 
-public sealed class SyntaxComment : SyntaxElement
+public class SyntaxComment : SyntaxElement
 {
     public SyntaxComment(CommentType type, string value)
     {

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -2,7 +2,7 @@
 
 namespace Esprima.Ast;
 
-public sealed class SyntaxToken : SyntaxElement
+public class SyntaxToken : SyntaxElement
 {
     public SyntaxToken(TokenType type, string value, RegexValue? regexValue = null)
     {

--- a/src/Esprima/CollectingErrorHandler.cs
+++ b/src/Esprima/CollectingErrorHandler.cs
@@ -5,9 +5,9 @@
 /// </summary>
 public sealed class CollectingErrorHandler : ErrorHandler
 {
-    private readonly List<ParserException> _errors = new();
+    private readonly List<ParseError> _errors = new();
 
-    public IReadOnlyCollection<ParserException> Errors => _errors;
+    public IReadOnlyCollection<ParseError> Errors => _errors;
 
     protected internal override void Reset()
     {
@@ -18,7 +18,7 @@ public sealed class CollectingErrorHandler : ErrorHandler
         }
     }
 
-    protected override void RecordError(ParserException error)
+    protected override void RecordError(ParseError error)
     {
         _errors.Add(error);
     }

--- a/src/Esprima/Comment.cs
+++ b/src/Esprima/Comment.cs
@@ -13,11 +13,11 @@ public readonly record struct Comment
 {
     internal Comment(
         CommentType type,
-        in Range slice,
+        Range slice,
         int start,
         int end,
-        in Position startPosition,
-        in Position endPosition)
+        Position startPosition,
+        Position endPosition)
     {
         Type = type;
         Slice = slice;

--- a/src/Esprima/ErrorHandler.cs
+++ b/src/Esprima/ErrorHandler.cs
@@ -9,11 +9,11 @@ public class ErrorHandler
 
     protected internal virtual void Reset() { }
 
-    protected virtual void RecordError(ParserException error)
+    protected virtual void RecordError(ParseError error)
     {
     }
 
-    internal void Tolerate(ParserException error, bool tolerant)
+    internal void Tolerate(ParseError error, bool tolerant)
     {
         if (tolerant)
         {
@@ -21,13 +21,13 @@ public class ErrorHandler
         }
         else
         {
-            throw error;
+            throw error.ToException();
         }
     }
 
-    protected internal virtual ParserException CreateError(string? source, int index, int line, int col, string description)
+    protected internal virtual ParseError CreateError(string? source, int index, int line, int col, string description)
     {
-        return new(new ParseError(description, source, index, new Position(line, col)));
+        return new ParseError(description, source, index, new Position(line, col));
     }
 
     internal void TolerateError(string? source, int index, int line, int col, string description, bool tolerant)

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -323,16 +323,20 @@ public partial class JavaScriptParser
         return _scanner._source.Between(token.Start, token.End).ToInternedString(ref _scanner._stringPool);
     }
 
+    private protected SyntaxToken FinalizeToken(int start, int end, SyntaxToken token)
+    {
+        var startPosition = new Position(_startMarker.Line, _startMarker.Column);
+        var endPosition = new Position(_scanner._lineNumber, _scanner._index - _scanner._lineStart);
+
+        token.Range = new Range(start, end);
+        token.Location = new Location(in startPosition, in endPosition);
+
+        return token;
+    }
+
     private protected SyntaxToken ConvertToken(in Token token)
     {
-        var start = new Position(_startMarker.Line, _startMarker.Column);
-        var end = new Position(_scanner._lineNumber, _scanner._index - _scanner._lineStart);
-
-        return new SyntaxToken(token.Type, GetTokenRaw(token), token.RegexValue)
-        {
-            Range = new Range(token.Start, token.End),
-            Location = new Location(in start, in end)
-        };
+        return FinalizeToken(token.Start, token.End, new SyntaxToken(token.Type, GetTokenRaw(token), token.RegexValue));
     }
 
     private protected Token NextToken(bool allowIdentifierEscape = false)
@@ -1861,7 +1865,7 @@ public partial class JavaScriptParser
 
         if (hasOptional)
         {
-            return new ChainExpression(expr);
+            return Finalize(startMarker, new ChainExpression(expr));
         }
 
         return expr;
@@ -1970,7 +1974,7 @@ public partial class JavaScriptParser
 
         if (hasOptional)
         {
-            return new ChainExpression(expr);
+            return Finalize(startMarker, new ChainExpression(expr));
         }
 
         return expr;

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -5390,22 +5390,22 @@ public partial class JavaScriptParser
     [DoesNotReturn]
     internal void ThrowError(string messageFormat, params object?[] values)
     {
-        throw CreateError(messageFormat, values);
+        throw CreateError(messageFormat, values).ToException();
     }
 
     [DoesNotReturn]
     internal T ThrowError<T>(string messageFormat, params object?[] values)
     {
-        throw CreateError(messageFormat, values);
+        throw CreateError(messageFormat, values).ToException();
     }
 
-    private ParserException CreateError(string messageFormat, params object?[] values)
+    private ParseError CreateError(string messageFormat, params object?[] values)
     {
         var msg = string.Format(messageFormat, values);
 
         var index = _lastMarker.Index;
         var line = _lastMarker.Line;
-        var column = _lastMarker.Column + 1;
+        var column = _lastMarker.Column;
         return _errorHandler.CreateError(_scanner._sourceLocation, index, line, column, msg);
     }
 
@@ -5415,11 +5415,11 @@ public partial class JavaScriptParser
 
         var index = _lastMarker.Index;
         var line = _scanner._lineNumber;
-        var column = _lastMarker.Column + 1;
+        var column = _lastMarker.Column;
         _errorHandler.TolerateError(_scanner._sourceLocation, index, line, column, msg, _tolerant);
     }
 
-    private ParserException UnexpectedTokenError(in Token token, string? message = null)
+    private ParseError UnexpectedTokenError(in Token token, string? message = null)
     {
         var msg = message ?? Messages.UnexpectedToken;
         string value;
@@ -5464,14 +5464,14 @@ public partial class JavaScriptParser
             var index = token.Start;
             var line = token.LineNumber;
             var lastMarkerLineStart = _lastMarker.Index - _lastMarker.Column;
-            var column = token.Start - lastMarkerLineStart + 1;
+            var column = token.Start - lastMarkerLineStart;
             return _errorHandler.CreateError(_scanner._sourceLocation, index, line, column, msg);
         }
         else
         {
             var index = _lastMarker.Index;
             var line = _lastMarker.Line;
-            var column = _lastMarker.Column + 1;
+            var column = _lastMarker.Column;
             return _errorHandler.CreateError(_scanner._sourceLocation, index, line, column, msg);
         }
     }
@@ -5480,14 +5480,14 @@ public partial class JavaScriptParser
     [MethodImpl(MethodImplOptions.NoInlining)]
     private protected T ThrowUnexpectedToken<T>(in Token token = default, string? message = null)
     {
-        throw UnexpectedTokenError(token, message);
+        throw UnexpectedTokenError(token, message).ToException();
     }
 
     [DoesNotReturn]
     [MethodImpl(MethodImplOptions.NoInlining)]
     private protected void ThrowUnexpectedToken(in Token token = default, string? message = null)
     {
-        throw UnexpectedTokenError(token, message);
+        throw UnexpectedTokenError(token, message).ToException();
     }
 
     private protected void TolerateUnexpectedToken(in Token token, string? message = null)

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -279,7 +279,7 @@ public partial class JavaScriptParser
                 var comment = new SyntaxComment(e.Type, value)
                 {
                     Range = new Range(e.Start, e.End),
-                    Location = new Location(in e.StartPosition, in e.EndPosition, _scanner._sourceLocation)
+                    Location = new Location(e.StartPosition, e.EndPosition, _scanner._sourceLocation)
                 };
 
                 _comments.Add(comment);
@@ -329,7 +329,7 @@ public partial class JavaScriptParser
         var endPosition = new Position(_scanner._lineNumber, _scanner._index - _scanner._lineStart);
 
         token.Range = new Range(start, end);
-        token.Location = new Location(in startPosition, in endPosition);
+        token.Location = new Location(startPosition, endPosition);
 
         return token;
     }

--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -489,6 +489,14 @@ public class JsxParser : JavaScriptParser
         return this._scanner.Lex();
     }
 
+    private SyntaxToken ConvertJsxToken(in Token token)
+    {
+        var jsxTokenType = token.JsxTokenType();
+        return jsxTokenType == JsxTokenType.Unknown
+            ? ConvertToken(token)
+            : FinalizeToken(token.Start, token.End, new JsxSyntaxToken(jsxTokenType, GetTokenRaw(token)));
+    }
+
     private Token NextJsxToken()
     {
         CollectComments();
@@ -499,7 +507,7 @@ public class JsxParser : JavaScriptParser
 
         if (_tokens is not null)
         {
-            _tokens.Add(ConvertToken(token));
+            _tokens.Add(ConvertJsxToken(token));
         }
 
         return token;
@@ -541,7 +549,7 @@ public class JsxParser : JavaScriptParser
 
         if (text.Length > 0 && _tokens is not null)
         {
-            _tokens.Add(ConvertToken(token));
+            _tokens.Add(ConvertJsxToken(token));
         }
 
         return token;

--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -11,7 +11,7 @@ public readonly struct Location : IEquatable<Location>
     public readonly Position End;
     public readonly string? Source;
 
-    private static bool Validate(in Position start, in Position end, bool throwOnError)
+    private static bool Validate(Position start, Position end, bool throwOnError)
     {
         if (start == default && end != default)
         {
@@ -35,33 +35,33 @@ public readonly struct Location : IEquatable<Location>
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public static Location From(in Position start, in Position end, string? source = null)
+    public static Location From(Position start, Position end, string? source = null)
     {
-        Validate(in start, in end, throwOnError: true);
+        Validate(start, end, throwOnError: true);
         return new Location(start, end, source);
     }
 
-    internal Location(in Position start, in Position end) : this(start, end, null)
+    internal Location(Position start, Position end) : this(start, end, null)
     {
     }
 
-    internal Location(in Position start, in Position end, string? source)
+    internal Location(Position start, Position end, string? source)
     {
-        Debug.Assert(Validate(in start, in end, throwOnError: false));
+        Debug.Assert(Validate(start, end, throwOnError: false));
 
         Start = start;
         End = end;
         Source = source;
     }
 
-    public Location WithPosition(in Position start, in Position end)
+    public Location WithPosition(Position start, Position end)
     {
         return From(start, end, Source);
     }
 
     public Location WithSource(string source)
     {
-        return new Location(in Start, in End, source);
+        return new Location(Start, End, source);
     }
 
     public override bool Equals(object obj)
@@ -69,12 +69,14 @@ public readonly struct Location : IEquatable<Location>
         return obj is Location other && Equals(other);
     }
 
-    public bool Equals(Location other)
+    public bool Equals(in Location other)
     {
         return Start.Equals(other.Start)
                && End.Equals(other.End)
                && string.Equals(Source, other.Source);
     }
+
+    bool IEquatable<Location>.Equals(Location other) => Equals(in other);
 
     public static bool operator ==(in Location left, in Location right)
     {
@@ -205,9 +207,9 @@ SourcePart:
         var start = new Position(startLine, startColumn);
         var end = new Position(endLine, endColumn);
 
-        if (Validate(in start, in end, throwIfInvalid))
+        if (Validate(start, end, throwIfInvalid))
         {
-            result = new Location(in start, in end, source.Length > 0 ? source.ToString() : null);
+            result = new Location(start, end, source.Length > 0 ? source.ToString() : null);
             return true;
         }
 

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -3,20 +3,25 @@
 public sealed class ParseError
 {
     public string Description { get; }
+
     public string? Source { get; }
 
     public bool IsIndexDefined => Index >= 0;
+
     /// <summary>
-    /// Zero-based index within the parsed code string. (Can be negative if code is not available.)
+    /// Zero-based index within the parsed code string. (Can be negative if location information is available.)
     /// </summary>
     public int Index { get; }
 
     public bool IsPositionDefined => Position.Line > 0;
+
     public Position Position { get; }
+
     /// <summary>
-    /// One-based line number. (Can be zero if code is not available.)
+    /// One-based line number. (Can be zero if location information is not available.)
     /// </summary>
     public int LineNumber => Position.Line;
+
     /// <summary>
     /// One-based column index.
     /// </summary>

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -22,7 +22,7 @@ public sealed class ParseError
     /// </summary>
     public int Column => Position.Column + 1;
 
-    public ParseError(string description, string? source = null, int index = -1, in Position position = default)
+    public ParseError(string description, string? source = null, int index = -1, Position position = default)
     {
         Description = description ?? throw new ArgumentNullException(nameof(description));
         Source = source;

--- a/src/Esprima/ParseError.cs
+++ b/src/Esprima/ParseError.cs
@@ -6,12 +6,21 @@ public sealed class ParseError
     public string? Source { get; }
 
     public bool IsIndexDefined => Index >= 0;
+    /// <summary>
+    /// Zero-based index within the parsed code string. (Can be negative if code is not available.)
+    /// </summary>
     public int Index { get; }
 
     public bool IsPositionDefined => Position.Line > 0;
     public Position Position { get; }
+    /// <summary>
+    /// One-based line number. (Can be zero if code is not available.)
+    /// </summary>
     public int LineNumber => Position.Line;
-    public int Column => Position.Column;
+    /// <summary>
+    /// One-based column index.
+    /// </summary>
+    public int Column => Position.Column + 1;
 
     public ParseError(string description, string? source = null, int index = -1, in Position position = default)
     {
@@ -24,5 +33,10 @@ public sealed class ParseError
     public override string ToString()
     {
         return LineNumber > 0 ? $"Line {LineNumber}: {Description}" : Description;
+    }
+
+    public ParserException ToException()
+    {
+        return new ParserException(this);
     }
 }

--- a/src/Esprima/ParserException.cs
+++ b/src/Esprima/ParserException.cs
@@ -5,15 +5,19 @@ public sealed class ParserException : Exception
     public ParseError? Error { get; }
 
     public string? Description => Error?.Description;
+
     public string? SourceLocation => Error?.Source;
+
     /// <summary>
-    /// Zero-based index within the parsed code string. (Can be negative if code is not available.)
+    /// Zero-based index within the parsed code string. (Can be negative if location information is available.)
     /// </summary>
     public int Index => Error?.Index ?? -1;
+
     /// <summary>
-    /// One-based line number. (Can be zero if code is not available.)
+    /// One-based line number. (Can be zero if location information is not available.)
     /// </summary>
     public int LineNumber => Error?.LineNumber ?? 0;
+
     /// <summary>
     /// One-based column index.
     /// </summary>
@@ -23,19 +27,11 @@ public sealed class ParserException : Exception
     {
     }
 
-    public ParserException(string? message, Exception innerException) : this(message, null, innerException)
+    public ParserException(ParseError error) : this(null, null, error)
     {
     }
 
-    public ParserException(ParseError error) : this(null, error)
-    {
-    }
-
-    public ParserException(string? message, ParseError error) : this(message, error, null)
-    {
-    }
-
-    public ParserException(string? message, ParseError? error = null, Exception? innerException = null)
+    public ParserException(string? message, Exception? innerException = null, ParseError? error = null)
         : base(message ?? error?.ToString(), innerException)
     {
         Error = error;

--- a/src/Esprima/ParserException.cs
+++ b/src/Esprima/ParserException.cs
@@ -5,10 +5,19 @@ public sealed class ParserException : Exception
     public ParseError? Error { get; }
 
     public string? Description => Error?.Description;
-    public string? SourceText => Error?.Source;
+    public string? SourceLocation => Error?.Source;
+    /// <summary>
+    /// Zero-based index within the parsed code string. (Can be negative if code is not available.)
+    /// </summary>
     public int Index => Error?.Index ?? -1;
+    /// <summary>
+    /// One-based line number. (Can be zero if code is not available.)
+    /// </summary>
     public int LineNumber => Error?.LineNumber ?? 0;
-    public int Column => Error?.Column ?? 0;
+    /// <summary>
+    /// One-based column index.
+    /// </summary>
+    public int Column => Error?.Column ?? 1;
 
     public ParserException() : this(null, null, null)
     {

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -5,32 +5,34 @@ namespace Esprima;
 /// <summary>
 /// Parser options.
 /// </summary>
-public record class ParserOptions
+public record class ParserOptions : IScannerOptions
 {
     public static readonly ParserOptions Default = new();
 
-    /// <summary>
-    /// Gets or sets whether the tokens are included in the parsed tree.
-    /// </summary>
-    public bool Tokens { get; init; } = false;
+    internal readonly ScannerOptions _scannerOptions = new();
 
     /// <summary>
-    /// Gets or sets whether the comments are included in the parsed tree.
+    /// Gets or sets whether the tokens are included in the parsed tree, defaults to <see langword="false"/>.
     /// </summary>
-    public bool Comments { get; init; } = false;
+    public bool Tokens { get; init; }
 
     /// <summary>
-    /// Gets or sets whether the parser is tolerant to errors.
+    /// Gets or sets whether the comments are included in the parsed tree, defaults to <see langword="false"/>.
+    /// </summary>
+    public bool Comments { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the parser is tolerant to errors, defaults to <see langword="true"/>.
     /// </summary>
     public bool Tolerant { get; init; } = true;
 
     /// <summary>
-    /// Gets or sets the <see cref="ErrorHandler"/> to use.
+    /// Gets or sets the <see cref="ErrorHandler"/> to use, defaults to <see cref="ErrorHandler.Default"/>.
     /// </summary>
-    public ErrorHandler ErrorHandler { get; init; } = Esprima.ErrorHandler.Default;
+    public ErrorHandler ErrorHandler { get; init; } = ErrorHandler.Default;
 
     /// <summary>
-    /// Gets or sets whether the Regular Expression syntax should be converted to a .NET compatible one.
+    /// Gets or sets whether the Regular Expression syntax should be converted to a .NET compatible one, defaults to <see langword="true"/>.
     /// </summary>
     public bool AdaptRegexp { get; init; } = true;
 

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -281,11 +281,11 @@ public sealed partial class Scanner
                     var entry = new Comment
                     (
                         type: CommentType.Line,
-                        slice: in slice,
+                        slice,
                         start: start,
                         end: _index - 1,
-                        in startPosition,
-                        in endPosition
+                        startPosition,
+                        endPosition
                     );
 
                     comments.Add(entry);
@@ -309,11 +309,11 @@ public sealed partial class Scanner
             var entry = new Comment
             (
                 type: CommentType.Line,
-                slice: in slice,
+                slice,
                 start: start,
                 end: _index,
-                in startPosition,
-                in endPosition
+                startPosition,
+                endPosition
             );
 
             comments.Add(entry);
@@ -362,11 +362,11 @@ public sealed partial class Scanner
                         var entry = new Comment
                         (
                             type: CommentType.Block,
-                            slice: in slice,
+                            slice,
                             start: start,
                             end: _index,
-                            in startPosition,
-                            in endPosition
+                            startPosition,
+                            endPosition
                         );
                         comments.Add(entry);
                     }
@@ -390,11 +390,11 @@ public sealed partial class Scanner
             var entry = new Comment
             (
                 type: CommentType.Block,
-                slice: in slice,
+                slice,
                 start: start,
                 end: _index,
-                in startPosition,
-                in endPosition
+                startPosition,
+                endPosition
             );
             comments.Add(entry);
         }

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -205,18 +205,18 @@ public sealed partial class Scanner
     [DoesNotReturn]
     private void ThrowUnexpectedToken(string message = Messages.UnexpectedTokenIllegal)
     {
-        throw _errorHandler.CreateError(_sourceLocation, _index, _lineNumber, _index - _lineStart + 1, message);
+        throw _errorHandler.CreateError(_sourceLocation, _index, _lineNumber, _index - _lineStart, message).ToException();
     }
 
     [DoesNotReturn]
     private T ThrowUnexpectedToken<T>(string message = Messages.UnexpectedTokenIllegal)
     {
-        throw _errorHandler.CreateError(_sourceLocation, _index, _lineNumber, _index - _lineStart + 1, message);
+        throw _errorHandler.CreateError(_sourceLocation, _index, _lineNumber, _index - _lineStart, message).ToException();
     }
 
     private void TolerateUnexpectedToken(string message = Messages.UnexpectedTokenIllegal)
     {
-        _errorHandler.TolerateError(_sourceLocation, _index, _lineNumber, _index - _lineStart + 1, message, _tolerant);
+        _errorHandler.TolerateError(_sourceLocation, _index, _lineNumber, _index - _lineStart, message, _tolerant);
     }
 
     private StringBuilder GetStringBuilder()

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -85,7 +85,7 @@ public sealed partial class Scanner
         return ch - '0';
     }
 
-    internal Scanner(ParserOptions options)
+    internal Scanner(IScannerOptions options)
     {
         if (options == null)
         {
@@ -101,19 +101,19 @@ public sealed partial class Scanner
         _source = string.Empty;
     }
 
-    public Scanner(string code) : this(code, ParserOptions.Default)
+    public Scanner(string code) : this(code, ScannerOptions.Default)
     {
     }
 
-    public Scanner(string code, ParserOptions options) : this(code, null, options)
+    public Scanner(string code, ScannerOptions options) : this(code, null, options)
     {
     }
 
-    public Scanner(string code, string? source) : this(code, source, ParserOptions.Default)
+    public Scanner(string code, string? source) : this(code, source, ScannerOptions.Default)
     {
     }
 
-    public Scanner(string code, string? source, ParserOptions options) : this(options)
+    public Scanner(string code, string? source, ScannerOptions options) : this(options)
     {
         Reset(code, source);
     }

--- a/src/Esprima/ScannerOptions.cs
+++ b/src/Esprima/ScannerOptions.cs
@@ -1,0 +1,43 @@
+﻿namespace Esprima;
+
+internal interface IScannerOptions
+{
+    bool Comments { get; }
+    bool Tolerant { get; }
+    ErrorHandler ErrorHandler { get; }
+    bool AdaptRegexp { get; }
+    TimeSpan RegexTimeout { get; }
+}
+
+/// <summary>
+/// Scanner options.
+/// </summary>
+public record class ScannerOptions : IScannerOptions
+{
+    public static readonly ScannerOptions Default = new();
+
+    /// <summary>
+    /// Gets or sets whether the comments are collected, defaults to <see langword="false"/>.
+    /// </summary>
+    public bool Comments { get; init; }
+
+    /// <summary>
+    /// Gets or sets whether the scanner is tolerant to errors, defaults to <see langword="true"/>.
+    /// </summary>
+    public bool Tolerant { get; init; } = true;
+
+    /// <summary>
+    /// Gets or sets the <see cref="ErrorHandler"/> to use, defaults to <see cref="ErrorHandler.Default"/>.
+    /// </summary>
+    public ErrorHandler ErrorHandler { get; init; } = ErrorHandler.Default;
+
+    /// <summary>
+    /// Gets or sets whether the Regular Expression syntax should be converted to a .NET compatible one, defaults to <see langword="true"/>.
+    /// </summary>
+    public bool AdaptRegexp { get; init; } = true;
+
+    /// <summary>
+    /// Default timeout for created regexes, defaults to 10 seconds.
+    /// </summary>
+    public TimeSpan RegexTimeout { get; init; } = TimeSpan.FromSeconds(10);
+}

--- a/src/Esprima/Utils/AstToJson.cs
+++ b/src/Esprima/Utils/AstToJson.cs
@@ -18,8 +18,11 @@ public record class AstToJsonOptions
 {
     public static readonly AstToJsonOptions Default = new();
 
-    public bool IncludingLineColumn { get; init; }
-    public bool IncludingRange { get; init; }
+    public bool IncludeTokens { get; init; }
+    public bool IncludeComments { get; init; }
+
+    public bool IncludeLineColumn { get; init; }
+    public bool IncludeRange { get; init; }
     public LocationMembersPlacement LocationMembersPlacement { get; init; }
     /// <summary>
     /// This switch is intended for enabling a compatibility mode for <see cref="AstToJsonConverter"/> to build a JSON output

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -691,7 +691,7 @@ public class AstToJsonConverter : AstVisitor
 
             var callee = new ImportCompat
             {
-                Location = new Location(in import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
+                Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
                 Range = new Range(import.Range.Start, import.Range.Start + importToken.Length)
             };
             var args = new NodeList<Expression>(new Expression[] { import.Source });

--- a/src/Esprima/Utils/Jsx/JsxAstToJsonConverter.cs
+++ b/src/Esprima/Utils/Jsx/JsxAstToJsonConverter.cs
@@ -29,6 +29,16 @@ public class JsxAstToJsonConverter : AstToJsonConverter, IJsxAstVisitor
         return base.GetNodeType(node);
     }
 
+    protected override string GetTokenType(SyntaxToken token)
+    {
+        if (token is JsxSyntaxToken jsxToken)
+        {
+            return "JSX" + jsxToken.Type.ToString();
+        }
+
+        return base.GetTokenType(token);
+    }
+
     object? IJsxAstVisitor.VisitJsxAttribute(JsxAttribute jsxAttribute)
     {
         using (StartNodeObject(jsxAttribute))

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -302,8 +302,8 @@ public class Fixtures
         public AstToJsonOptions CreateConversionOptions(AstToJsonOptions defaultOptions) => defaultOptions with
         {
             TestCompatibilityMode = TestCompatibilityMode,
-            IncludingLineColumn = IncludesLocation,
-            IncludingRange = IncludesRange,
+            IncludeLineColumn = IncludesLocation,
+            IncludeRange = IncludesRange,
         };
     }
 }

--- a/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-call-grouping.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-call-grouping.tree.json
@@ -97,6 +97,20 @@
               "column": 8
             }
           }
+        },
+        "range": [
+          0,
+          8
+        ],
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 8
+          }
         }
       },
       "range": [
@@ -175,6 +189,20 @@
                 "line": 2,
                 "column": 7
               }
+            }
+          },
+          "range": [
+            11,
+            17
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 1
+            },
+            "end": {
+              "line": 2,
+              "column": 7
             }
           }
         },
@@ -324,6 +352,20 @@
               "column": 9
             }
           }
+        },
+        "range": [
+          22,
+          31
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 9
+          }
         }
       },
       "range": [
@@ -401,6 +443,20 @@
                 "line": 4,
                 "column": 7
               }
+            }
+          },
+          "range": [
+            34,
+            40
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 1
+            },
+            "end": {
+              "line": 4,
+              "column": 7
             }
           }
         },
@@ -551,6 +607,20 @@
               "column": 9
             }
           }
+        },
+        "range": [
+          46,
+          55
+        ],
+        "loc": {
+          "start": {
+            "line": 5,
+            "column": 0
+          },
+          "end": {
+            "line": 5,
+            "column": 9
+          }
         }
       },
       "range": [
@@ -629,6 +699,20 @@
                 "line": 6,
                 "column": 7
               }
+            }
+          },
+          "range": [
+            58,
+            64
+          ],
+          "loc": {
+            "start": {
+              "line": 6,
+              "column": 1
+            },
+            "end": {
+              "line": 6,
+              "column": 7
             }
           }
         },

--- a/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-computed-property-grouping.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-computed-property-grouping.tree.json
@@ -314,6 +314,20 @@
               "column": 9
             }
           }
+        },
+        "range": [
+          20,
+          29
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 9
+          }
         }
       },
       "range": [
@@ -391,6 +405,20 @@
                 "line": 4,
                 "column": 7
               }
+            }
+          },
+          "range": [
+            32,
+            38
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 1
+            },
+            "end": {
+              "line": 4,
+              "column": 7
             }
           }
         },

--- a/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-new-grouping.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-new-grouping.tree.json
@@ -61,6 +61,20 @@
                 "column": 9
               }
             }
+          },
+          "range": [
+            5,
+            9
+          ],
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 5
+            },
+            "end": {
+              "line": 1,
+              "column": 9
+            }
           }
         },
         "arguments": [],
@@ -153,6 +167,20 @@
                 "line": 2,
                 "column": 9
               }
+            }
+          },
+          "range": [
+            16,
+            20
+          ],
+          "loc": {
+            "start": {
+              "line": 2,
+              "column": 5
+            },
+            "end": {
+              "line": 2,
+              "column": 9
             }
           }
         },
@@ -267,6 +295,20 @@
                   "line": 3,
                   "column": 9
                 }
+              }
+            },
+            "range": [
+              30,
+              34
+            ],
+            "loc": {
+              "start": {
+                "line": 3,
+                "column": 5
+              },
+              "end": {
+                "line": 3,
+                "column": 9
               }
             }
           },
@@ -439,6 +481,20 @@
                   "column": 9
                 }
               }
+            },
+            "range": [
+              47,
+              51
+            ],
+            "loc": {
+              "start": {
+                "line": 4,
+                "column": 5
+              },
+              "end": {
+                "line": 4,
+                "column": 9
+              }
             }
           },
           "arguments": [],
@@ -591,6 +647,20 @@
                   "column": 10
                 }
               }
+            },
+            "range": [
+              64,
+              68
+            ],
+            "loc": {
+              "start": {
+                "line": 5,
+                "column": 6
+              },
+              "end": {
+                "line": 5,
+                "column": 10
+              }
             }
           },
           "arguments": [],
@@ -742,6 +812,20 @@
                   "line": 6,
                   "column": 9
                 }
+              }
+            },
+            "range": [
+              79,
+              83
+            ],
+            "loc": {
+              "start": {
+                "line": 6,
+                "column": 5
+              },
+              "end": {
+                "line": 6,
+                "column": 9
               }
             }
           },

--- a/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-static-property-grouping.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2020/optional-chaining/optional-chaining-static-property-grouping.tree.json
@@ -314,6 +314,20 @@
               "column": 6
             }
           }
+        },
+        "range": [
+          16,
+          22
+        ],
+        "loc": {
+          "start": {
+            "line": 3,
+            "column": 0
+          },
+          "end": {
+            "line": 3,
+            "column": 6
+          }
         }
       },
       "range": [
@@ -391,6 +405,20 @@
                 "line": 4,
                 "column": 5
               }
+            }
+          },
+          "range": [
+            25,
+            29
+          ],
+          "loc": {
+            "start": {
+              "line": 4,
+              "column": 1
+            },
+            "end": {
+              "line": 4,
+              "column": 5
             }
           }
         },

--- a/test/Esprima.Tests/LocationTests.cs
+++ b/test/Esprima.Tests/LocationTests.cs
@@ -12,7 +12,7 @@ public class LocationTests
     {
         var start = Position.From(startLine, startColumn);
         var end = Position.From(endLine, endColumn);
-        var (actualStart, actualEnd) = Location.From(in start, in end);
+        var (actualStart, actualEnd) = Location.From(start, end);
         Assert.Equal(start, actualStart);
         Assert.Equal(end, actualEnd);
     }
@@ -27,7 +27,7 @@ public class LocationTests
         var start = Position.From(startLine, startColumn);
         var end = Position.From(endLine, endColumn);
         var e = Assert.Throws<ArgumentOutOfRangeException>(() =>
-            Location.From(in start, in end));
+            Location.From(start, end));
         Assert.Equal(paramName, e.ParamName);
         Assert.Equal(paramName == "end" ? end : start, e.ActualValue);
     }
@@ -41,7 +41,7 @@ public class LocationTests
     {
         var start = Position.From(startLine, startColumn);
         var end = Position.From(endLine, endColumn);
-        var location = Location.From(in start, in end, source);
+        var location = Location.From(start, end, source);
         Assert.Equal(expected, location.ToString());
     }
 
@@ -54,7 +54,7 @@ public class LocationTests
     {
         var start = Position.From(startLine, startColumn);
         var end = Position.From(endLine, endColumn);
-        var location = Location.From(in start, in end, source);
+        var location = Location.From(start, end, source);
         Assert.Equal(location, Location.Parse(location.ToString()));
     }
 

--- a/test/Esprima.Tests/RegExpTests.cs
+++ b/test/Esprima.Tests/RegExpTests.cs
@@ -15,7 +15,7 @@ public class RegExpTests
 
     private static Regex CreateRegex(string code)
     {
-        var options = new ParserOptions { AdaptRegexp = true };
+        var options = new ScannerOptions { AdaptRegexp = true };
         var token = new Scanner(code, options).ScanRegExp();
         return (Regex) token.Value!;
     }
@@ -186,7 +186,7 @@ public class RegExpTests
     [Fact]
     public void ShouldPreventInfiniteLoopWhenAdaptingMultiLine()
     {
-        var scanner = new Scanner("", new ParserOptions { AdaptRegexp = true });
+        var scanner = new Scanner("", new ScannerOptions { AdaptRegexp = true });
         var regex = scanner.ParseRegex("\\$", "gm", TimeSpan.FromSeconds(10));
         Assert.NotNull(regex);
     }

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -5,7 +5,7 @@ public class ScannerTests
     [Fact]
     public void CanScanMultiLineComment()
     {
-        var scanner = new Scanner("var foo=1; /* \"330413500\" */", new ParserOptions { Comments = true });
+        var scanner = new Scanner("var foo=1; /* \"330413500\" */", new ScannerOptions { Comments = true });
 
         var results = new List<string>();
         Token token;
@@ -25,7 +25,7 @@ public class ScannerTests
     [Fact]
     public void CanResetScanner()
     {
-        var scanner = new Scanner("var /* c1 */ foo=1; // c2", new ParserOptions { Comments = true });
+        var scanner = new Scanner("var /* c1 */ foo=1; // c2", new ScannerOptions { Comments = true });
 
         for (var n = 0; n < 3; n++, scanner.Reset())
         {
@@ -57,7 +57,7 @@ public class ScannerTests
     [Fact]
     public void CanResetScannerToCustomPosition()
     {
-        var scanner = new Scanner("var /* c1 */ foo=1; // c2", new ParserOptions { Comments = true });
+        var scanner = new Scanner("var /* c1 */ foo=1; // c2", new ScannerOptions { Comments = true });
         scanner.Reset(4, 1, 0);
 
         var tokens = new List<Token>();


### PR DESCRIPTION
This PR started out as an enhancement of the sample project to make it (more) useful (#332). But along the way I found some missing parts to implement, issues to fix (and APIs to break... 😄) so I've decided that it's better off split into two parts.

BCs were made especially around error handling/reporting:
* IMO it doesn't make sense to collect exceptions in `CollectingErrorHandler` once we have a separate data class (`ParseError`) for describing errors. This would only result in unnecessary memory allocation since the exception class (`ParserException`) adds no value, just wraps the error class. I set this straight and added a method named `ToException` to convert error objects to throwable exception instances.
* There was a discrepancy between the definition of the type `Position` and its usage in `ParseError.Position`: it's documented that `Position` uses a zero-based column index. The type is used accordingly throughout the codebase except for `ParseError.Position`, which used one-based column indices. I fixed this but kept `ParseError.Column` one-based to not break everything unnecessary. I also documented this for clarity.

I also revised passing of `Position`, `Range` and `Location` parameters. Removed passing `Position` and `Range` structs by-ref as it doesn't really make sense to pass pointer-sized structs that way. On 64-bit platforms it just looks like an unnecessary indirection (unless inlined), plus it may increase the stack consumption of the caller method.

Of course, for the sake of certainty, I checked for regression in performance:

## Esprima.Benchmark.FileParsingBenchmark

| **Diff**|Method|FileName|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |ParseProgram|angular-1.2.5|17.267 ms|0.0734 ms|750.0000|312.5000|-|4,315 KB|
| **New** |	|	| **17.106 ms (-1%)** | **0.0697 ms** | **750.0000 (0%)** | **312.5000 (0%)** | **-** | **4,315 KB (0%)** |
| Old |ParseProgram|backbone-1.1.0|2.322 ms|0.0103 ms|128.9063|35.1563|-|676 KB|
| **New** |	|	| **2.305 ms (-1%)** | **0.0160 ms** | **125.0000 (-3%)** | **46.8750 (+33%)** | **-** | **676 KB (0%)** |
| Old |ParseProgram|jquery-1.9.1|13.673 ms|0.0733 ms|640.6250|312.5000|-|3,764 KB|
| **New** |	|	| **13.587 ms (-1%)** | **0.0398 ms** | **625.0000 (-2%)** | **312.5000 (0%)** | **-** | **3,764 KB (0%)** |
| Old |ParseProgram|jquery.mobile-1.4.2|21.975 ms|0.1064 ms|968.7500|437.5000|-|5,798 KB|
| **New** |	|	| **21.659 ms (-1%)** | **0.2019 ms** | **1031.2500 (+6%)** | **500.0000 (+14%)** | **31.2500** | **5,798 KB (0%)** |
| Old |ParseProgram|mootools-1.4.5|10.938 ms|0.0175 ms|500.0000|250.0000|-|3,091 KB|
| **New** |	|	| **10.887 ms (0%)** | **0.0145 ms** | **500.0000 (0%)** | **250.0000 (0%)** | **-** | **3,091 KB (0%)** |
| Old |ParseProgram|underscore-1.5.2|1.946 ms|0.0118 ms|113.2813|46.8750|-|571 KB|
| **New** |	|	| **1.930 ms (-1%)** | **0.0093 ms** | **113.2813 (0%)** | **46.8750 (0%)** | **-** | **571 KB (0%)** |
| Old |ParseProgram|yui-3.12.0|9.830 ms|0.0397 ms|468.7500|234.3750|-|2,856 KB|
| **New** |	|	| **9.966 ms (+1%)** | **0.0367 ms** | **468.7500 (0%)** | **234.3750 (0%)** | **-** | **2,856 KB (0%)** |

With these changes we gained a few extra stack frames though: max. nesting depth has been increased from 585 to 589.