### PR TITLE
Add SyntaxElement internal data set and get API

### DIFF
--- a/src/Esprima/Ast/SyntaxElement.cs
+++ b/src/Esprima/Ast/SyntaxElement.cs
@@ -27,6 +27,26 @@ public abstract class SyntaxElement
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
 
+    /// <summary>
+    /// Returns internal data state value without any checks.
+    /// </summary>
+    /// <remarks>
+    /// This is an advanced API and can/will break additional data handling, you should prefer using SetAdditionalData/SetAdditionalData.
+    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public object? GetInternalData() => _additionalDataContainer._data;
+
+    /// <summary>
+    /// Forcefully sets internal data state value to given value overwriting any current state.
+    /// </summary>
+    /// <remarks>
+    /// This is an advanced API and can/will break additional data handling, you should prefer using SetAdditionalData/SetAdditionalData.
+    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
+    /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void SetInternalData(object? value) => _additionalDataContainer._data = value;
+
     public Range Range;
     public Location Location;
 

--- a/src/Esprima/Utils/AdditionalDataContainer.cs
+++ b/src/Esprima/Utils/AdditionalDataContainer.cs
@@ -4,7 +4,7 @@ internal struct AdditionalDataContainer
 {
     private static readonly object s_internalDataKey = new();
 
-    private object? _data;
+    internal object? _data;
 
     internal object? InternalData
     {


### PR DESCRIPTION
In order for Jint to easily leverage the new data slot for its selfish needs, I think it's easiest to open a public API. Exposing internals via attribute doesn't pan out very well as there are clashes with all the attributes that have been internalized in both projects, like `DoesNotReturn` etc.

I think it's enough to add enough documentation and no-no to the description for people to understand that this API isn't for the faint-hearted.