### PR TITLE
Allow attaching user-defined data to nodes without dictionary lookup

### DIFF
--- a/src/Esprima/Ast/Expression.cs
+++ b/src/Esprima/Ast/Expression.cs
@@ -21,9 +21,9 @@ public abstract class Expression : StatementListItem, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxToken>? Tokens
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxToken>?) AdditionalData[s_tokensAdditionalDataKey];
+        get => (IReadOnlyList<SyntaxToken>?) GetDynamicPropertyValue(TokensPropertyIndex);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => AdditionalData[s_tokensAdditionalDataKey] = value;
+        set => SetDynamicPropertyValue(TokensPropertyIndex, value);
     }
 
     /// <summary>
@@ -36,8 +36,8 @@ public abstract class Expression : StatementListItem, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxComment>? Comments
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxComment>?) AdditionalData[s_commentsAdditionalDataKey];
+        get => (IReadOnlyList<SyntaxComment>?) GetDynamicPropertyValue(CommentsPropertyIndex);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => AdditionalData[s_commentsAdditionalDataKey] = value;
+        set => SetDynamicPropertyValue(CommentsPropertyIndex, value);
     }
 }

--- a/src/Esprima/Ast/Expression.cs
+++ b/src/Esprima/Ast/Expression.cs
@@ -21,9 +21,9 @@ public abstract class Expression : StatementListItem, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxToken>? Tokens
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxToken>?) GetAdditionalData(s_tokensAdditionalDataKey);
+        get => (IReadOnlyList<SyntaxToken>?) AdditionalData[s_tokensAdditionalDataKey];
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => SetAdditionalData(s_tokensAdditionalDataKey, value);
+        set => AdditionalData[s_tokensAdditionalDataKey] = value;
     }
 
     /// <summary>
@@ -36,8 +36,8 @@ public abstract class Expression : StatementListItem, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxComment>? Comments
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxComment>?) GetAdditionalData(s_commentsAdditionalDataKey);
+        get => (IReadOnlyList<SyntaxComment>?) AdditionalData[s_commentsAdditionalDataKey];
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => SetAdditionalData(s_commentsAdditionalDataKey, value);
+        set => AdditionalData[s_commentsAdditionalDataKey] = value;
     }
 }

--- a/src/Esprima/Ast/Node.cs
+++ b/src/Esprima/Ast/Node.cs
@@ -5,8 +5,8 @@ namespace Esprima.Ast;
 
 public abstract class Node : SyntaxElement
 {
-    private protected static readonly object s_tokensAdditionalDataKey = new();
-    private protected static readonly object s_commentsAdditionalDataKey = new();
+    private protected const int TokensPropertyIndex = 1;
+    private protected const int CommentsPropertyIndex = 2;
 
     protected Node(Nodes type)
     {

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -27,9 +27,9 @@ public abstract class Program : Node, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxToken>? Tokens
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxToken>?) AdditionalData[s_tokensAdditionalDataKey];
+        get => (IReadOnlyList<SyntaxToken>?) GetDynamicPropertyValue(TokensPropertyIndex);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => AdditionalData[s_tokensAdditionalDataKey] = value;
+        set => SetDynamicPropertyValue(TokensPropertyIndex, value);
     }
 
     /// <summary>
@@ -42,9 +42,9 @@ public abstract class Program : Node, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxComment>? Comments
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxComment>?) AdditionalData[s_commentsAdditionalDataKey];
+        get => (IReadOnlyList<SyntaxComment>?) GetDynamicPropertyValue(CommentsPropertyIndex);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => AdditionalData[s_commentsAdditionalDataKey] = value;
+        set => SetDynamicPropertyValue(CommentsPropertyIndex, value);
     }
 
     internal sealed override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => enumerator.MoveNext(Body);

--- a/src/Esprima/Ast/Program.cs
+++ b/src/Esprima/Ast/Program.cs
@@ -27,9 +27,9 @@ public abstract class Program : Node, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxToken>? Tokens
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxToken>?) GetAdditionalData(s_tokensAdditionalDataKey);
+        get => (IReadOnlyList<SyntaxToken>?) AdditionalData[s_tokensAdditionalDataKey];
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => SetAdditionalData(s_tokensAdditionalDataKey, value);
+        set => AdditionalData[s_tokensAdditionalDataKey] = value;
     }
 
     /// <summary>
@@ -42,9 +42,9 @@ public abstract class Program : Node, ISyntaxTreeRoot
     public IReadOnlyList<SyntaxComment>? Comments
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (IReadOnlyList<SyntaxComment>?) GetAdditionalData(s_commentsAdditionalDataKey);
+        get => (IReadOnlyList<SyntaxComment>?) AdditionalData[s_commentsAdditionalDataKey];
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        set => SetAdditionalData(s_commentsAdditionalDataKey, value);
+        set => AdditionalData[s_commentsAdditionalDataKey] = value;
     }
 
     internal sealed override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => enumerator.MoveNext(Body);

--- a/src/Esprima/Ast/SyntaxElement.cs
+++ b/src/Esprima/Ast/SyntaxElement.cs
@@ -9,16 +9,32 @@ public abstract class SyntaxElement
 {
     private protected AdditionalDataSlot _additionalDataSlot;
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected object? GetDynamicPropertyValue(int propertyIndex)
+    {
+        Debug.Assert(propertyIndex > 0, "Index must be greater than 0.");
+        return _additionalDataSlot[propertyIndex];
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private protected void SetDynamicPropertyValue(int propertyIndex, object? value)
+    {
+        Debug.Assert(propertyIndex > 0, "Index must be greater than 0.");
+        _additionalDataSlot[propertyIndex] = value;
+    }
+
     /// <summary>
-    /// Gets the container of user-defined data.
+    /// Gets or sets the arbitrary, user-defined data object associated with the current <see cref="SyntaxElement"/>.
     /// </summary>
     /// <remarks>
     /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
     /// </remarks>
-    public AdditionalDataContainer AdditionalData
+    public object? AssociatedData
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => _additionalDataSlot.GetOrCreateContainer();
+        get => _additionalDataSlot.PrimaryData;
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        set => _additionalDataSlot.PrimaryData = value;
     }
 
     public Range Range;

--- a/src/Esprima/Ast/SyntaxElement.cs
+++ b/src/Esprima/Ast/SyntaxElement.cs
@@ -7,25 +7,19 @@ namespace Esprima.Ast;
 [DebuggerDisplay($"{{{nameof(GetDebuggerDisplay)}(), nq}}")]
 public abstract class SyntaxElement
 {
-    private protected AdditionalDataContainer _additionalDataContainer;
+    private protected AdditionalDataSlot _additionalDataSlot;
 
     /// <summary>
-    /// Gets additional, user-defined data associated with the specified key.
+    /// Gets the container of user-defined data.
     /// </summary>
     /// <remarks>
     /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
     /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public object? GetAdditionalData(object key) => _additionalDataContainer.GetData(key);
-
-    /// <summary>
-    /// Sets additional, user-defined data associated with the specified key.
-    /// </summary>
-    /// <remarks>
-    /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
-    /// </remarks>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
+    public AdditionalDataContainer AdditionalData
+    {
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        get => _additionalDataSlot.GetOrCreateContainer();
+    }
 
     public Range Range;
     public Location Location;

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -4,6 +4,8 @@ namespace Esprima.Ast;
 
 public class SyntaxToken : SyntaxElement
 {
+    private const int RegexValuePropertyIndex = 1;
+
     public SyntaxToken(TokenType type, string value, RegexValue? regexValue = null)
     {
         Type = type;
@@ -19,9 +21,9 @@ public class SyntaxToken : SyntaxElement
     public RegexValue? RegexValue
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (RegexValue?) _additionalDataSlot.InternalData;
+        get => (RegexValue?) GetDynamicPropertyValue(RegexValuePropertyIndex);
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private set => _additionalDataSlot.InternalData = value;
+        private set => SetDynamicPropertyValue(RegexValuePropertyIndex, value);
     }
 
     public override string ToString() => Value;

--- a/src/Esprima/Ast/SyntaxToken.cs
+++ b/src/Esprima/Ast/SyntaxToken.cs
@@ -19,9 +19,9 @@ public class SyntaxToken : SyntaxElement
     public RegexValue? RegexValue
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        get => (RegexValue?) _additionalDataContainer.InternalData;
+        get => (RegexValue?) _additionalDataSlot.InternalData;
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private set => _additionalDataContainer.InternalData = value;
+        private set => _additionalDataSlot.InternalData = value;
     }
 
     public override string ToString() => Value;

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -57,7 +57,7 @@ public record class ParserOptions : IScannerOptions
     /// { 
     ///     foreach (var child in node.ChildNodes)
     ///     {
-    ///         child.SetAdditionalData("Parent", node);
+    ///         child.AdditionalData["Parent"] = node;
     ///     }
     /// };
     /// </code>

--- a/src/Esprima/Utils/AdditionalDataContainer.cs
+++ b/src/Esprima/Utils/AdditionalDataContainer.cs
@@ -14,7 +14,7 @@ internal struct AdditionalDataSlot
     private object? _data;
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ref object? GetPrimaryDataRef(ref AdditionalDataSlot slot)
+    private static ref object? GetPrimaryDataRef(ref AdditionalDataSlot slot)
     {
         return ref (slot._data is not AdditionalDataHolder[] array ? ref slot._data : ref array[0].Data);
     }
@@ -33,15 +33,19 @@ internal struct AdditionalDataSlot
     {
         get
         {
+            Debug.Assert(index >= 0, "Index must be greater than or equal to 0.");
+
             if (index == 0)
             {
                 return GetPrimaryDataRef(ref this);
             }
 
-            return _data is AdditionalDataHolder[] array && index < array.Length ? array[index].Data : null;
+            return _data is AdditionalDataHolder[] array && (uint) index < (uint) array.Length ? array[index].Data : null;
         }
         set
         {
+            Debug.Assert(index >= 0, "Index must be greater than or equal to 0.");
+
             if (index == 0)
             {
                 Debug.Assert(value is not AdditionalDataHolder[], $"Value of type {typeof(AdditionalDataHolder[])} is not allowed.");
@@ -51,7 +55,7 @@ internal struct AdditionalDataSlot
 
             if (_data is AdditionalDataHolder[] array)
             {
-                if (index >= array.Length)
+                if ((uint) index >= (uint) array.Length)
                 {
                     if (value is null)
                     {

--- a/src/Esprima/Utils/JavascriptTextFormatter.cs
+++ b/src/Esprima/Utils/JavascriptTextFormatter.cs
@@ -280,12 +280,12 @@ public abstract class JavaScriptTextFormatter : JavaScriptTextWriter
 
     protected void StoreStatementBodyIntoContext(Statement statement, ref WriteContext context)
     {
-        context._additionalDataSlot.InternalData = statement;
+        context._additionalDataSlot.PrimaryData = statement;
     }
 
     protected Statement RetrieveStatementBodyFromContext(ref WriteContext context)
     {
-        return (Statement) (context._additionalDataSlot.InternalData ?? throw new InvalidOperationException());
+        return (Statement) (context._additionalDataSlot.PrimaryData ?? throw new InvalidOperationException());
     }
 
     public override void StartStatement(StatementFlags flags, ref WriteContext context)

--- a/src/Esprima/Utils/JavascriptTextFormatter.cs
+++ b/src/Esprima/Utils/JavascriptTextFormatter.cs
@@ -280,12 +280,12 @@ public abstract class JavaScriptTextFormatter : JavaScriptTextWriter
 
     protected void StoreStatementBodyIntoContext(Statement statement, ref WriteContext context)
     {
-        context._additionalDataContainer.InternalData = statement;
+        context._additionalDataSlot.InternalData = statement;
     }
 
     protected Statement RetrieveStatementBodyFromContext(ref WriteContext context)
     {
-        return (Statement) (context._additionalDataContainer.InternalData ?? throw new InvalidOperationException());
+        return (Statement) (context._additionalDataSlot.InternalData ?? throw new InvalidOperationException());
     }
 
     public override void StartStatement(StatementFlags flags, ref WriteContext context)

--- a/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
@@ -16,7 +16,7 @@ partial class JavaScriptTextWriter
         public WriteContext From(Node? parentNode, Node node) =>
             new WriteContext(parentNode, node ?? ThrowArgumentNullException<Node>(nameof(node)));
 
-        internal AdditionalDataContainer _additionalDataContainer;
+        internal AdditionalDataSlot _additionalDataSlot;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal WriteContext(Node? parentNode, Node node)
@@ -25,7 +25,7 @@ partial class JavaScriptTextWriter
             Node = node;
             _nodePropertyName = null;
             _nodePropertyValueAccessor = null;
-            _additionalDataContainer = default;
+            _additionalDataSlot = default;
         }
 
         public Node? ParentNode { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
@@ -94,21 +94,15 @@ partial class JavaScriptTextWriter
             SetNodeProperty(name ?? ThrowArgumentNullException<string>(nameof(name)), listValueAccessor ?? ThrowArgumentNullException<NodePropertyListValueAccessor<T>>(nameof(listValueAccessor)));
 
         /// <summary>
-        /// Gets additional, user-defined data associated with the specified key.
+        /// Gets the container of user-defined data.
         /// </summary>
         /// <remarks>
         /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
         /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public object? GetAdditionalData(object key) => _additionalDataContainer.GetData(key);
-
-        /// <summary>
-        /// Sets additional, user-defined data associated with the specified key.
-        /// </summary>
-        /// <remarks>
-        /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
-        /// </remarks>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public void SetAdditionalData(object key, object? value) => _additionalDataContainer.SetData(key, value);
+        public AdditionalDataContainer AdditionalData
+        {
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            get => _additionalDataSlot.GetOrCreateContainer();
+        }
     }
 }

--- a/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavascriptTextWriter.WriteContext.cs
@@ -94,15 +94,17 @@ partial class JavaScriptTextWriter
             SetNodeProperty(name ?? ThrowArgumentNullException<string>(nameof(name)), listValueAccessor ?? ThrowArgumentNullException<NodePropertyListValueAccessor<T>>(nameof(listValueAccessor)));
 
         /// <summary>
-        /// Gets the container of user-defined data.
+        /// Gets or sets the arbitrary, user-defined data object associated with the current <see cref="WriteContext"/>.
         /// </summary>
         /// <remarks>
         /// The operation is not guaranteed to be thread-safe. In case concurrent access or update is possible, the necessary synchronization is caller's responsibility.
         /// </remarks>
-        public AdditionalDataContainer AdditionalData
+        public object? AssociatedData
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _additionalDataSlot.GetOrCreateContainer();
+            get => _additionalDataSlot[1];
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            set => _additionalDataSlot[1] = value;
         }
     }
 }

--- a/test/Esprima.Tests/AstTests.cs
+++ b/test/Esprima.Tests/AstTests.cs
@@ -48,10 +48,10 @@ public class AstTests
             // Save visited child nodes into parent's additional data.
             if (_parentNode is not null)
             {
-                var children = (List<Node>?) _parentNode.GetAdditionalData("Children");
+                var children = (List<Node>?) _parentNode.AdditionalData["Children"];
                 if (children is null)
                 {
-                    _parentNode.SetAdditionalData("Children", children = new List<Node>());
+                    _parentNode.AdditionalData["Children"] = children = new List<Node>();
                 }
                 children.Add(node);
             }
@@ -64,7 +64,7 @@ public class AstTests
             _parentNode = originalParentNode;
 
             // Verify that the list of visited children matches ChildNodes.
-            Assert.True(node.ChildNodes.SequenceEqualUnordered((IEnumerable<Node>?) node.GetAdditionalData("Children") ?? Enumerable.Empty<Node>()));
+            Assert.True(node.ChildNodes.SequenceEqualUnordered((IEnumerable<Node>?) node.AdditionalData["Children"] ?? Enumerable.Empty<Node>()));
 
             return result;
         }

--- a/test/Esprima.Tests/AstTests.cs
+++ b/test/Esprima.Tests/AstTests.cs
@@ -48,10 +48,10 @@ public class AstTests
             // Save visited child nodes into parent's additional data.
             if (_parentNode is not null)
             {
-                var children = (List<Node>?) _parentNode.AdditionalData["Children"];
+                var children = (List<Node>?) _parentNode.AssociatedData;
                 if (children is null)
                 {
-                    _parentNode.AdditionalData["Children"] = children = new List<Node>();
+                    _parentNode.AssociatedData = children = new List<Node>();
                 }
                 children.Add(node);
             }
@@ -64,7 +64,7 @@ public class AstTests
             _parentNode = originalParentNode;
 
             // Verify that the list of visited children matches ChildNodes.
-            Assert.True(node.ChildNodes.SequenceEqualUnordered((IEnumerable<Node>?) node.AdditionalData["Children"] ?? Enumerable.Empty<Node>()));
+            Assert.True(node.ChildNodes.SequenceEqualUnordered((IEnumerable<Node>?) node.AssociatedData ?? Enumerable.Empty<Node>()));
 
             return result;
         }

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -413,14 +413,14 @@ block comment", comment.Value);
     {
         public void Check(Node node)
         {
-            Assert.Null(node.GetAdditionalData("Parent"));
+            Assert.Null(node.AdditionalData["Parent"]);
 
             base.Visit(node);
         }
 
         public override object? Visit(Node node)
         {
-            var parent = (Node?) node.GetAdditionalData("Parent");
+            var parent = (Node?) node.AdditionalData["Parent"];
             Assert.NotNull(parent);
             Assert.Contains(node, parent!.ChildNodes);
 
@@ -435,7 +435,7 @@ block comment", comment.Value);
         {
             foreach (var child in node.ChildNodes)
             {
-                child.SetAdditionalData("Parent", node);
+                child.AdditionalData["Parent"] = node;
             }
         };
 

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -413,14 +413,14 @@ block comment", comment.Value);
     {
         public void Check(Node node)
         {
-            Assert.Null(node.AdditionalData["Parent"]);
+            Assert.Null(node.AssociatedData);
 
             base.Visit(node);
         }
 
         public override object? Visit(Node node)
         {
-            var parent = (Node?) node.AdditionalData["Parent"];
+            var parent = (Node?) node.AssociatedData;
             Assert.NotNull(parent);
             Assert.Contains(node, parent!.ChildNodes);
 
@@ -435,7 +435,7 @@ block comment", comment.Value);
         {
             foreach (var child in node.ChildNodes)
             {
-                child.AdditionalData["Parent"] = node;
+                child.AssociatedData = node;
             }
         };
 


### PR DESCRIPTION
This is an alternative solution to the issue addressed by #337. It works without leaking internals through the public API (and at the same time makes it a bit cleaner) at the expense of a bit of extra allocation. (An `AdditionalDataContainer` instance is created when user-defined data is actually attached.)
