### PR TITLE
Fix AOT-related issues using function pointers

### DIFF
--- a/src/Esprima/JsxParser.cs
+++ b/src/Esprima/JsxParser.cs
@@ -296,9 +296,9 @@ public class JsxParser : JavaScriptParser
     {
     }
 
-    private protected override Expression ParsePrimaryExpression()
+    private protected override Expression? ParseExtensionExpression()
     {
-        return Match("<") ? ParseJsxRoot() : base.ParsePrimaryExpression();
+        return Match("<") ? ParseJsxRoot() : null;
     }
 
     private protected override bool IsStartOfExpression()


### PR DESCRIPTION
This is a potential solution to #344 if you are ok with a bit of unsafe code ([C# 9 function pointers](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-9.0/function-pointers)). Of course, unsafe code should be avoided if possible, yet in this case we might consider it because besides solving the issue, it would also bring a minor performance improvement:

## Esprima.Benchmark.FileParsingBenchmark

| **Diff**|Method|FileName|Mean|Error|Allocated|
|------- |-------|-------|-------:|-------|-------:|
| Old |ParseProgram|angular-1.2.5|16.386 ms|0.0850 ms|4314.91 KB|
| **New** |	|	| **16.211 ms (-1%)** | **0.0765 ms** | **4314.91 KB (0%)** |
| Old |ParseProgram|backbone-1.1.0|2.187 ms|0.0073 ms|676.04 KB|
| **New** |	|	| **2.147 ms (-2%)** | **0.0069 ms** | **676.04 KB (0%)** |
| Old |ParseProgram|jquery-1.9.1|13.007 ms|0.0689 ms|3764.05 KB|
| **New** |	|	| **12.846 ms (-1%)** | **0.0645 ms** | **3764.05 KB (0%)** |
| Old |ParseProgram|jquery.mobile-1.4.2|20.247 ms|0.0386 ms|5797.76 KB|
| **New** |	|	| **20.086 ms (-1%)** | **0.0854 ms** | **5797.79 KB (0%)** |
| Old |ParseProgram|mootools-1.4.5|10.244 ms|0.0672 ms|3090.51 KB|
| **New** |	|	| **10.099 ms (-1%)** | **0.0071 ms** | **3090.51 KB (0%)** |
| Old |ParseProgram|underscore-1.5.2|1.866 ms|0.0089 ms|570.9 KB|
| **New** |	|	| **1.837 ms (-2%)** | **0.0065 ms** | **570.9 KB (0%)** |
| Old |ParseProgram|yui-3.12.0|9.518 ms|0.0586 ms|2856.3 KB|
| **New** |	|	| **9.287 ms (-2%)** | **0.0549 ms** | **2856.3 KB (0%)** |

As for `MaxAssignmentDepth`, this approach has a minimal negative effect (considering the core parser): max. possible depth reduced by 3.

Are you ok with this or would you rather go the "safe" way?