### PR TITLE
 Revise usage of string operations which are culture-sensitive by default

### DIFF
--- a/src/Esprima.SourceGenerators/StringMatcherGenerator.cs
+++ b/src/Esprima.SourceGenerators/StringMatcherGenerator.cs
@@ -111,7 +111,7 @@ public class StringMatcherGenerator : IIncrementalGenerator
             returnType = "string";
         }*/
 
-        var typeModifiers = method.ContainingSymbol.DeclaredAccessibility.ToString().ToLower();
+        var typeModifiers = method.ContainingSymbol.DeclaredAccessibility.ToString().ToLowerInvariant();
         var containingType = method.ContainingType.Name;
         var modifiers = methodDeclarationSyntax.Modifiers.ToString();
         var inputType = method.Parameters.Single().Type.ToString();

--- a/src/Esprima.SourceGenerators/StringMatcherGenerator.cs
+++ b/src/Esprima.SourceGenerators/StringMatcherGenerator.cs
@@ -57,7 +57,7 @@ public class StringMatcherGenerator : IIncrementalGenerator
         static string CleanTarget(string s)
         {
             s = s.TrimStart('"');
-            if (s.EndsWith("\""))
+            if (s.EndsWith("\"", StringComparison.Ordinal))
             {
                 s = s.Substring(0, s.Length - 1);
             }
@@ -159,8 +159,8 @@ public class StringMatcherGenerator : IIncrementalGenerator
                 sourceBuilder.Append(method.Modifiers).Append(" ").Append(method.ReturnType).Append(" ").Append(method.Name).Append("(").Append(method.InputType).AppendLine(" input)");
                 sourceBuilder.Append(indent).AppendLine("{");
 
-                var checkNull = method.InputType.EndsWith("?");
-                var returnString = method.ReturnType.StartsWith("string");
+                var checkNull = method.InputType.EndsWith("?", StringComparison.Ordinal);
+                var returnString = method.ReturnType.StartsWith("string", StringComparison.Ordinal);
                 var sourceIsSpan = method.InputType.Contains("Span");
 
                 sourceBuilder.Append(SourceGenerationHelper.GenerateLookups(method.Alternatives, indent: "    ", indentionLevel: 2, checkNull, returnString, sourceIsSpan));

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1320,7 +1320,7 @@ public sealed partial class Scanner
         }
         else
         {
-            d = number.TrimStart().StartsWith("-")
+            d = number.TrimStart().StartsWith("-", StringComparison.Ordinal)
                 ? double.NegativeInfinity
                 : double.PositiveInfinity;
 

--- a/test/Esprima.Tests.Test262/Program.cs
+++ b/test/Esprima.Tests.Test262/Program.cs
@@ -21,7 +21,7 @@ public static class Program
         var allowListFile = Path.Combine(projectRoot, "allow-list.txt");
         var lines = File.Exists(allowListFile) ? await File.ReadAllLinesAsync(allowListFile) : Array.Empty<string>();
         var knownFailing = new HashSet<string>(lines
-            .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("#"))
+            .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("#", StringComparison.Ordinal))
         );
 
         var serializerOptions = new JsonSerializerOptions { ReadCommentHandling = JsonCommentHandling.Skip };

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -696,7 +696,7 @@ if (b == 2) {
         static T CreateParserOptions<T>() where T : ParserOptions, new() =>
             new T { Tokens = false, Tolerant = false, AdaptRegexp = false };
 
-        var (parserOptionsFactory, parserFactory, convertToCode) = fixture.StartsWith("JSX")
+        var (parserOptionsFactory, parserFactory, convertToCode) = fixture.StartsWith("JSX", StringComparison.Ordinal)
             ? (CreateParserOptions<JsxParserOptions>,
                 opts => new JsxParser((JsxParserOptions) opts),
                 (node, format) => node.ToJavaScriptString(format ? KnRJavaScriptTextFormatterOptions.Default : JavaScriptTextWriterOptions.Default, JsxAstToJavaScriptOptions.Default))
@@ -707,7 +707,7 @@ if (b == 2) {
         string treeFilePath, failureFilePath, moduleFilePath;
         var jsFilePath = Path.Combine(Fixtures.GetFixturesPath(), Fixtures.FixturesDirName, fixture);
         var jsFileDirectoryName = Path.GetDirectoryName(jsFilePath)!;
-        if (jsFilePath.EndsWith(".source.js"))
+        if (jsFilePath.EndsWith(".source.js", StringComparison.Ordinal))
         {
             treeFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".tree.json";
             failureFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".failure.json";
@@ -721,7 +721,7 @@ if (b == 2) {
         }
 
         var script = File.ReadAllText(jsFilePath);
-        if (jsFilePath.EndsWith(".source.js"))
+        if (jsFilePath.EndsWith(".source.js", StringComparison.Ordinal))
         {
             var parser = new JavaScriptParser();
             var program = parser.ParseScript(script);

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -89,7 +89,7 @@ public class Fixtures
         static T CreateParserOptions<T>(bool tolerant, bool adaptRegex) where T : ParserOptions, new() =>
             new T { Tokens = true, Tolerant = tolerant, AdaptRegexp = adaptRegex };
 
-        var (parserOptionsFactory, parserFactory, conversionDefaultOptions) = fixture.StartsWith("JSX")
+        var (parserOptionsFactory, parserFactory, conversionDefaultOptions) = fixture.StartsWith("JSX", StringComparison.Ordinal)
             ? (CreateParserOptions<JsxParserOptions>,
                 opts => new JsxParser((JsxParserOptions) opts),
                 JsxAstToJsonOptions.Default)
@@ -100,7 +100,7 @@ public class Fixtures
         string treeFilePath, failureFilePath, moduleFilePath;
         var jsFilePath = Path.Combine(GetFixturesPath(), FixturesDirName, fixture);
         var jsFileDirectoryName = Path.GetDirectoryName(jsFilePath)!;
-        if (jsFilePath.EndsWith(".source.js"))
+        if (jsFilePath.EndsWith(".source.js", StringComparison.Ordinal))
         {
             treeFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".tree.json";
             failureFilePath = Path.Combine(jsFileDirectoryName, Path.GetFileNameWithoutExtension(Path.GetFileNameWithoutExtension(jsFilePath))) + ".failure.json";
@@ -114,7 +114,7 @@ public class Fixtures
         }
 
         var script = File.ReadAllText(jsFilePath);
-        if (jsFilePath.EndsWith(".source.js"))
+        if (jsFilePath.EndsWith(".source.js", StringComparison.Ordinal))
         {
             var parser = new JavaScriptParser();
             var program = parser.ParseScript(script);


### PR DESCRIPTION
When I tried to compile source code, sourceGenerator generate wrong content. This is caused by culture. I'm using in Tr-TR culture and it's try to convert 'i' to 'I'. This pr solve the issue when building.

Logs:

```log
Esprima.SourceGenerators.StringMatcherGenerator/StringMatchers.g.cs(159,1): error CS0246: 'ınternal' türü veya ad alanı adı bulunamadı (bir using yönergeniz veya derleme başvurunuz mu eksik?) 
```


```cs
"internal".ToLower() = "ınternal" //Problem
"internal".ToLowerInvariant() = "internal"
```

I → lowercase → ı
i → uppercase → İ

