### PR TITLE
Allow end users to directly instantiate Scanner using a ParserOptions instance

### DIFF
--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -142,7 +142,7 @@ public partial class JavaScriptParser
         _maxAssignmentDepth = options.MaxAssignmentDepth;
         _onNodeCreated = options.OnNodeCreated;
 
-        _scanner = new Scanner(options);
+        _scanner = new Scanner(options.ScannerOptions);
 
         _context = new Context();
 

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -5,11 +5,11 @@ namespace Esprima;
 /// <summary>
 /// Parser options.
 /// </summary>
-public record class ParserOptions : IScannerOptions
+public record class ParserOptions
 {
     public static readonly ParserOptions Default = new();
 
-    internal readonly ScannerOptions _scannerOptions = new();
+    public ScannerOptions ScannerOptions { get; } = new();
 
     /// <summary>
     /// Gets or sets whether the tokens are included in the parsed tree, defaults to <see langword="false"/>.
@@ -19,27 +19,27 @@ public record class ParserOptions : IScannerOptions
     /// <summary>
     /// Gets or sets whether the comments are included in the parsed tree, defaults to <see langword="false"/>.
     /// </summary>
-    public bool Comments { get; init; }
+    public bool Comments { get => ScannerOptions._comments; init => ScannerOptions._comments = value; }
 
     /// <summary>
     /// Gets or sets whether the parser is tolerant to errors, defaults to <see langword="true"/>.
     /// </summary>
-    public bool Tolerant { get; init; } = true;
+    public bool Tolerant { get => ScannerOptions._tolerant; init => ScannerOptions._tolerant = value; }
 
     /// <summary>
     /// Gets or sets the <see cref="ErrorHandler"/> to use, defaults to <see cref="ErrorHandler.Default"/>.
     /// </summary>
-    public ErrorHandler ErrorHandler { get; init; } = ErrorHandler.Default;
+    public ErrorHandler ErrorHandler { get => ScannerOptions._errorHandler; init => ScannerOptions._errorHandler = value; }
 
     /// <summary>
     /// Gets or sets whether the Regular Expression syntax should be converted to a .NET compatible one, defaults to <see langword="true"/>.
     /// </summary>
-    public bool AdaptRegexp { get; init; } = true;
+    public bool AdaptRegexp { get => ScannerOptions._adaptRegexp; init => ScannerOptions._adaptRegexp = value; }
 
     /// <summary>
     /// Default timeout for created regexes, defaults to 10 seconds.
     /// </summary>
-    public TimeSpan RegexTimeout { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan RegexTimeout { get => ScannerOptions._regexTimeout; init => ScannerOptions._regexTimeout = value; }
 
     /// <summary>
     /// The maximum depth of assignments allowed, defaults to 200.
@@ -57,7 +57,7 @@ public record class ParserOptions : IScannerOptions
     /// { 
     ///     foreach (var child in node.ChildNodes)
     ///     {
-    ///         child.AdditionalData["Parent"] = node;
+    ///         child.AdditionalData = node;
     ///     }
     /// };
     /// </code>

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -85,7 +85,7 @@ public sealed partial class Scanner
         return ch - '0';
     }
 
-    internal Scanner(IScannerOptions options)
+    internal Scanner(ScannerOptions options)
     {
         if (options == null)
         {

--- a/src/Esprima/ScannerOptions.cs
+++ b/src/Esprima/ScannerOptions.cs
@@ -1,43 +1,40 @@
 ﻿namespace Esprima;
 
-internal interface IScannerOptions
-{
-    bool Comments { get; }
-    bool Tolerant { get; }
-    ErrorHandler ErrorHandler { get; }
-    bool AdaptRegexp { get; }
-    TimeSpan RegexTimeout { get; }
-}
-
 /// <summary>
 /// Scanner options.
 /// </summary>
-public record class ScannerOptions : IScannerOptions
+public record class ScannerOptions
 {
     public static readonly ScannerOptions Default = new();
+
+    internal bool _comments;
+    internal bool _tolerant = true;
+    internal ErrorHandler _errorHandler = ErrorHandler.Default;
+    internal bool _adaptRegexp = true;
+    internal TimeSpan _regexTimeout = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// Gets or sets whether the comments are collected, defaults to <see langword="false"/>.
     /// </summary>
-    public bool Comments { get; init; }
+    public bool Comments { get => _comments; init => _comments = value; }
 
     /// <summary>
     /// Gets or sets whether the scanner is tolerant to errors, defaults to <see langword="true"/>.
     /// </summary>
-    public bool Tolerant { get; init; } = true;
+    public bool Tolerant { get => _tolerant; init => _tolerant = value; }
 
     /// <summary>
     /// Gets or sets the <see cref="ErrorHandler"/> to use, defaults to <see cref="ErrorHandler.Default"/>.
     /// </summary>
-    public ErrorHandler ErrorHandler { get; init; } = ErrorHandler.Default;
+    public ErrorHandler ErrorHandler { get => _errorHandler; init => _errorHandler = value; }
 
     /// <summary>
     /// Gets or sets whether the Regular Expression syntax should be converted to a .NET compatible one, defaults to <see langword="true"/>.
     /// </summary>
-    public bool AdaptRegexp { get; init; } = true;
+    public bool AdaptRegexp { get => _adaptRegexp; init => _adaptRegexp = value; }
 
     /// <summary>
     /// Default timeout for created regexes, defaults to 10 seconds.
     /// </summary>
-    public TimeSpan RegexTimeout { get; init; } = TimeSpan.FromSeconds(10);
+    public TimeSpan RegexTimeout { get => _regexTimeout; init => _regexTimeout = value; }
 }


### PR DESCRIPTION
After recent changes, no simple way exists for end users to convert a `ParserOptions` to a `ScannerOptions` instance when they want to create a `Scanner` with the same configuration. The proposed change would simplify use cases like [this](https://github.com/adams85/bundling/commit/f7f92b203fa4f0a2b80a9a1e85074dd0f8b9017c#diff-92b345a131fd56a8f3975d6c4cc410aeef3886cbf7aeac38facb5ee471208087L59).
