### PR TITLE
Remove Data member from PropertyKind and make it non-Flags

### DIFF
--- a/src/Esprima/Ast/PropertyKind.cs
+++ b/src/Esprima/Ast/PropertyKind.cs
@@ -1,14 +1,12 @@
 ﻿namespace Esprima.Ast;
 
-[Flags]
 public enum PropertyKind
 {
-    None = 0,
-    Data = 1,
-    Get = 2,
-    Set = 4,
-    Init = 8,
-    Constructor = 16,
-    Method = 32,
-    Property = 64
-};
+    None,
+    Get,
+    Set,
+    Init,
+    Constructor,
+    Method,
+    Property
+}


### PR DESCRIPTION
I could have sworn that this cleanup was already done earlier. `Data` is never used and `[Flags] `really makes no sense as you cannot have multiple active values.