### PR TITLE
Fix building of release artifacts in GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
         VERSION="${arrTag[2]}"
         VERSION="${VERSION//v}"
         echo "$VERSION"
-        dotnet pack --output artifacts --configuration Release -p:Version=$VERSION
+        dotnet pack src/Esprima/Esprima.csproj --output artifacts --configuration Release -p:Version=$VERSION
 
     - name: Push with dotnet
       run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -28,7 +28,7 @@ jobs:
       run: dotnet test --configuration Release --logger GitHubActions
 
     - name: Pack with dotnet
-      run: dotnet pack --output artifacts --configuration Release -p:PackageVersion=3.0.0-preview-$GITHUB_RUN_NUMBER
+      run: dotnet pack src/Esprima/Esprima.csproj --output artifacts --configuration Release -p:PackageVersion=3.0.0-preview-$GITHUB_RUN_NUMBER
 
     - name: Push with dotnet
       run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.MYGET_API_KEY }} --skip-duplicate --source https://www.myget.org/F/esprimadotnet/api/v2/package


### PR DESCRIPTION
Looks like we've been bitten by [this BC recently introduced in the .NET 7 SDK](https://github.com/dotnet/sdk/issues/30625).

Also, we've been polluting NuGet & MyGet with [our internal source generator project](https://www.nuget.org/packages/Esprima.SourceGenerators) for a while...

This PR attempts to solve both issues.