### PR TITLE
Minor corrections

### DIFF
--- a/src/Esprima/Loc.cs
+++ b/src/Esprima/Loc.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using static Esprima.EsprimaExceptionHelper;
@@ -233,12 +234,14 @@ InvalidFormat:
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Location Parse(string s) => Parse(s.AsSpan());
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Deconstruct(out Position start, out Position end)
     {
         start = Start;
         end = End;
     }
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Deconstruct(out Position start, out Position end, out string? source)
     {
         start = Start;

--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -57,7 +57,7 @@ public record class ParserOptions
     /// { 
     ///     foreach (var child in node.ChildNodes)
     ///     {
-    ///         child.AdditionalData = node;
+    ///         child.AssociatedData = node;
     ///     }
     /// };
     /// </code>

--- a/src/Esprima/Position.cs
+++ b/src/Esprima/Position.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using static Esprima.EsprimaExceptionHelper;
@@ -168,6 +169,7 @@ InvalidFormat:
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Position Parse(string s) => Parse(s.AsSpan());
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Deconstruct(out int line, out int column)
     {
         line = Line;

--- a/src/Esprima/Range.cs
+++ b/src/Esprima/Range.cs
@@ -146,4 +146,11 @@ InvalidFormat:
         start = Start;
         end = End;
     }
+
+#if NETSTANDARD2_1_OR_GREATER
+    public System.Range ToSystemRange()
+    {
+        return new System.Range(Start, End);
+    }
+#endif
 }

--- a/src/Esprima/Range.cs
+++ b/src/Esprima/Range.cs
@@ -1,4 +1,5 @@
-﻿using System.Diagnostics;
+﻿using System.ComponentModel;
+using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.CompilerServices;
 using static Esprima.EsprimaExceptionHelper;
@@ -139,6 +140,7 @@ InvalidFormat:
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static Range Parse(string s) => Parse(s.AsSpan());
 
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public void Deconstruct(out int start, out int end)
     {
         start = Start;


### PR DESCRIPTION
Some small corrections and a minor QoL improvement to `Range`, which makes the following pattern possible by leveraging [C# 8 indices and ranges](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/proposals/csharp-8.0/ranges):

```csharp
var code = "...";
var script = parser.ParseScript(code);
var node = script.DescendantNodes()./* ... */;
var nodeText = code[node.Range.ToSystemRange()];
```

(Unfortunately, we need a method for this, implicit conversion won't work.)


