### PR TITLE
Internalize some members

### DIFF
--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Esprima.Utils;
 
 namespace Esprima.Ast;
 

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using Esprima.Utils;
 
 namespace Esprima.Ast;
 

--- a/src/Esprima/Character.cs
+++ b/src/Esprima/Character.cs
@@ -20,7 +20,7 @@ public static partial class Character
 
     // https://tc39.github.io/ecma262/#sec-line-terminators
 
-    public static bool IsLineTerminator(char ch)
+    internal static bool IsLineTerminator(char ch)
     {
         return ch == 10
                || ch == 13
@@ -31,29 +31,29 @@ public static partial class Character
 
     // https://tc39.github.io/ecma262/#sec-white-space
 
-    public static bool IsWhiteSpace(char ch)
+    internal static bool IsWhiteSpace(char ch)
     {
         return (_characterData[ch] & (byte) CharacterMask.WhiteSpace) != 0;
     }
 
     // https://tc39.github.io/ecma262/#sec-names-and-keywords
 
-    public static bool IsIdentifierStart(char ch)
+    internal static bool IsIdentifierStart(char ch)
     {
         return (_characterData[ch] & (byte) CharacterMask.IdentifierStart) != 0;
     }
 
-    public static bool IsIdentifierStart(string s, int index)
+    internal static bool IsIdentifierStart(string s, int index)
     {
         return IsIdentifierStartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
     }
 
-    public static bool IsIdentifierPart(char ch)
+    internal static bool IsIdentifierPart(char ch)
     {
         return (_characterData[ch] & (byte) CharacterMask.IdentifierPart) != 0;
     }
 
-    public static bool IsIdentifierPart(string s, int index)
+    internal static bool IsIdentifierPart(string s, int index)
     {
         return IsIdentifierPartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
     }
@@ -72,11 +72,10 @@ public static partial class Character
 
     public static bool IsOctalDigit(char cp) => IsInRange(cp, '0', '7');
 
-    public static string FromCodePoint(int cp) => char.ConvertFromUtf32(cp);
+    internal static string FromCodePoint(int cp) => char.ConvertFromUtf32(cp);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsInRange(char c, char min, char max) => c - (uint) min <= max - (uint) min;
-
 
     internal static bool IsIdentifierStartUnicodeCategory(UnicodeCategory cat)
     {

--- a/src/Esprima/Messages.cs
+++ b/src/Esprima/Messages.cs
@@ -1,7 +1,7 @@
 ﻿namespace Esprima;
 
 // Error messages should be identical to V8.
-public static class Messages
+internal static class Messages
 {
     public const string ArgumentsNotAllowedInClassField = "'arguments' is not allowed in class field initializer or static initialization block";
     public const string AsyncFunctionInSingleStatementContext = "Async functions can only be declared at the top level or inside a block.";

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Globalization;
 using System.Numerics;
 using System.Reflection;


### PR DESCRIPTION
Tested using Jint's point of view and `Messages` and most of `Character` helpers can be made `internal`. We can make public again later if requested, but harder to hide later without major release.