### PR TITLE
Improve ESTree compliance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ parser (also popularly known as
 ### Features
 
 - Full support for ECMAScript 2019 ([ECMA-262 10th Edition](http://www.ecma-international.org/publications/standards/Ecma-262.htm))
-- Sensible [syntax tree format](https://github.com/estree/estree/blob/master/es5.md) as standardized by [ESTree project](https://github.com/estree/estree)
+- Sensible [syntax tree format](https://github.com/estree/estree/blob/master/es5.md) which follows the standard established by the [ESTree project](https://github.com/estree/estree)
 - Experimental support for [JSX](https://facebook.github.io/jsx/), a syntax extension for [React](https://facebook.github.io/react/)
 - Optional tracking of syntax node location (index-based and line-column)
 - Heavily tested

--- a/src/Esprima/Ast/AssignmentExpression.cs
+++ b/src/Esprima/Ast/AssignmentExpression.cs
@@ -64,7 +64,7 @@ public sealed partial class AssignmentExpression : Expression
             "??=" => AssignmentOperator.NullishAssign,
             "&&=" => AssignmentOperator.AndAssign,
             "||=" => AssignmentOperator.OrAssign,
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid assignment operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid assignment operator.")
         };
     }
 
@@ -88,7 +88,7 @@ public sealed partial class AssignmentExpression : Expression
             AssignmentOperator.NullishAssign => "??=",
             AssignmentOperator.AndAssign => "&&=",
             AssignmentOperator.OrAssign => "||=",
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid assignment operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid assignment operator.")
         };
     }
 

--- a/src/Esprima/Ast/BinaryExpression.cs
+++ b/src/Esprima/Ast/BinaryExpression.cs
@@ -40,6 +40,10 @@ public partial class BinaryExpression : Expression
 
     public BinaryExpression(BinaryOperator op, Expression left, Expression right) : this(Nodes.BinaryExpression, op, left, right)
     {
+        if (LogicalExpression.IsLogicalOperator(op))
+        {
+            throw new ArgumentOutOfRangeException(nameof(op), op, "Value must be a non-logical operator.");
+        }
     }
 
     private protected BinaryExpression(Nodes type, string op, Expression left, Expression right) : this(type, ParseBinaryOperator(op), left, right)
@@ -82,7 +86,7 @@ public partial class BinaryExpression : Expression
             "||" => BinaryOperator.LogicalOr,
             "**" => BinaryOperator.Exponentiation,
             "??" => BinaryOperator.NullishCoalescing,
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid binary operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid binary operator.")
         };
     }
 
@@ -115,7 +119,7 @@ public partial class BinaryExpression : Expression
             BinaryOperator.LogicalOr => "||",
             BinaryOperator.Exponentiation => "**",
             BinaryOperator.NullishCoalescing => "??",
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid binary operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid binary operator.")
         };
     }
 

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -3,7 +3,7 @@
 namespace Esprima.Ast;
 
 [VisitableNode(ChildProperties = new[] { nameof(Local), nameof(Exported) })]
-public sealed partial class ExportSpecifier : Node
+public sealed partial class ExportSpecifier : Node, IModuleSpecifier
 {
     public ExportSpecifier(Expression local, Expression exported) : base(Nodes.ExportSpecifier)
     {

--- a/src/Esprima/Ast/IModuleSpecifier.cs
+++ b/src/Esprima/Ast/IModuleSpecifier.cs
@@ -1,0 +1,11 @@
+﻿namespace Esprima.Ast;
+
+/// <summary>
+/// Represents either an <see cref="ExportSpecifier"/> or an <see cref="ImportDeclarationSpecifier"/>
+/// </summary>
+public interface IModuleSpecifier
+{
+    Nodes Type { get; }
+    Expression Local { get; }
+    ChildNodes ChildNodes { get; }
+}

--- a/src/Esprima/Ast/ImportDeclarationSpecifier.cs
+++ b/src/Esprima/Ast/ImportDeclarationSpecifier.cs
@@ -2,7 +2,7 @@
 
 namespace Esprima.Ast;
 
-public abstract class ImportDeclarationSpecifier : Node
+public abstract class ImportDeclarationSpecifier : Node, IModuleSpecifier
 {
     protected ImportDeclarationSpecifier(Identifier local, Nodes type) : base(type)
     {
@@ -10,4 +10,5 @@ public abstract class ImportDeclarationSpecifier : Node
     }
 
     public Identifier Local { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+    Expression IModuleSpecifier.Local => Local;
 }

--- a/src/Esprima/Ast/ImportExpression.cs
+++ b/src/Esprima/Ast/ImportExpression.cs
@@ -3,9 +3,9 @@
 namespace Esprima.Ast;
 
 [VisitableNode(ChildProperties = new[] { nameof(Source) })]
-public sealed partial class Import : Expression
+public sealed partial class ImportExpression : Expression
 {
-    public Import(Expression source) : base(Nodes.Import)
+    public ImportExpression(Expression source) : base(Nodes.ImportExpression)
     {
         Source = source;
     }
@@ -13,8 +13,8 @@ public sealed partial class Import : Expression
     public Expression Source { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private Import Rewrite(Expression source)
+    private ImportExpression Rewrite(Expression source)
     {
-        return new Import(source);
+        return new ImportExpression(source);
     }
 }

--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -4,8 +4,8 @@ using System.Text.RegularExpressions;
 
 namespace Esprima.Ast;
 
-[VisitableNode]
-public sealed partial class Literal : Expression
+[VisitableNode(SealOverrideMethods = true)]
+public partial class Literal : Expression
 {
     private static readonly object s_boxedTrue = true;
     private static readonly object s_boxedFalse = false;
@@ -37,16 +37,9 @@ public sealed partial class Literal : Expression
     {
     }
 
-    public Literal(string pattern, string flags, object? value, string raw) : this(TokenType.RegularExpression, value, raw)
-    {
-        // value is null if a Regex object couldn't be created out of the pattern or options
-        Regex = new RegexValue(pattern, flags);
-    }
-
     public TokenType TokenType { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public object? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
     public string Raw { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
-    public RegexValue? Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? (string) Value! : null; }
     public bool? BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral ? ReferenceEquals(Value, s_boxedTrue) : null; }

--- a/src/Esprima/Ast/LogicalExpression.cs
+++ b/src/Esprima/Ast/LogicalExpression.cs
@@ -2,12 +2,24 @@
 
 public sealed class LogicalExpression : BinaryExpression
 {
-    public LogicalExpression(string op, Expression left, Expression right) : base(Nodes.LogicalExpression, op, left, right)
+    public LogicalExpression(string op, Expression left, Expression right) : this(ParseBinaryOperator(op), left, right)
     {
     }
 
     public LogicalExpression(BinaryOperator op, Expression left, Expression right) : base(Nodes.LogicalExpression, op, left, right)
     {
+        if (!IsLogicalOperator(op))
+        {
+            throw new ArgumentOutOfRangeException(nameof(op), op, "Value must be a logical operator.");
+        }
+    }
+
+    internal static bool IsLogicalOperator(BinaryOperator op)
+    {
+        return op is
+            BinaryOperator.LogicalAnd or
+            BinaryOperator.LogicalOr or
+            BinaryOperator.NullishCoalescing;
     }
 
     protected override BinaryExpression Rewrite(Expression left, Expression right)

--- a/src/Esprima/Ast/Nodes.cs
+++ b/src/Esprima/Ast/Nodes.cs
@@ -23,7 +23,7 @@ public enum Nodes
     FunctionExpression,
     Identifier,
     IfStatement,
-    Import,
+    ImportExpression,
     Literal,
     LabeledStatement,
     LogicalExpression,

--- a/src/Esprima/Ast/RegExpLiteral.cs
+++ b/src/Esprima/Ast/RegExpLiteral.cs
@@ -1,0 +1,15 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace Esprima.Ast;
+
+public sealed class RegExpLiteral : Literal
+{
+    public RegExpLiteral(string pattern, string flags, object? value, string raw) : base(TokenType.RegularExpression, value, raw)
+    {
+        // value is null if a Regex object couldn't be created out of the pattern or options
+
+        Regex = new RegexValue(pattern, flags);
+    }
+
+    public RegexValue Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
+}

--- a/src/Esprima/Ast/RegExpLiteral.cs
+++ b/src/Esprima/Ast/RegExpLiteral.cs
@@ -4,11 +4,15 @@ namespace Esprima.Ast;
 
 public sealed class RegExpLiteral : Literal
 {
-    public RegExpLiteral(string pattern, string flags, object? value, string raw) : base(TokenType.RegularExpression, value, raw)
+    public RegExpLiteral(string pattern, string flags, object? value, string raw) : this(new RegexValue(pattern, flags), value, raw)
+    {
+    }
+
+    public RegExpLiteral(RegexValue regex, object? value, string raw) : base(TokenType.RegularExpression, value, raw)
     {
         // value is null if a Regex object couldn't be created out of the pattern or options
 
-        Regex = new RegexValue(pattern, flags);
+        Regex = regex;
     }
 
     public RegexValue Regex { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }

--- a/src/Esprima/Ast/UnaryExpression.cs
+++ b/src/Esprima/Ast/UnaryExpression.cs
@@ -24,6 +24,10 @@ public partial class UnaryExpression : Expression
 
     public UnaryExpression(UnaryOperator op, Expression arg) : this(Nodes.UnaryExpression, op, arg, prefix: true)
     {
+        if (UpdateExpression.IsUpdateOperator(op))
+        {
+            throw new ArgumentOutOfRangeException(nameof(op), op, "Value must be a non-update operator.");
+        }
     }
 
     private protected UnaryExpression(Nodes type, string op, Expression arg, bool prefix) : this(type, ParseUnaryOperator(op), arg, prefix)
@@ -50,7 +54,7 @@ public partial class UnaryExpression : Expression
             "typeof" => UnaryOperator.TypeOf,
             "++" => UnaryOperator.Increment,
             "--" => UnaryOperator.Decrement,
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid unary operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid unary operator.")
         };
     }
 
@@ -67,7 +71,7 @@ public partial class UnaryExpression : Expression
             UnaryOperator.TypeOf => "typeof",
             UnaryOperator.Increment => "++",
             UnaryOperator.Decrement => "--",
-            _ => throw new ArgumentOutOfRangeException(nameof(op), "Invalid unary operator: " + op)
+            _ => throw new ArgumentOutOfRangeException(nameof(op), op, "Invalid unary operator.")
         };
     }
 

--- a/src/Esprima/Ast/UpdateExpression.cs
+++ b/src/Esprima/Ast/UpdateExpression.cs
@@ -2,12 +2,23 @@
 
 public sealed class UpdateExpression : UnaryExpression
 {
-    public UpdateExpression(string op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg, prefix)
+    public UpdateExpression(string op, Expression arg, bool prefix) : this(ParseUnaryOperator(op), arg, prefix)
     {
     }
 
     public UpdateExpression(UnaryOperator op, Expression arg, bool prefix) : base(Nodes.UpdateExpression, op, arg, prefix)
     {
+        if (!IsUpdateOperator(op))
+        {
+            throw new ArgumentOutOfRangeException(nameof(op), op, "Value must be an update operator.");
+        }
+    }
+
+    internal static bool IsUpdateOperator(UnaryOperator op)
+    {
+        return op is
+            UnaryOperator.Increment or
+            UnaryOperator.Decrement;
     }
 
     protected override UnaryExpression Rewrite(Expression argument)

--- a/src/Esprima/Ast/VariableDeclaration.cs
+++ b/src/Esprima/Ast/VariableDeclaration.cs
@@ -12,7 +12,7 @@ public sealed partial class VariableDeclaration : Declaration
             VariableDeclarationKind.Var => "var",
             VariableDeclarationKind.Let => "let",
             VariableDeclarationKind.Const => "const",
-            _ => throw new ArgumentOutOfRangeException(nameof(kind), "Invalid variable declaration kind: " + kind)
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, "Invalid variable declaration kind.")
         };
     }
 

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -765,7 +765,7 @@ public partial class JavaScriptParser
                         _scanner._index = _startMarker.Index;
                         token = NextRegexToken();
                         raw = GetTokenRaw(token);
-                        expr = Finalize(node, new RegExpLiteral(token.RegexValue!.Pattern, token.RegexValue.Flags, token.Value, raw));
+                        expr = Finalize(node, new RegExpLiteral(token.RegexValue!, token.Value, raw));
                         break;
                     case "#":
                         expr = ParsePrivateIdentifier(node);

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -765,7 +765,7 @@ public partial class JavaScriptParser
                         _scanner._index = _startMarker.Index;
                         token = NextRegexToken();
                         raw = GetTokenRaw(token);
-                        expr = Finalize(node, new Literal(token.RegexValue!.Pattern, token.RegexValue.Flags, token.Value, raw));
+                        expr = Finalize(node, new RegExpLiteral(token.RegexValue!.Pattern, token.RegexValue.Flags, token.Value, raw));
                         break;
                     case "#":
                         expr = ParsePrivateIdentifier(node);

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -1699,7 +1699,7 @@ public partial class JavaScriptParser
         return match;
     }
 
-    private Import ParseImportCall()
+    private ImportExpression ParseImportCall()
     {
         var node = CreateNode();
         ExpectKeyword("import");
@@ -1723,7 +1723,7 @@ public partial class JavaScriptParser
             this.Expect(")");
         }
 
-        return Finalize(node, new Import(source));
+        return Finalize(node, new ImportExpression(source));
     }
 
     private bool MatchImportMeta()

--- a/src/Esprima/Utils/AstToJavascriptConverter.cs
+++ b/src/Esprima/Utils/AstToJavascriptConverter.cs
@@ -971,29 +971,6 @@ public partial class AstToJavaScriptConverter : AstVisitor
         return ifStatement;
     }
 
-    protected internal override object? VisitImport(Import import)
-    {
-        Writer.WriteKeyword("import", ref _writeContext);
-
-        Writer.WritePunctuator("(", TokenFlags.Leading, ref _writeContext);
-
-        // Import arguments need special care because of the unusual model (separate expressions instead of an expression list).
-
-        const int paramCount = 1;
-        Writer.StartExpressionList(paramCount, ref _writeContext);
-
-        _writeContext.SetNodeProperty(nameof(Import.Source), static node => node.As<Import>().Source);
-        VisitExpressionListItem(import.Source, 0, paramCount, static (@this, expression, _, _) =>
-            s_getCombinedSubExpressionFlags(@this, expression, SubExpressionFlags(@this.ExpressionNeedsBracketsInList(expression), isLeftMost: false)));
-
-        Writer.EndExpressionList(paramCount, ref _writeContext);
-
-        _writeContext.ClearNodeProperty();
-        Writer.WritePunctuator(")", TokenFlags.Trailing, ref _writeContext);
-
-        return import;
-    }
-
     protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         Writer.WriteKeyword("import", TokenFlags.SurroundingSpaceRecommended, ref _writeContext);
@@ -1063,6 +1040,29 @@ WriteSource:
         VisitAuxiliaryNode(importDefaultSpecifier.Local);
 
         return importDefaultSpecifier;
+    }
+
+    protected internal override object? VisitImportExpression(ImportExpression importExpression)
+    {
+        Writer.WriteKeyword("import", ref _writeContext);
+
+        Writer.WritePunctuator("(", TokenFlags.Leading, ref _writeContext);
+
+        // ImportExpression arguments need special care because of the unusual model (separate expressions instead of an expression list).
+
+        const int paramCount = 1;
+        Writer.StartExpressionList(paramCount, ref _writeContext);
+
+        _writeContext.SetNodeProperty(nameof(ImportExpression.Source), static node => node.As<ImportExpression>().Source);
+        VisitExpressionListItem(importExpression.Source, 0, paramCount, static (@this, expression, _, _) =>
+            s_getCombinedSubExpressionFlags(@this, expression, SubExpressionFlags(@this.ExpressionNeedsBracketsInList(expression), isLeftMost: false)));
+
+        Writer.EndExpressionList(paramCount, ref _writeContext);
+
+        _writeContext.ClearNodeProperty();
+        Writer.WritePunctuator(")", TokenFlags.Trailing, ref _writeContext);
+
+        return importExpression;
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -816,10 +816,10 @@ public class AstToJsonConverter : AstVisitor
 
             Member("raw", literal.Raw);
 
-            if (literal.Regex is not null)
+            if (literal is RegExpLiteral regExpLiteral)
             {
                 _writer.Member("regex");
-                WriteRegexValue(literal.Regex);
+                WriteRegexValue(regExpLiteral.Regex);
             }
             else if (literal.Value is BigInteger bigInt)
             {

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -674,52 +674,20 @@ public class AstToJsonConverter : AstVisitor
         return ifStatement;
     }
 
-    private object? VisitImportCompat(ImportCompat import)
-    {
-        EmptyNodeObject(import);
-        return import;
-    }
-
     private sealed class ImportCompat : Expression
     {
-        public ImportCompat() : base(Nodes.Import) { }
+        public ImportCompat() : base(Nodes.ImportExpression) { }
 
         internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => null;
 
         protected internal override object? Accept(AstVisitor visitor) => ((AstToJsonConverter) visitor).VisitImportCompat(this);
     }
 
-    protected internal override object? VisitImport(Import import)
+    private object? VisitImportCompat(ImportCompat import)
     {
-        // original Esprima uses CallExpression to represent dynamic imports currently,
-        // so we need to rewrite our representation to match this expectation
-        if (_testCompatibilityMode == AstToJsonTestCompatibilityMode.EsprimaOrg)
-        {
-            const string importToken = "import";
-
-            var callee = new ImportCompat
-            {
-                Location = new Location(import.Location.Start, new Position(import.Location.Start.Line, import.Location.Start.Column + importToken.Length)),
-                Range = new Range(import.Range.Start, import.Range.Start + importToken.Length)
-            };
-            var args = new NodeList<Expression>(new Expression[] { import.Source });
-            var callExpression = new CallExpression(callee, args, optional: false)
-            {
-                Location = import.Location,
-                Range = import.Range,
-            };
-
-            return Visit(callExpression);
-        }
-
-        using (StartNodeObject(import))
-        {
-            if (_testCompatibilityMode != AstToJsonTestCompatibilityMode.EsprimaOrg)
-            {
-                Member("source", import.Source);
-            }
-        }
-
+        OnStartSyntaxElementObject(import);
+        Member("type", "Import");
+        using (new NodeObjectDisposable(this, import)) { }
         return import;
     }
 
@@ -742,6 +710,40 @@ public class AstToJsonConverter : AstVisitor
         }
 
         return importDefaultSpecifier;
+    }
+
+    protected internal override object? VisitImportExpression(ImportExpression importExpression)
+    {
+        // original Esprima uses CallExpression to represent dynamic imports currently,
+        // so we need to rewrite our representation to match this expectation
+        if (_testCompatibilityMode == AstToJsonTestCompatibilityMode.EsprimaOrg)
+        {
+            const string importToken = "import";
+
+            var callee = new ImportCompat
+            {
+                Location = new Location(importExpression.Location.Start, new Position(importExpression.Location.Start.Line, importExpression.Location.Start.Column + importToken.Length)),
+                Range = new Range(importExpression.Range.Start, importExpression.Range.Start + importToken.Length)
+            };
+            var args = new NodeList<Expression>(new Expression[] { importExpression.Source }, count: 1);
+            var callExpression = new CallExpression(callee, args, optional: false)
+            {
+                Location = importExpression.Location,
+                Range = importExpression.Range,
+            };
+
+            return Visit(callExpression);
+        }
+
+        using (StartNodeObject(importExpression))
+        {
+            if (_testCompatibilityMode != AstToJsonTestCompatibilityMode.EsprimaOrg)
+            {
+                Member("source", importExpression.Source);
+            }
+        }
+
+        return importExpression;
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/src/Esprima/Utils/AstVisitorEventSource.cs
+++ b/src/Esprima/Utils/AstVisitorEventSource.cs
@@ -77,12 +77,12 @@ public class AstVisitorEventSource : AstVisitor
     public event EventHandler<Identifier>? VisitedIdentifier;
     public event EventHandler<IfStatement>? VisitingIfStatement;
     public event EventHandler<IfStatement>? VisitedIfStatement;
-    public event EventHandler<Import>? VisitingImport;
-    public event EventHandler<Import>? VisitedImport;
     public event EventHandler<ImportDeclaration>? VisitingImportDeclaration;
     public event EventHandler<ImportDeclaration>? VisitedImportDeclaration;
     public event EventHandler<ImportDefaultSpecifier>? VisitingImportDefaultSpecifier;
     public event EventHandler<ImportDefaultSpecifier>? VisitedImportDefaultSpecifier;
+    public event EventHandler<ImportExpression>? VisitingImportExpression;
+    public event EventHandler<ImportExpression>? VisitedImportExpression;
     public event EventHandler<ImportNamespaceSpecifier>? VisitingImportNamespaceSpecifier;
     public event EventHandler<ImportNamespaceSpecifier>? VisitedImportNamespaceSpecifier;
     public event EventHandler<ImportSpecifier>? VisitingImportSpecifier;
@@ -434,14 +434,6 @@ public class AstVisitorEventSource : AstVisitor
         return result;
     }
 
-    protected internal override object? VisitImport(Import import)
-    {
-        VisitingImport?.Invoke(this, import);
-        var result = base.VisitImport(import);
-        VisitedImport?.Invoke(this, import);
-        return result;
-    }
-
     protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         VisitingImportDeclaration?.Invoke(this, importDeclaration);
@@ -455,6 +447,14 @@ public class AstVisitorEventSource : AstVisitor
         VisitingImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
         var result = base.VisitImportDefaultSpecifier(importDefaultSpecifier);
         VisitedImportDefaultSpecifier?.Invoke(this, importDefaultSpecifier);
+        return result;
+    }
+
+    protected internal override object? VisitImportExpression(ImportExpression importExpression)
+    {
+        VisitingImportExpression?.Invoke(this, importExpression);
+        var result = base.VisitImportExpression(importExpression);
+        VisitedImportExpression?.Invoke(this, importExpression);
         return result;
     }
 

--- a/src/Esprima/Utils/ExpressionHelper.cs
+++ b/src/Esprima/Utils/ExpressionHelper.cs
@@ -46,7 +46,7 @@ internal static class ExpressionHelper
                 goto case Nodes.MemberExpression;
             case Nodes.MemberExpression:
             case Nodes.CallExpression:
-            case Nodes.Import:
+            case Nodes.ImportExpression:
             case Nodes.NewExpression when expression.As<NewExpression>().Arguments.Count > 0:
                 return 1700;
 

--- a/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.03Esprima.Ast.VisitableNodes.g.verified.cs
+++ b/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.03Esprima.Ast.VisitableNodes.g.verified.cs
@@ -549,23 +549,6 @@ partial class IfStatement
     }
 }
 
-partial class Import
-{
-    internal override Esprima.Ast.Node? NextChildNode(ref Esprima.Ast.ChildNodes.Enumerator enumerator) => enumerator.MoveNext(Source);
-
-    protected internal override object? Accept(Esprima.Utils.AstVisitor visitor) => visitor.VisitImport(this);
-
-    public Import UpdateWith(Esprima.Ast.Expression source)
-    {
-        if (ReferenceEquals(source, Source))
-        {
-            return this;
-        }
-        
-        return Rewrite(source);
-    }
-}
-
 partial class ImportDeclaration
 {
     internal override Esprima.Ast.Node? NextChildNode(ref Esprima.Ast.ChildNodes.Enumerator enumerator) => enumerator.MoveNext(Specifiers, Source);
@@ -597,6 +580,23 @@ partial class ImportDefaultSpecifier
         }
         
         return Rewrite(local);
+    }
+}
+
+partial class ImportExpression
+{
+    internal override Esprima.Ast.Node? NextChildNode(ref Esprima.Ast.ChildNodes.Enumerator enumerator) => enumerator.MoveNext(Source);
+
+    protected internal override object? Accept(Esprima.Utils.AstVisitor visitor) => visitor.VisitImportExpression(this);
+
+    public ImportExpression UpdateWith(Esprima.Ast.Expression source)
+    {
+        if (ReferenceEquals(source, Source))
+        {
+            return this;
+        }
+        
+        return Rewrite(source);
     }
 }
 

--- a/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.03Esprima.Ast.VisitableNodes.g.verified.cs
+++ b/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.03Esprima.Ast.VisitableNodes.g.verified.cs
@@ -651,9 +651,9 @@ partial class LabeledStatement
 
 partial class Literal
 {
-    internal override Esprima.Ast.Node? NextChildNode(ref Esprima.Ast.ChildNodes.Enumerator enumerator) => null;
+    internal sealed override Esprima.Ast.Node? NextChildNode(ref Esprima.Ast.ChildNodes.Enumerator enumerator) => null;
 
-    protected internal override object? Accept(Esprima.Utils.AstVisitor visitor) => visitor.VisitLiteral(this);
+    protected internal sealed override object? Accept(Esprima.Utils.AstVisitor visitor) => visitor.VisitLiteral(this);
 }
 
 partial class MemberExpression

--- a/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.04Esprima.Utils.AstRewriter.g.verified.cs
+++ b/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.04Esprima.Utils.AstRewriter.g.verified.cs
@@ -281,13 +281,6 @@ partial class AstRewriter
         return ifStatement.UpdateWith(test, consequent, alternate);
     }
 
-    protected internal override object? VisitImport(Esprima.Ast.Import import)
-    {
-        var source = VisitAndConvert(import.Source);
-
-        return import.UpdateWith(source);
-    }
-
     protected internal override object? VisitImportDeclaration(Esprima.Ast.ImportDeclaration importDeclaration)
     {
         VisitAndConvert(importDeclaration.Specifiers, out var specifiers);
@@ -302,6 +295,13 @@ partial class AstRewriter
         var local = VisitAndConvert(importDefaultSpecifier.Local);
 
         return importDefaultSpecifier.UpdateWith(local);
+    }
+
+    protected internal override object? VisitImportExpression(Esprima.Ast.ImportExpression importExpression)
+    {
+        var source = VisitAndConvert(importExpression.Source);
+
+        return importExpression.UpdateWith(source);
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(Esprima.Ast.ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.05Esprima.Utils.AstVisitor.g.verified.cs
+++ b/test/Esprima.Tests.SourceGenerators/Snapshots/VisitationBoilerplateGeneratorTests.VisitationBoilerplateGeneration.05Esprima.Utils.AstVisitor.g.verified.cs
@@ -403,13 +403,6 @@ partial class AstVisitor
         return ifStatement;
     }
 
-    protected internal virtual object? VisitImport(Esprima.Ast.Import import)
-    {
-        Visit(import.Source);
-
-        return import;
-    }
-
     protected internal virtual object? VisitImportDeclaration(Esprima.Ast.ImportDeclaration importDeclaration)
     {
         ref readonly var specifiers = ref importDeclaration.Specifiers;
@@ -428,6 +421,13 @@ partial class AstVisitor
         Visit(importDefaultSpecifier.Local);
 
         return importDefaultSpecifier;
+    }
+
+    protected internal virtual object? VisitImportExpression(Esprima.Ast.ImportExpression importExpression)
+    {
+        Visit(importExpression.Source);
+
+        return importExpression;
     }
 
     protected internal virtual object? VisitImportNamespaceSpecifier(Esprima.Ast.ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -382,7 +382,7 @@ sealed class TestRewriter : JsxAstRewriter
         return ForceNewObjectByControlType((Literal) base.VisitLiteral(literal)!,
             node => node switch
             {
-                RegExpLiteral regExpLiteral => new RegExpLiteral(regExpLiteral.Regex.Pattern, regExpLiteral.Regex.Flags, node.Value, node.Raw),
+                RegExpLiteral regExpLiteral => new RegExpLiteral(regExpLiteral.Regex, node.Value, node.Raw),
                 _ => new Literal(node.TokenType, node.Value, node.Raw),
             });
     }

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -380,9 +380,9 @@ sealed class TestRewriter : JsxAstRewriter
     protected internal override object? VisitLiteral(Literal literal)
     {
         return ForceNewObjectByControlType((Literal) base.VisitLiteral(literal)!,
-            node => node.TokenType switch
+            node => node switch
             {
-                TokenType.RegularExpression => new Literal(node.Regex!.Pattern, node.Regex.Flags, node.Value, node.Raw),
+                RegExpLiteral regExpLiteral => new RegExpLiteral(regExpLiteral.Regex.Pattern, regExpLiteral.Regex.Flags, node.Value, node.Raw),
                 _ => new Literal(node.TokenType, node.Value, node.Raw),
             });
     }

--- a/test/Esprima.Tests/AstRewriterTests.cs
+++ b/test/Esprima.Tests/AstRewriterTests.cs
@@ -159,7 +159,7 @@ public class AstRewriterTests
     [InlineData(typeof(ExportDefaultDeclaration), "export default (1 + 2);")]
     [InlineData(typeof(ExportAllDeclaration), "export * from 'foo';")]
     [InlineData(typeof(ExportNamedDeclaration), "export {foo as bar} from 'foo';")]
-    [InlineData(typeof(Import), "import(`lib/${fname}.js`).then(doSomething);")]
+    [InlineData(typeof(ImportExpression), "import(`lib/${fname}.js`).then(doSomething);")]
     [InlineData(typeof(ImportDeclaration), "import {a,b,c} from 'module'")]
     [InlineData(typeof(ImportNamespaceSpecifier), "import * as foo from \"foo\";")]
     [InlineData(typeof(ImportDefaultSpecifier), "import M from 'module'")]
@@ -453,16 +453,16 @@ sealed class TestRewriter : JsxAstRewriter
             node => new ExportSpecifier(node.Local, node.Exported));
     }
 
-    protected internal override object? VisitImport(Import import)
-    {
-        return ForceNewObjectByControlType((Import) base.VisitImport(import)!,
-            node => new Import(node.Source));
-    }
-
     protected internal override object? VisitImportDeclaration(ImportDeclaration importDeclaration)
     {
         return ForceNewObjectByControlType((ImportDeclaration) base.VisitImportDeclaration(importDeclaration)!,
             node => new ImportDeclaration(node.Specifiers, node.Source));
+    }
+
+    protected internal override object? VisitImportExpression(ImportExpression importExpression)
+    {
+        return ForceNewObjectByControlType((ImportExpression) base.VisitImportExpression(importExpression)!,
+            node => new ImportExpression(node.Source));
     }
 
     protected internal override object? VisitImportNamespaceSpecifier(ImportNamespaceSpecifier importNamespaceSpecifier)

--- a/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.tree.json
+++ b/test/Esprima.Tests/Fixtures/es2018/dynamic-import/import-call-in-statement.tree.json
@@ -25,7 +25,7 @@
             }
           },
           "init": {
-            "type": "Import",
+            "type": "ImportExpression",
             "source": {
               "type": "Literal",
               "value": "url",

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -639,7 +639,7 @@ class X {
             var node = parseAction(parser);
             var awaitExpression = node.DescendantNodesAndSelf().OfType<AwaitExpression>().FirstOrDefault();
             Assert.NotNull(awaitExpression);
-            Assert.IsType<Import>(awaitExpression.Argument);
+            Assert.IsType<ImportExpression>(awaitExpression.Argument);
         }
         else
         {


### PR DESCRIPTION
This PR aims to improve compliance with the ESTree specification.

Besides what have been discussed [here](https://github.com/sebastienros/esprima-dotnet/issues/382), I made an attempt to address a few further issues:
* In our AST model we don't have separate [`BinaryOperator`/`LogicalOperator`](https://github.com/estree/estree/blob/master/es5.md#binary-operations) and [`UnaryOperator`/`UpdateOperator`](https://github.com/estree/estree/blob/master/es5.md#unary-operations) enums as specified by the standard but have the separation w.r.t. the corresponding node types (`BinaryExpression`/`LogicalExpression` and `UnaryExpression`/`UpdateExpression`). However, there were no checks in place to prevent instantiation of these types with a wrong operator type (e.g. a `LogicalExpression` with a multiplication operator.) Thus, checks have been added to prevent invalid combinations.
* The standard defines special cases (subclasses) for [regex](https://github.com/estree/estree/blob/master/es5.md#regexpliteral) and [bigint](https://github.com/estree/estree/blob/master/es2020.md#bigintliteral) literals. In the case of bigints, I don't think we'd gain anything from a subclass since we don't really have additional data to store (the `bigint` property defined by the standard can be replaced with a simple `literal.BigIntValue.ToString()` call in our current model). However, adding a subclass for the regex case seems beneficial as it's a cleaner design and reduces the memory footprint of the AST a bit. (As a matter of fact, we may also consider changing `RegexValue` and `TemplateElementValue` to readonly struct records to save a few further allocations.) I'm not sure about this change though, its impact on existing codebases might be more than acceptable. Please let me know how do you feel about this.