### PR TITLE
Quick fix for IsIdentifierStart/IsIdentifierPart (UTF32)

### DIFF
--- a/src/Esprima/Character.cs
+++ b/src/Esprima/Character.cs
@@ -43,7 +43,10 @@ public static partial class Character
 
     internal static bool IsIdentifierStart(string s, int index)
     {
-        return IsIdentifierStartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
+        var ch = s[index];
+        return !char.IsHighSurrogate(ch)
+            ? IsIdentifierStart(ch)
+            : IsIdentifierStartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
     }
 
     internal static bool IsIdentifierPart(char ch)
@@ -53,7 +56,10 @@ public static partial class Character
 
     internal static bool IsIdentifierPart(string s, int index)
     {
-        return IsIdentifierPartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
+        var ch = s[index];
+        return !char.IsHighSurrogate(ch)
+            ? IsIdentifierPart(ch)
+            : IsIdentifierPartUnicodeCategory(CharUnicodeInfo.GetUnicodeCategory(s, index));
     }
 
     // https://tc39.github.io/ecma262/#sec-literals-numeric-literals


### PR DESCRIPTION
The `Character.IsIdentifierStart`/`Character.IsIdentifierPart` overloads accepting code points produce inconsistent results (for example, won't accept `$` as a valid start of an identifier) compared to the overloads accepting characters. This patch improves the situation at least in the \u0000..\uFFFF range.

However, above \uFFFF we'll still get an approximation only, not what the specification says (any Unicode code point with the Unicode property “ID_Start” / "ID_Continue"). I have some ideas how we can implement this but that will be another story in another PR.