### PR TITLE
Fix bug in ArrayList.RemoveAt

### DIFF
--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -265,18 +265,19 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     {
         AssertUnchanged();
 
-        if (index < 0 || index >= _count)
+        if ((uint) index >= (uint) _count)
         {
             throw new ArgumentOutOfRangeException(nameof(index), index, null);
         }
 
-        _items![index] = default!;
         _count--;
 
-        if (index < _count - 1)
+        if (index < _count)
         {
             Array.Copy(_items, index + 1, _items, index, Count - index);
         }
+
+        _items![_count] = default!;
 
         OnChanged();
     }

--- a/test/Esprima.Tests/ArrayListTests.cs
+++ b/test/Esprima.Tests/ArrayListTests.cs
@@ -1,0 +1,24 @@
+﻿namespace Esprima.Tests;
+
+public class ArrayListTests
+{
+    [Theory]
+    [InlineData(new int[] { 1, 2, 3 }, -1, null)]
+    [InlineData(new int[] { 1, 2, 3 }, 0, new int[] { 2, 3 })]
+    [InlineData(new int[] { 1, 2, 3 }, 1, new int[] { 1, 3 })]
+    [InlineData(new int[] { 1, 2, 3 }, 2, new int[] { 1, 2 })]
+    [InlineData(new int[] { 1, 2, 3 }, 3, null)]
+    public void RemoveAt(int[] items, int index, int[]? expectedItems)
+    {
+        var list = new ArrayList<int>(items);
+        if (expectedItems is not null)
+        {
+            list.RemoveAt(index);
+            Assert.Equal(expectedItems.AsEnumerable(), list.AsEnumerable());
+        }
+        else
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => list.RemoveAt(index));
+        }
+    }
+}


### PR DESCRIPTION
When removing the item preceding the last one using `ArrayList.RemoveAt`, the resulting list is incorrect. This PR fixes this.