### PR TITLE
Fix number parsing issues

### DIFF
--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -370,13 +370,18 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     /// </remarks>
     public Span<T> AsSpan() => new Span<T>(_items, 0, _count);
 
+    /// <remarks>
+    /// Items should not be added or removed from the <see cref="ArrayList{T}"/> while the returned <see cref="ReadOnlySpan{T}"/> is in use!
+    /// </remarks>
+    public ReadOnlySpan<T> AsReadOnlySpan() => new ReadOnlySpan<T>(_items, 0, _count);
+
 #if NETSTANDARD2_1_OR_GREATER
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
     public T[] ToArray()
     {
 #if NETSTANDARD2_1_OR_GREATER
-        return AsSpan().ToArray();
+        return AsReadOnlySpan().ToArray();
 #else
         if (_count == 0)
         {

--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -368,11 +368,13 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     /// <remarks>
     /// Items should not be added or removed from the <see cref="ArrayList{T}"/> while the returned <see cref="Span{T}"/> is in use!
     /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Span<T> AsSpan() => new Span<T>(_items, 0, _count);
 
     /// <remarks>
     /// Items should not be added or removed from the <see cref="ArrayList{T}"/> while the returned <see cref="ReadOnlySpan{T}"/> is in use!
     /// </remarks>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<T> AsReadOnlySpan() => new ReadOnlySpan<T>(_items, 0, _count);
 
 #if NETSTANDARD2_1_OR_GREATER

--- a/src/Esprima/Ast/NodeList.cs
+++ b/src/Esprima/Ast/NodeList.cs
@@ -77,8 +77,10 @@ public readonly struct NodeList<T> : IReadOnlyList<T> where T : Node?
         return new NodeList<TTo>((TTo[]?) (object?) _items, _count);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlySpan<T> AsSpan() => new ReadOnlySpan<T>(_items, 0, _count);
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public ReadOnlyMemory<T> AsMemory() => new ReadOnlyMemory<T>(_items, 0, _count);
 
 #if NETSTANDARD2_1_OR_GREATER

--- a/src/Esprima/HexConverter.cs
+++ b/src/Esprima/HexConverter.cs
@@ -5,6 +5,8 @@
 
 using System.Runtime.CompilerServices;
 
+namespace System;
+
 internal static class HexConverter
 {
     [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -274,7 +274,7 @@ public partial class JavaScriptParser
         }
         else
         {
-            var comments = _scanner.ScanCommentsInternal().AsSpan();
+            var comments = _scanner.ScanCommentsInternal().AsReadOnlySpan();
 
             for (var i = 0; i < comments.Length; ++i)
             {

--- a/src/Esprima/JavascriptParser.cs
+++ b/src/Esprima/JavascriptParser.cs
@@ -274,12 +274,8 @@ public partial class JavaScriptParser
         }
         else
         {
-            var comments = _scanner.ScanCommentsInternal().AsReadOnlySpan();
-
-            for (var i = 0; i < comments.Length; ++i)
+            foreach (var e in _scanner.ScanCommentsInternal().AsReadOnlySpan())
             {
-                var e = comments[i];
-
                 var value = _scanner._source.AsSpan(e.Slice.Start, e.Slice.Length)
                     .ToInternedString(ref _scanner._stringPool, Scanner.NonIdentifierInterningThreshold);
 

--- a/src/Esprima/Scanner.RegExpParser.Unicode.cs
+++ b/src/Esprima/Scanner.RegExpParser.Unicode.cs
@@ -157,7 +157,7 @@ partial class Scanner
 
                     CodePointRange.NormalizeRanges(ref context.UnicodeSet);
 
-                    AppendSet(sb, context.UnicodeSet.AsSpan(), isInverted: pattern.CharCodeAt(context.SetStartIndex + 1) == '^');
+                    AppendSet(sb, context.UnicodeSet.AsReadOnlySpan(), isInverted: pattern.CharCodeAt(context.SetStartIndex + 1) == '^');
 
                     context.UnicodeSet = default;
                 }
@@ -242,7 +242,7 @@ partial class Scanner
 
                 if (isInverted)
                 {
-                    astralRanges = CodePointRange.InvertRanges(astralRanges.AsSpan(), start: char.MaxValue + 1);
+                    astralRanges = CodePointRange.InvertRanges(astralRanges.AsReadOnlySpan(), start: char.MaxValue + 1);
                 }
 
                 // 3. Lone surrogates need special care: we need to handle ranges which contains surrogates separately
@@ -308,8 +308,8 @@ partial class Scanner
                 if (isInverted)
                 {
                     bmpRanges.Add(new CodePointRange(0xD800, 0xDFFF));
-                    loneHighSurrogateRanges = CodePointRange.InvertRanges(loneHighSurrogateRanges.AsSpan(), start: 0xD800, end: 0xDBFF);
-                    loneLowSurrogateRanges = CodePointRange.InvertRanges(loneLowSurrogateRanges.AsSpan(), start: 0xDC00, end: 0xDFFF);
+                    loneHighSurrogateRanges = CodePointRange.InvertRanges(loneHighSurrogateRanges.AsReadOnlySpan(), start: 0xD800, end: 0xDBFF);
+                    loneLowSurrogateRanges = CodePointRange.InvertRanges(loneLowSurrogateRanges.AsReadOnlySpan(), start: 0xDC00, end: 0xDFFF);
                 }
 
                 // 4. Append ranges
@@ -911,7 +911,7 @@ partial class Scanner
                                 }
 
                                 categoryRangeSpan = ch == 'P'
-                                    ? CodePointRange.InvertRanges(categoryRanges).AsSpan()
+                                    ? CodePointRange.InvertRanges(categoryRanges).AsReadOnlySpan()
                                     : categoryRanges;
                             }
                             else

--- a/src/Esprima/Scanner.RegExpParser.cs
+++ b/src/Esprima/Scanner.RegExpParser.cs
@@ -405,7 +405,7 @@ partial class Scanner
                 sb = null;
             }
 
-            var context = new ParsePatternContext(sb, capturingGroups.AsSpan(), capturingGroupNames)
+            var context = new ParsePatternContext(sb, capturingGroups.AsReadOnlySpan(), capturingGroupNames)
             {
                 CapturingGroupCounter = 0,
                 GroupStack = capturingGroupNames is not null
@@ -466,7 +466,7 @@ partial class Scanner
 
                     case '(' when !context.WithinSet:
                         var currentGroupAlternate = capturingGroupNames is not null
-                            ? context.GroupStack.AsSpan().Last().LastAlternate
+                            ? context.GroupStack.AsReadOnlySpan().Last().LastAlternate
                             : null;
 
                         var groupType = DetermineGroupType(i);
@@ -1226,11 +1226,11 @@ partial class Scanner
 
         public readonly RegExpGroupAlternate? Parent;
 
-        public bool IsDefinedGroupName(string value) => _groupNames.AsSpan().BinarySearch(value) >= 0;
+        public bool IsDefinedGroupName(string value) => _groupNames.AsReadOnlySpan().BinarySearch(value) >= 0;
 
         public bool TryAddGroupName(string value)
         {
-            var index = _groupNames.AsSpan().BinarySearch(value);
+            var index = _groupNames.AsReadOnlySpan().BinarySearch(value);
 
             var isDefined = index >= 0;
             var scope = this;
@@ -1265,7 +1265,7 @@ partial class Scanner
                 {
                     foreach (var groupName in _groupNames)
                     {
-                        var index = other._groupNames.AsSpan().BinarySearch(groupName);
+                        var index = other._groupNames.AsReadOnlySpan().BinarySearch(groupName);
                         if (index < 0)
                         {
                             other._groupNames.Insert(~index, groupName);

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -418,7 +418,7 @@ public sealed partial class Scanner
                     var comment = SkipSingleLineComment(2);
                     if (_trackComment)
                     {
-                        comments.AddRange(comment.AsSpan());
+                        comments.AddRange(comment.AsReadOnlySpan());
                     }
 
                     start = true;
@@ -430,7 +430,7 @@ public sealed partial class Scanner
                     var comment = SkipMultiLineComment();
                     if (_trackComment)
                     {
-                        comments.AddRange(comment.AsSpan());
+                        comments.AddRange(comment.AsReadOnlySpan());
                     }
                 }
                 else
@@ -449,7 +449,7 @@ public sealed partial class Scanner
                     var comment = SkipSingleLineComment(3);
                     if (_trackComment)
                     {
-                        comments.AddRange(comment.AsSpan());
+                        comments.AddRange(comment.AsReadOnlySpan());
                     }
                 }
                 else
@@ -473,7 +473,7 @@ public sealed partial class Scanner
                     var comment = SkipSingleLineComment(4);
                     if (_trackComment)
                     {
-                        comments.AddRange(comment.AsSpan());
+                        comments.AddRange(comment.AsReadOnlySpan());
                     }
                 }
                 else
@@ -518,7 +518,7 @@ public sealed partial class Scanner
     {
         var comments = ScanCommentsInternal();
         comments.TrimExcess();
-        return comments.AsSpan();
+        return comments.AsReadOnlySpan();
     }
 
     private bool ScanHexEscape(char prefix, out char result)

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -1038,7 +1038,7 @@ ParseIdentifierPart:
 
     private Token ScanHexLiteral(int start)
     {
-        var number = this.ScanLiteralPart(Character.IsHexDigitFunc, allowNumericSeparator: true, out var hasUpperCase);
+        var number = this.ScanLiteralPart(Character.IsHexDigitFunc, allowNumericSeparator: true);
 
         if (number.Length == 0)
         {
@@ -1056,39 +1056,57 @@ ParseIdentifierPart:
             ThrowUnexpectedToken();
         }
 
-        double value = 0;
+        double value;
 
-        if (number.Length < 16)
+        if (number.Length <= 16)
         {
-            value = long.Parse(number.ToParsable(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
-        }
-        else if (number.Length > 255)
-        {
-            value = double.PositiveInfinity;
+            value = ulong.Parse(number.ToParsable(), NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
         }
         else
         {
-            double modulo = 1;
-            var literal = hasUpperCase ? number.ToString().ToLowerInvariant().AsSpan() : number;
-            var length = literal.Length - 1;
-            for (var i = length; i >= 0; i--)
-            {
-                var c = literal[i];
-
-                if (c <= '9')
-                {
-                    value += modulo * (c - '0');
-                }
-                else
-                {
-                    value += modulo * (c - 'a' + 10);
-                }
-
-                modulo *= 16;
-            }
+            value = ParseIntAsDouble(number, fromBase: 16);
         }
 
         return Token.CreateNumericLiteral(value, octal: false, start, end: _index, _lineNumber, _lineStart);
+    }
+
+    private static double ParseIntAsDouble(ReadOnlySpan<char> number, byte fromBase)
+    {
+        double value = 0;
+        double modulo = 1;
+        int i;
+        for (i = number.Length; i > 0;)
+        {
+            var code = number[--i];
+            ushort digitValue;
+
+            if (code >= 'a')
+            {
+                digitValue = (ushort) (code - ('a' - 10));
+            }
+            else if (code >= 'A')
+            {
+                digitValue = (ushort) (code - ('A' - 10));
+            }
+            else if (code is >= '0' and <= '9') // TODO: <= 9 needed?
+            {
+                digitValue = (ushort) (code - '0');
+            }
+            else
+            {
+                Debug.Assert(false, $"Invalid digit in number: U+{(ushort) code:X4}");
+                break;
+            }
+
+            Debug.Assert(digitValue < fromBase, $"Invalid digit in number: U+{(ushort) code:X4}");
+
+            value += modulo * digitValue;
+            modulo *= fromBase;
+        }
+
+        Debug.Assert(i == 0, $"Invalid number: {number.ToString()}");
+
+        return value;
     }
 
     private enum JavaScriptNumberStyle
@@ -1102,13 +1120,13 @@ ParseIdentifierPart:
     private Token ScanBigIntLiteral(int start, ReadOnlySpan<char> number, JavaScriptNumberStyle style)
     {
         BigInteger bigInt = 0;
-        if (style == JavaScriptNumberStyle.Binary)
+        if (style is JavaScriptNumberStyle.Binary or JavaScriptNumberStyle.Octal)
         {
-            // binary
+            var shift = style is JavaScriptNumberStyle.Binary ? 1 : 3;
             foreach (var c in number)
             {
-                bigInt <<= 1;
-                bigInt += c == '1' ? BigInteger.One : BigInteger.Zero;
+                bigInt <<= shift;
+                bigInt += c - '0';
             }
         }
         else
@@ -1139,7 +1157,7 @@ ParseIdentifierPart:
 
     private Token ScanBinaryLiteral(int start)
     {
-        var number = this.ScanLiteralPart(static c => c is '0' or '1', allowNumericSeparator: true, out _);
+        var number = this.ScanLiteralPart(static c => c is '0' or '1', allowNumericSeparator: true);
 
         if (number.Length == 0)
         {
@@ -1162,8 +1180,17 @@ ParseIdentifierPart:
             }
         }
 
-        var numberString = number.ToString();
-        var value = Convert.ToUInt32(numberString, 2);
+        double value;
+
+        if (number.Length <= 64)
+        {
+            value = Convert.ToUInt64(number.ToString(), fromBase: 2);
+        }
+        else
+        {
+            value = ParseIntAsDouble(number, fromBase: 2);
+        }
+
         return Token.CreateNumericLiteral(value, octal: false, start, end: _index, _lineNumber, _lineStart);
     }
 
@@ -1182,7 +1209,7 @@ ParseIdentifierPart:
             ++_index;
         }
 
-        sb.Append(this.ScanLiteralPart(Character.IsOctalDigitFunc, allowNumericSeparator: true, out _));
+        sb.Append(this.ScanLiteralPart(Character.IsOctalDigitFunc, allowNumericSeparator: !isLegacyOctalDigital));
         var number = sb.ToString();
 
         if (!octal && number.Length == 0)
@@ -1209,17 +1236,18 @@ ParseIdentifierPart:
             ThrowUnexpectedToken();
         }
 
-        ulong numericValue;
-        try
+        double value;
+
+        if (number.Length <= 21) // = Floor(Log8(Pow(2, 64))
         {
-            numericValue = Convert.ToUInt64(number, 8);
+            value = Convert.ToUInt64(number.ToString(), fromBase: 8);
         }
-        catch (OverflowException)
+        else
         {
-            return ThrowUnexpectedToken<Token>($"Value {number} was either too large or too small for a UInt64.");
+            value = ParseIntAsDouble(number.AsSpan(), fromBase: 8);
         }
 
-        return Token.CreateNumericLiteral(numericValue, octal, start, end: _index, _lineNumber, _lineStart);
+        return Token.CreateNumericLiteral(value, octal, start, end: _index, _lineNumber, _lineStart);
     }
 
     private bool IsImplicitOctalLiteral()
@@ -1243,9 +1271,8 @@ ParseIdentifierPart:
         return true;
     }
 
-    private ReadOnlySpan<char> ScanLiteralPart(Func<char, bool> check, bool allowNumericSeparator, out bool hasUpperCase)
+    private ReadOnlySpan<char> ScanLiteralPart(Func<char, bool> check, bool allowNumericSeparator)
     {
-        hasUpperCase = false;
         var start = _index;
 
         var charCode = _source.CharCodeAt(_index);
@@ -1265,8 +1292,6 @@ ParseIdentifierPart:
                 }
                 needsCleanup = true;
             }
-
-            hasUpperCase |= char.IsUpper(charCode);
 
             _index++;
             var newCharCode = _source.CharCodeAt(_index);
@@ -1310,7 +1335,8 @@ ParseIdentifierPart:
         //    'Numeric literal must start with a decimal digit or a decimal point');
 
         var nonOctal = false;
-        if (ch != '.')
+        var startsWithDot = ch == '.';
+        if (!startsWithDot)
         {
             var first = _source[_index++];
             ch = _source.CharCodeAt(_index);
@@ -1362,14 +1388,14 @@ ParseIdentifierPart:
             }
 
             --_index;
-            sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: !nonOctal, out _));
+            sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: !nonOctal));
             ch = _source.CharCodeAt(_index);
         }
 
         if (ch == '.')
         {
             sb.Append(_source[_index++]);
-            sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: !nonOctal, out _));
+            sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: !nonOctal));
             ch = _source.CharCodeAt(_index);
         }
 
@@ -1385,7 +1411,7 @@ ParseIdentifierPart:
 
             if (Character.IsDecimalDigit(_source.CharCodeAt(_index)))
             {
-                sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: true, out _));
+                sb.Append(this.ScanLiteralPart(Character.IsDecimalDigitFunc, allowNumericSeparator: true));
             }
             else
             {
@@ -1394,7 +1420,7 @@ ParseIdentifierPart:
         }
         else if (ch == 'n')
         {
-            if (nonOctal)
+            if (nonOctal || startsWithDot)
             {
                 ThrowUnexpectedToken();
             }

--- a/src/Esprima/Utils/AstToJsonConverter.cs
+++ b/src/Esprima/Utils/AstToJsonConverter.cs
@@ -813,25 +813,31 @@ public class AstToJsonConverter : AstVisitor
         using (StartNodeObject(literal))
         {
             _writer.Member("value");
-            var value = literal.Value;
 
-            switch (value)
+            switch (literal.TokenType)
             {
-                case null:
+                case TokenType.NullLiteral:
+                case TokenType.RegularExpression when literal.Value is null:
                     _writer.Null();
                     break;
-                case bool b:
-                    _writer.Boolean(b);
+
+                case TokenType.BooleanLiteral:
+                    _writer.Boolean((bool) literal.Value!);
                     break;
-                case Regex _:
+
+                case TokenType.RegularExpression:
                     _writer.StartObject();
                     _writer.EndObject();
                     break;
-                case double d:
-                    _writer.Number(d);
+
+                case TokenType.NumericLiteral when (double) literal.Value! is var doubleValue
+                    && !double.IsPositiveInfinity(doubleValue):
+
+                    _writer.Number(doubleValue);
                     break;
+
                 default:
-                    _writer.String(System.Convert.ToString(value, CultureInfo.InvariantCulture));
+                    _writer.String(System.Convert.ToString(literal.Value, CultureInfo.InvariantCulture));
                     break;
             }
 

--- a/test/Esprima.Tests/ParserTests.cs
+++ b/test/Esprima.Tests/ParserTests.cs
@@ -181,12 +181,6 @@ f(values);
         Assert.Throws<ParserException>(() => parser.ParseScript("if (1}=1) eval('1');"));
     }
 
-    [Fact]
-    public void CanReportProblemWithLargeNumber()
-    {
-        Assert.Throws<ParserException>(() => new JavaScriptParser().ParseExpression("066666666666666666666666666666"));
-    }
-
     [Theory]
     [InlineData(".")]
     [InlineData("..")]

--- a/test/Esprima.Tests/ScannerTests.cs
+++ b/test/Esprima.Tests/ScannerTests.cs
@@ -1,4 +1,7 @@
-﻿namespace Esprima.Tests;
+﻿using System.Globalization;
+using System.Numerics;
+
+namespace Esprima.Tests;
 
 public class ScannerTests
 {
@@ -161,5 +164,194 @@ public class ScannerTests
         var token = scanner.Lex();
         Assert.Equal(TokenType.StringLiteral, token.Type);
         Assert.Equal("a\ud800\udc00", token.Value);
+    }
+
+    private const string ValueOf_255_F_HexDigits = "11,235,582,092,889,474,423,308,157,442,431,404,585,112,356,118,389,416,079,589,380,072,358,292,237,843,810,195,794,279,832,650,471,001,320,007,117,491,962,084,853,674,360,550,901,038,905,802,964,414,967,132,773,610,493,339,054,092,829,768,888,725,077,880,882,465,817,684,505,312,860,552,384,417,646,403,930,092,119,569,408,801,702,322,709,406,917,786,643,639,996,702,871,154,982,269,052,209,770,601,514,008,575";
+    private const string ValueOf_256_F_HexDigits = "179,769,313,486,231,590,772,930,519,078,902,473,361,797,697,894,230,657,273,430,081,157,732,675,805,500,963,132,708,477,322,407,536,021,120,113,879,871,393,357,658,789,768,814,416,622,492,847,430,639,474,124,377,767,893,424,865,485,276,302,219,601,246,094,119,453,082,952,085,005,768,838,150,682,342,462,881,473,913,110,540,827,237,163,350,510,684,586,298,239,947,245,938,479,716,304,835,356,329,624,224,137,215";
+
+    [Theory]
+    [InlineData("0xfedc_ba98_7654_3210", "18,364,758,544,493,064,720")]
+    [InlineData("0xfedc_ba98_7654_3210n", "18,364,758,544,493,064,720")]
+    [InlineData("0xFEDC_BA98_7654_3210", "18,364,758,544,493,064,720")]
+    [InlineData("0xFEDC_BA98_7654_3210n", "18,364,758,544,493,064,720")]
+    [InlineData("0XFEDC_BA98_7654_3210", "18,364,758,544,493,064,720")]
+    [InlineData("0XFEDC_BA98_7654_3210n", "18,364,758,544,493,064,720")]
+    [InlineData("0o7_7777_7777_7777_7777_7777", "9,223,372,036,854,775,807")]
+    [InlineData("0o7_7777_7777_7777_7777_7777n", "9,223,372,036,854,775,807")]
+    [InlineData("0O7_7777_7777_7777_7777_7777", "9,223,372,036,854,775,807")]
+    [InlineData("0O7_7777_7777_7777_7777_7777n", "9,223,372,036,854,775,807")]
+    [InlineData("0b11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000", "18,364,758,544,493,064,720")]
+    [InlineData("0b11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000n", "18,364,758,544,493,064,720")]
+    [InlineData("0B11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000", "18,364,758,544,493,064,720")]
+    [InlineData("0B11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000n", "18,364,758,544,493,064,720")]
+
+    [InlineData("0x1_FEDC_BA98_7654_3210", "36,811,502,618,202,616,336")]
+    [InlineData("0x1_FEDC_BA98_7654_3210n", "36,811,502,618,202,616,336")]
+    [InlineData("0o37_7334_5651_4166_2503_1020", "36,811,502,618,202,616,336")]
+    [InlineData("0o37_7334_5651_4166_2503_1020n", "36,811,502,618,202,616,336")]
+    [InlineData("0b1_11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000", "36,811,502,618,202,616,336")]
+    [InlineData("0b1_11111110_11011100_10111010_10011000_01110110_01010100_00110010_00010000n", "36,811,502,618,202,616,336")]
+
+    [InlineData("0xFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF", ValueOf_255_F_HexDigits)]
+    [InlineData("0xFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFn", ValueOf_255_F_HexDigits)]
+    [InlineData("0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF", "Infinity")]
+    [InlineData("0xFFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFF_FFFFn", ValueOf_256_F_HexDigits)]
+    [InlineData("0x0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000", "0")] // 256 '0' digits
+    public void ShouldCorrectlyParsePrefixedNumber(string input, string expectedValue)
+    {
+        var scanner = new Scanner(input);
+
+        var token = scanner.Lex();
+
+        var expectedTokenType = input.AsSpan().Last() == 'n' ? TokenType.BigIntLiteral : TokenType.NumericLiteral;
+        Assert.Equal(expectedTokenType, token.Type);
+
+        expectedValue = expectedValue.Replace("_", "");
+
+        object expectedValueObj = expectedTokenType == TokenType.NumericLiteral
+            ? double.Parse(expectedValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture)
+            : BigInteger.Parse(expectedValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+
+        Assert.Equal(expectedValueObj, token.Value);
+    }
+
+    [Theory]
+    [InlineData("0", false, "0")]
+    [InlineData("0", true, "0")]
+    [InlineData("0n", false, "0")]
+    [InlineData("0n", true, "0")]
+    [InlineData("07", false, "7")]
+    [InlineData("07", true, null)]
+    [InlineData("07n", false, null)]
+    [InlineData("08", false, "8")]
+    [InlineData("08", true, null)]
+    [InlineData("08n", false, null)]
+    [InlineData("017", false, "15")]
+    [InlineData("017", true, null)]
+    [InlineData("017n", false, null)]
+    [InlineData("017.", false, "15")]
+    [InlineData("017.", true, null)]
+    [InlineData("017.1", false, "15")]
+    [InlineData("017.1", true, null)]
+    [InlineData("017e", false, null)]
+    [InlineData("017e", true, null)]
+    [InlineData("018", false, "18")]
+    [InlineData("018", true, null)]
+    [InlineData("018n", false, null)]
+    [InlineData("018.", false, "18")]
+    [InlineData("018.", true, null)]
+    [InlineData("018.1", false, "18.1")]
+    [InlineData("018.1", true, null)]
+    [InlineData("018e", false, null)]
+    [InlineData("018e", true, null)]
+    [InlineData("018.e", false, null)]
+    [InlineData("018.e", true, null)]
+    [InlineData("018e2", false, "1800")]
+    [InlineData("018e2", true, null)]
+    [InlineData("018e+", false, null)]
+    [InlineData("018e+", true, null)]
+    [InlineData("018e+2", false, "1800")]
+    [InlineData("018e+2", true, null)]
+    [InlineData("018e-", false, null)]
+    [InlineData("018e-", true, null)]
+    [InlineData("018e-1", false, "1.8")]
+    [InlineData("018e-1", true, null)]
+    [InlineData("018.1e2", false, "1810")]
+    [InlineData("018.1e2", true, null)]
+    [InlineData("018.1e+2", false, "1810")]
+    [InlineData("018.1e+2", true, null)]
+    [InlineData("018.1e-1", false, "1.81")]
+    [InlineData("018.1e-1", true, null)]
+    [InlineData("7", true, "7")]
+    [InlineData("7n", true, "7")]
+    [InlineData("17", true, "17")]
+    [InlineData("17n", true, "17")]
+    [InlineData("17.", true, "17")]
+    [InlineData("17.1", true, "17.1")]
+    [InlineData("17e", false, null)]
+    [InlineData("17.e", false, null)]
+    [InlineData("17e2", true, "1700")]
+    [InlineData("17e+", false, null)]
+    [InlineData("17e+2", true, "1700")]
+    [InlineData("17e-", false, null)]
+    [InlineData("17e-1", true, "1.7")]
+    [InlineData("17.1e2", true, "1710")]
+    [InlineData("17.1e+2", true, "1710")]
+    [InlineData("17.1e-1", true, "1.71")]
+    [InlineData(".7", true, "0.7")]
+    [InlineData(".7n", false, null)]
+    [InlineData(".17", true, "0.17")]
+    [InlineData(".17n", false, null)]
+    [InlineData(".17.", true, "0.17")]
+    [InlineData(".17.1", true, "0.17")]
+    [InlineData(".17e", false, null)]
+    [InlineData(".17.e", true, "0.17")]
+    [InlineData(".17e2", true, "17")]
+    [InlineData(".17e+", false, null)]
+    [InlineData(".17e+2", true, "17")]
+    [InlineData(".17e-", false, null)]
+    [InlineData(".17e-1", true, "0.017")]
+    [InlineData(".17.1e2", true, "0.17")]
+    [InlineData(".17.1e+2", true, "0.17")]
+    [InlineData(".17.1e-1", true, "0.17")]
+    [InlineData("0777_7777", false, null)]
+    [InlineData("0777_7777", true, null)]
+
+    [InlineData("18_364_758_544_493_064_720", true, "1.8364758544493064e+19")]
+    [InlineData("18_364_758_544_493_064_720n", true, "18_364_758_544_493_064_720")]
+    [InlineData("36_811_502_618_202_616_336", true, "3.6811502618202616E+19")]
+    [InlineData("36_811_502_618_202_616_336n", true, "36,811,502,618,202,616,336")]
+    [InlineData("11_235_582_092_889_474_423_308_157_442_431_404_585_112_356_118_389_416_079_589_380_072_358_292_237_843_810_195_794_279_832_650_471_001_320_007_117_491_962_084_853_674_360_550_901_038_905_802_964_414_967_132_773_610_493_339_054_092_829_768_888_725_077_880_882_465_817_684_505_312_860_552_384_417_646_403_930_092_119_569_408_801_702_322_709_406_917_786_643_639_996_702_871_154_982_269_052_209_770_601_514_008_575", true, ValueOf_255_F_HexDigits)]
+    [InlineData("11_235_582_092_889_474_423_308_157_442_431_404_585_112_356_118_389_416_079_589_380_072_358_292_237_843_810_195_794_279_832_650_471_001_320_007_117_491_962_084_853_674_360_550_901_038_905_802_964_414_967_132_773_610_493_339_054_092_829_768_888_725_077_880_882_465_817_684_505_312_860_552_384_417_646_403_930_092_119_569_408_801_702_322_709_406_917_786_643_639_996_702_871_154_982_269_052_209_770_601_514_008_575n", true, ValueOf_255_F_HexDigits)]
+    [InlineData("179_769_313_486_231_590_772_930_519_078_902_473_361_797_697_894_230_657_273_430_081_157_732_675_805_500_963_132_708_477_322_407_536_021_120_113_879_871_393_357_658_789_768_814_416_622_492_847_430_639_474_124_377_767_893_424_865_485_276_302_219_601_246_094_119_453_082_952_085_005_768_838_150_682_342_462_881_473_913_110_540_827_237_163_350_510_684_586_298_239_947_245_938_479_716_304_835_356_329_624_224_137_215", true, "Infinity")]
+    [InlineData("179_769_313_486_231_590_772_930_519_078_902_473_361_797_697_894_230_657_273_430_081_157_732_675_805_500_963_132_708_477_322_407_536_021_120_113_879_871_393_357_658_789_768_814_416_622_492_847_430_639_474_124_377_767_893_424_865_485_276_302_219_601_246_094_119_453_082_952_085_005_768_838_150_682_342_462_881_473_913_110_540_827_237_163_350_510_684_586_298_239_947_245_938_479_716_304_835_356_329_624_224_137_215n", true, ValueOf_256_F_HexDigits)]
+    [InlineData("0.000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_01", true, "1e-323")]
+    [InlineData("0.000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001", true, "0")]
+    [InlineData(".000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_01", true, "1e-323")]
+    [InlineData(".000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_000_001", true, "0")]
+    [InlineData("1.8_364_758_544_493_064_720e19", true, "1.8364758544493064e+19")]
+    [InlineData("1.8_364_758_544_493_064_720e+19", true, "1.8364758544493064e+19")]
+    [InlineData("1_8_364_758_544_493_064_720_000e-3", true, "1.8364758544493064e+19")]
+    [InlineData("1_8_364_758_544_493_064_720_000.0e-3", true, "1.8364758544493064e+19")]
+    [InlineData("1.8364758544493064720e1_9", true, "1.8364758544493064e+19")]
+    [InlineData("1.1235582092889474E+307", true, ValueOf_255_F_HexDigits)]
+    [InlineData("1.797_693_134_862_315_9e308", true, "Infinity")]
+    [InlineData("1.797_693_134_862_315_9e+308", true, "Infinity")]
+    [InlineData("1e-324", true, "0")]
+    [InlineData("0.01e-322", true, "0")]
+    [InlineData(".01e-322", true, "0")]
+
+    [InlineData("018364758544493064720", false, "1.8364758544493064e+19")]
+    [InlineData("018364758544493064720n", false, null)]
+    [InlineData("018364758544493064720n", true, null)]
+    [InlineData("036811502618202616336", false, "3.6811502618202616E+19")]
+    [InlineData("011235582092889474423308157442431404585112356118389416079589380072358292237843810195794279832650471001320007117491962084853674360550901038905802964414967132773610493339054092829768888725077880882465817684505312860552384417646403930092119569408801702322709406917786643639996702871154982269052209770601514008575", false, ValueOf_255_F_HexDigits)]
+    [InlineData("0179769313486231590772930519078902473361797697894230657273430081157732675805500963132708477322407536021120113879871393357658789768814416622492847430639474124377767893424865485276302219601246094119453082952085005768838150682342462881473913110540827237163350510684586298239947245938479716304835356329624224137215", false, "Infinity")]
+    [InlineData("00.1", false, "0")]
+    [InlineData("00.1e-324", false, "0")]
+    public void ShouldCorrectlyParseNonPrefixedNumber(string input, bool strict, string? expectedValue)
+    {
+        var scanner = new Scanner(input);
+        var lexOptions = new LexOptions(strict, false);
+
+        if (expectedValue is not null)
+        {
+            var token = scanner.Lex(lexOptions);
+
+            var expectedTokenType = input.AsSpan().Last() == 'n' ? TokenType.BigIntLiteral : TokenType.NumericLiteral;
+            Assert.Equal(expectedTokenType, token.Type);
+
+            expectedValue = expectedValue.Replace("_", "");
+
+            object expectedValueObj = expectedTokenType == TokenType.NumericLiteral
+                ? double.Parse(expectedValue, NumberStyles.AllowThousands | NumberStyles.AllowDecimalPoint | NumberStyles.AllowExponent, CultureInfo.InvariantCulture)
+                : BigInteger.Parse(expectedValue, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+
+            Assert.Equal(expectedValueObj, token.Value);
+        }
+        else
+        {
+            Assert.Throws<ParserException>(() => scanner.Lex(lexOptions));
+        }
     }
 }


### PR DESCRIPTION
Fixes several bugs in number parsing (especially bigints):
* `0o` bigint literals should be parsed as octal numbers (were incorrectly parsed as decimal).
* `0b` and `0o` literals which are larger than a 64-bit integer are valid and should be parsed.
* `0x<256 or more zeros>` should not result in `double.PositiveInfinity` (see https://github.com/sebastienros/esprima-dotnet/compare/fix/number-parsing?expand=1#diff-5c649e707747c206cd95c805966b187aa0e3f0725f25f51aef684f8254ad0149L1065).
* Legacy octal numbers with group separators (e.g. `0777_777`) should be a syntax error (`FormatException` was thrown).
* Fractions with omitted leading zero and trailing 'n'  (e.g. `.17n`) should be a syntax error (no exception was thrown).

Also fixes a few minor bugs (e.g. in `AstToJsonConverter` when numeric literal value is `Infinity`).

&plus; Some micro-optimization.