### PR TITLE
Fix a few edge cases in AST to JS conversion

### DIFF
--- a/src/Esprima/Ast/Literal.cs
+++ b/src/Esprima/Ast/Literal.cs
@@ -7,9 +7,6 @@ namespace Esprima.Ast;
 [VisitableNode(SealOverrideMethods = true)]
 public partial class Literal : Expression
 {
-    private static readonly object s_boxedTrue = true;
-    private static readonly object s_boxedFalse = false;
-
     internal Literal(TokenType tokenType, object? value, string raw) : base(Nodes.Literal)
     {
         TokenType = tokenType;
@@ -21,7 +18,7 @@ public partial class Literal : Expression
     {
     }
 
-    public Literal(bool value, string raw) : this(TokenType.BooleanLiteral, value ? s_boxedTrue : s_boxedFalse, raw)
+    public Literal(bool value, string raw) : this(TokenType.BooleanLiteral, value.AsCachedObject(), raw)
     {
     }
 
@@ -42,7 +39,7 @@ public partial class Literal : Expression
     public string Raw { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     public string? StringValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.StringLiteral ? (string) Value! : null; }
-    public bool? BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral ? ReferenceEquals(Value, s_boxedTrue) : null; }
+    public bool? BooleanValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BooleanLiteral ? ReferenceEquals(Value, ParserExtensions.s_boxedTrue) : null; }
     public double? NumericValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.NumericLiteral ? (double) Value! : null; }
     public Regex? RegexValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.RegularExpression ? (Regex?) Value : null; }
     public BigInteger? BigIntValue { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => TokenType == TokenType.BigIntLiteral ? (BigInteger) Value! : null; }

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -9,6 +9,11 @@ internal static partial class ParserExtensions
     // old framework doesn't know this flag
     private const int MethodImplOptionsAggressiveOptimization = 512;
 
+    internal static readonly object s_boxedTrue = true;
+    internal static readonly object s_boxedFalse = false;
+
+    public static object AsCachedObject(this bool value) => value ? s_boxedTrue : s_boxedFalse;
+
     private static readonly string[] s_charToString = new string[256];
 
     static ParserExtensions()

--- a/src/Esprima/Utils/AstToJavaScriptConverter.Helpers.cs
+++ b/src/Esprima/Utils/AstToJavaScriptConverter.Helpers.cs
@@ -81,6 +81,7 @@ partial class AstToJavaScriptConverter
         var originalStatementFlags = _currentStatementFlags;
         _currentStatementFlags = getCombinedFlags(this, statement, index, count);
 
+        _writeContext.SetNodePropertyItemIndex(index);
         Writer.StartStatementListItem(index, count, (JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
         Visit(statement);
         Writer.EndStatementListItem(index, count, (JavaScriptTextWriter.StatementFlags) _currentStatementFlags, ref _writeContext);
@@ -209,6 +210,7 @@ partial class AstToJavaScriptConverter
         var originalExpressionFlags = _currentExpressionFlags;
         _currentExpressionFlags = getCombinedFlags(this, expression, index, count);
 
+        _writeContext.SetNodePropertyItemIndex(index);
         Writer.StartExpressionListItem(index, count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
         Visit(expression);
         Writer.EndExpressionListItem(index, count, (JavaScriptTextWriter.ExpressionFlags) _currentExpressionFlags, ref _writeContext);
@@ -231,7 +233,7 @@ partial class AstToJavaScriptConverter
 
     private void VisitExportOrImportSpecifierIdentifier(Expression identifierExpression)
     {
-        if (identifierExpression is Identifier { Name: "default" } identifier)
+        if (identifierExpression is Identifier { Name: "default" })
         {
             Writer.WriteKeyword("default", ref _writeContext);
         }
@@ -429,6 +431,7 @@ partial class AstToJavaScriptConverter
         var originalAuxiliaryNodeContext = _currentAuxiliaryNodeContext;
         _currentAuxiliaryNodeContext = getNodeContext(this, node, index, count);
 
+        _writeContext.SetNodePropertyItemIndex(index);
         Writer.StartAuxiliaryNodeListItem<TNode>(index, count, separator, _currentAuxiliaryNodeContext, ref _writeContext);
         Visit(node);
         Writer.EndAuxiliaryNodeListItem<TNode>(index, count, separator, _currentAuxiliaryNodeContext, ref _writeContext);

--- a/src/Esprima/Utils/JavaScriptTextWriter.Enums.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.Enums.cs
@@ -66,6 +66,12 @@ partial class JavaScriptTextWriter
         /// </summary>
         FollowsStatementBody = StatementFlags.IsStatementBody,
 
+        // Whitespace hints for punctuators
+
+        IsPotentialAmbiguousPlusOperator = 1 << 6,
+        IsPotentialAmbiguousMinusOperator = 1 << 7,
+        IsPotentialAmbiguousBinaryOperator = IsPotentialAmbiguousPlusOperator | IsPotentialAmbiguousMinusOperator,
+
         // General whitespace hints
 
         /// <summary>

--- a/src/Esprima/Utils/JavaScriptTextWriter.Enums.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.Enums.cs
@@ -7,6 +7,23 @@ partial class JavaScriptTextWriter
     private protected const TriviaType WhiteSpaceTriviaFlag = (TriviaType) (1 << 1);
     private protected const TriviaType CommentTriviaFlag = (TriviaType) (1 << 2);
 
+    private enum TokenSequence : byte
+    {
+        None,
+
+        // State values for tracking problematic punctuator sequences which must be disambiguated
+        // by inserting a white-space or parenthesis
+
+        BinaryPlus, // for tracking cases like a+ ++b
+        BinaryMinus, // for tracking cases like a- --b
+        BinaryDivide, // for tracking cases like a/ /regex/
+        BinaryLess,
+        BinaryLessThenUnaryLogicalNot, // for tracking cases like a<! --b
+        UnaryPlus, // for tracking cases like + +a or + ++a
+        UnaryMinus, // for tracking cases like - -a or - --a
+        UnaryPostfixDecrement, // for tracking cases like a-- >b
+    }
+
     protected internal enum TriviaType
     {
         None = 0,
@@ -66,11 +83,11 @@ partial class JavaScriptTextWriter
         /// </summary>
         FollowsStatementBody = StatementFlags.IsStatementBody,
 
-        // Whitespace hints for punctuators
+        // Punctuator hints
 
-        IsPotentialAmbiguousPlusOperator = 1 << 6,
-        IsPotentialAmbiguousMinusOperator = 1 << 7,
-        IsPotentialAmbiguousBinaryOperator = IsPotentialAmbiguousPlusOperator | IsPotentialAmbiguousMinusOperator,
+        IsAssignmentOperator = 1 << 8,
+        IsUnaryOperator = 1 << 9,
+        IsBinaryOperator = 1 << 10,
 
         // General whitespace hints
 

--- a/src/Esprima/Utils/JavaScriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.WriteContext.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Esprima.Ast;
 using static Esprima.EsprimaExceptionHelper;
 
@@ -8,6 +9,24 @@ public delegate object? NodePropertyValueAccessor(Node node);
 
 public delegate ref readonly NodeList<T> NodePropertyListValueAccessor<T>(Node node) where T : Node?;
 
+internal abstract class NodePropertyListValueHelper
+{
+    public abstract Type ItemType { get; }
+
+    public abstract NodeList<Node?> GetNodeList(ref JavaScriptTextWriter.WriteContext context);
+}
+
+internal sealed class NodePropertyListValueHelper<T> : NodePropertyListValueHelper where T : Node?
+{
+    public static readonly NodePropertyListValueHelper<T> Instance = new();
+
+    private NodePropertyListValueHelper() { }
+
+    public override Type ItemType => typeof(T);
+
+    public override NodeList<Node?> GetNodeList(ref JavaScriptTextWriter.WriteContext context) => context.GetNodePropertyListValue<T>().As<Node?>();
+}
+
 partial class JavaScriptTextWriter
 {
     public struct WriteContext
@@ -16,6 +35,10 @@ partial class JavaScriptTextWriter
         public WriteContext From(Node? parentNode, Node node) =>
             new WriteContext(parentNode, node ?? ThrowArgumentNullException<Node>(nameof(node)));
 
+        private string? _nodePropertyName;
+        private Delegate? _nodePropertyAccessor;
+        private NodePropertyListValueHelper? _nodePropertyListValueHelper;
+        private int _nodePropertyItemIndex;
         internal AdditionalDataSlot _additionalDataSlot;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -24,58 +47,94 @@ partial class JavaScriptTextWriter
             ParentNode = parentNode;
             Node = node;
             _nodePropertyName = null;
-            _nodePropertyValueAccessor = null;
+            _nodePropertyAccessor = null;
+            _nodePropertyListValueHelper = null;
+            _nodePropertyItemIndex = -1;
             _additionalDataSlot = default;
         }
 
         public Node? ParentNode { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
         public Node Node { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
-        private string? _nodePropertyName;
         public string? NodePropertyName { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _nodePropertyName; }
-
-        private Delegate? _nodePropertyValueAccessor;
-        private Delegate NodePropertyAccessor
-        {
-            [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => _nodePropertyValueAccessor ?? ThrowInvalidOperationException<Delegate>("The context has no associated node property.");
-        }
 
         public bool NodePropertyHasListValue
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
-            get => NodePropertyAccessor.GetType().IsGenericType;
+            get => _nodePropertyListValueHelper is not null;
         }
 
+
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public Type GetNodePropertyListItemType()
+        private Delegate EnsureNodePropertyAccessor()
         {
-            var type = NodePropertyAccessor.GetType();
-            return type.IsGenericType
-                ? type.GetGenericArguments()[0]
-                : ThrowInvalidOperationException<Type>("The context has an associated node property but its value is not a node list.");
+            return _nodePropertyAccessor ?? ThrowInvalidOperationException<Delegate>("The context has no associated node property.");
+        }
+
+        private NodePropertyValueAccessor EnsureNodePropertyValueAccessor()
+        {
+            if (_nodePropertyAccessor is NodePropertyValueAccessor accessor)
+            {
+                return accessor;
+            }
+
+            EnsureNodePropertyAccessor();
+            return ThrowInvalidOperationException<NodePropertyValueAccessor>("The context has an associated node property but its value is a node list.");
+        }
+
+        private NodePropertyListValueHelper EnsureNodePropertyListValueAccessor()
+        {
+            if (_nodePropertyListValueHelper is not null)
+            {
+                Debug.Assert(_nodePropertyAccessor?.GetType() is { IsGenericType: true });
+                return _nodePropertyListValueHelper;
+            }
+
+            EnsureNodePropertyAccessor();
+            return ThrowInvalidOperationException<NodePropertyListValueHelper>("The context has an associated node property but its value is not a node list.");
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public T GetNodePropertyValue<T>() =>
-            (T) ((NodePropertyValueAccessor) NodePropertyAccessor)(Node)!;
+        public T GetNodePropertyValue<T>()
+        {
+            return (T) EnsureNodePropertyValueAccessor()(Node)!;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public ref readonly NodeList<T> GetNodePropertyListValue<T>() where T : Node? =>
-            ref ((NodePropertyListValueAccessor<T>) NodePropertyAccessor)(Node);
+        public ref readonly NodeList<T> GetNodePropertyListValue<T>() where T : Node?
+        {
+            EnsureNodePropertyListValueAccessor();
+            return ref ((NodePropertyListValueAccessor<T>) _nodePropertyAccessor!)(Node);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public NodeList<Node?> GetNodePropertyListValue()
+        {
+            return EnsureNodePropertyListValueAccessor().GetNodeList(ref this);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public T GetNodePropertyListItem<T>() where T : Node?
+        {
+            return (T) GetNodePropertyListValue()[_nodePropertyItemIndex]!;
+        }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ClearNodeProperty()
         {
             _nodePropertyName = null;
-            _nodePropertyValueAccessor = null;
+            _nodePropertyAccessor = null;
+            _nodePropertyListValueHelper = null;
+            _nodePropertyItemIndex = -1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal void SetNodeProperty(string name, NodePropertyValueAccessor valueAccessor)
         {
             _nodePropertyName = name;
-            _nodePropertyValueAccessor = valueAccessor;
+            _nodePropertyAccessor = valueAccessor;
+            _nodePropertyListValueHelper = null;
+            _nodePropertyItemIndex = -1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -86,12 +145,32 @@ partial class JavaScriptTextWriter
         internal void SetNodeProperty<T>(string name, NodePropertyListValueAccessor<T> listValueAccessor) where T : Node?
         {
             _nodePropertyName = name;
-            _nodePropertyValueAccessor = listValueAccessor;
+            _nodePropertyAccessor = listValueAccessor;
+            _nodePropertyListValueHelper = NodePropertyListValueHelper<T>.Instance;
+            _nodePropertyItemIndex = -1;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void ChangeNodeProperty<T>(string name, NodePropertyListValueAccessor<T> listValueAccessor) where T : Node? =>
             SetNodeProperty(name ?? ThrowArgumentNullException<string>(nameof(name)), listValueAccessor ?? ThrowArgumentNullException<NodePropertyListValueAccessor<T>>(nameof(listValueAccessor)));
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void SetNodePropertyItemIndex(int index)
+        {
+            Debug.Assert(_nodePropertyAccessor is not null && index >= 0);
+            _nodePropertyItemIndex = index;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public void ChangeNodePropertyItemIndex(int index)
+        {
+            EnsureNodePropertyAccessor();
+            if (index < 0)
+            {
+                ThrowArgumentOutOfRangeException(nameof(index), index);
+            }
+            SetNodePropertyItemIndex(index);
+        }
 
         /// <summary>
         /// Gets or sets the arbitrary, user-defined data object associated with the current <see cref="WriteContext"/>.

--- a/src/Esprima/Utils/JavaScriptTextWriter.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.cs
@@ -304,7 +304,25 @@ public partial class JavaScriptTextWriter
 
     protected virtual void EndLiteral(string value, TokenType type, TokenFlags flags, ref WriteContext context) { }
 
-    protected virtual void StartPunctuator(string value, TokenFlags flags, ref WriteContext context) { }
+    protected void WriteRequiredSpaceBetweenTokenAndPunctuator(string value)
+    {
+        if ((LastTokenFlags & TokenFlags.IsPotentialAmbiguousBinaryOperator) != 0)
+        {
+            if ((LastTokenFlags & TokenFlags.IsPotentialAmbiguousPlusOperator) != 0 && value[0] == '+' ||
+                (LastTokenFlags & TokenFlags.IsPotentialAmbiguousMinusOperator) != 0 && value[0] == '-')
+            {
+                WriteSpace();
+            }
+        }
+    }
+
+    protected virtual void StartPunctuator(string value, TokenFlags flags, ref WriteContext context)
+    {
+        if (LastTriviaType == TriviaType.None)
+        {
+            WriteRequiredSpaceBetweenTokenAndPunctuator(value);
+        }
+    }
 
     public void WritePunctuator(string value, TokenFlags flags, ref WriteContext context)
     {

--- a/src/Esprima/Utils/JavaScriptTextWriter.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.cs
@@ -16,6 +16,7 @@ public record class JavaScriptTextWriterOptions
 public partial class JavaScriptTextWriter
 {
     private readonly TextWriter _writer;
+    private TokenSequence _lookbehind;
 
     public JavaScriptTextWriter(TextWriter writer, JavaScriptTextWriterOptions options)
     {
@@ -54,6 +55,7 @@ public partial class JavaScriptTextWriter
     {
         _writer.Write(value);
         OnTriviaWritten(TriviaType.WhiteSpace, TriviaFlags.None);
+        _lookbehind = TokenSequence.None;
     }
 
     protected void WriteEndOfLine()
@@ -62,6 +64,7 @@ public partial class JavaScriptTextWriter
         OnTriviaWritten(TriviaType.EndOfLine, TriviaFlags.None);
         CurrentLineIsEmptyOrWhiteSpace = true;
         PendingRequiredNewLine = false;
+        _lookbehind = TokenSequence.None;
     }
 
     protected virtual void WriteLine()
@@ -86,6 +89,7 @@ public partial class JavaScriptTextWriter
         OnTriviaWritten(TriviaType.LineComment, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
         PendingRequiredNewLine = true; // New line after line comments is always required.
+        _lookbehind = TokenSequence.None;
     }
 
     protected virtual void WriteBlockCommentLine(TextWriter writer, string line, bool isFirst)
@@ -123,6 +127,7 @@ public partial class JavaScriptTextWriter
         OnTriviaWritten(TriviaType.BlockComment, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
         PendingRequiredNewLine = flags.HasFlagFast(TriviaFlags.TrailingNewLineRequired);
+        _lookbehind = TokenSequence.None;
     }
 
     protected virtual void OnTokenWritten(TokenType type, TokenFlags flags)
@@ -183,6 +188,7 @@ public partial class JavaScriptTextWriter
 
         OnTokenWritten(TokenType.Identifier, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
+        _lookbehind = TokenSequence.None;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -237,6 +243,7 @@ public partial class JavaScriptTextWriter
 
         OnTokenWritten(TokenType.Keyword, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
+        _lookbehind = TokenSequence.None;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -264,9 +271,14 @@ public partial class JavaScriptTextWriter
                 }
                 break;
             case TokenType.EOF:
-            case TokenType.Punctuator:
             case TokenType.StringLiteral:
             case TokenType.Template:
+                break;
+            case TokenType.Punctuator:
+                if (type == TokenType.RegularExpression && _lookbehind == TokenSequence.BinaryDivide)
+                {
+                    WriteSpace();
+                }
                 break;
             default:
                 throw new InvalidOperationException();
@@ -294,6 +306,7 @@ public partial class JavaScriptTextWriter
 
         OnTokenWritten(type, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
+        _lookbehind = TokenSequence.None;
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -304,15 +317,28 @@ public partial class JavaScriptTextWriter
 
     protected virtual void EndLiteral(string value, TokenType type, TokenFlags flags, ref WriteContext context) { }
 
-    protected void WriteRequiredSpaceBetweenTokenAndPunctuator(string value)
+    protected virtual bool ShouldDisambiguatePunctuator(string value, TokenFlags flags, ref WriteContext context)
     {
-        if ((LastTokenFlags & TokenFlags.IsPotentialAmbiguousBinaryOperator) != 0)
+        if (_lookbehind != TokenSequence.None)
         {
-            if ((LastTokenFlags & TokenFlags.IsPotentialAmbiguousPlusOperator) != 0 && value[0] == '+' ||
-                (LastTokenFlags & TokenFlags.IsPotentialAmbiguousMinusOperator) != 0 && value[0] == '-')
+            switch (_lookbehind)
             {
-                WriteSpace();
+                case TokenSequence.BinaryPlus or TokenSequence.UnaryPlus when value[0] == '+':
+                case TokenSequence.BinaryMinus or TokenSequence.UnaryMinus when value[0] == '-':
+                case TokenSequence.BinaryLessThenUnaryLogicalNot when value[0] == '-' && value.CharCodeAt(1) == '-':
+                case TokenSequence.UnaryPostfixDecrement when value[0] == '>':
+                    return true;
             }
+        }
+
+        return false;
+    }
+
+    protected void WriteRequiredSpaceBetweenTokenAndPunctuator(string value, TokenFlags flags, ref WriteContext context)
+    {
+        if (ShouldDisambiguatePunctuator(value, flags, ref context))
+        {
+            WriteSpace();
         }
     }
 
@@ -320,7 +346,7 @@ public partial class JavaScriptTextWriter
     {
         if (LastTriviaType == TriviaType.None)
         {
-            WriteRequiredSpaceBetweenTokenAndPunctuator(value);
+            WriteRequiredSpaceBetweenTokenAndPunctuator(value, flags, ref context);
         }
     }
 
@@ -337,6 +363,32 @@ public partial class JavaScriptTextWriter
 
         OnTokenWritten(TokenType.Punctuator, flags);
         CurrentLineIsEmptyOrWhiteSpace = false;
+
+        if ((flags & (TokenFlags.IsBinaryOperator | TokenFlags.IsUnaryOperator)) != 0)
+        {
+            if (_lookbehind == TokenSequence.BinaryLess && context.Node is UnaryExpression { Operator: UnaryOperator.LogicalNot })
+            {
+                _lookbehind = TokenSequence.BinaryLessThenUnaryLogicalNot;
+            }
+            else
+            {
+                _lookbehind = context.Node switch
+                {
+                    BinaryExpression { Operator: BinaryOperator.Plus } => TokenSequence.BinaryPlus,
+                    BinaryExpression { Operator: BinaryOperator.Minus } => TokenSequence.BinaryMinus,
+                    BinaryExpression { Operator: BinaryOperator.Divide } => TokenSequence.BinaryDivide,
+                    BinaryExpression { Operator: BinaryOperator.Less } => TokenSequence.BinaryLess,
+                    UnaryExpression { Operator: UnaryOperator.Plus } => TokenSequence.UnaryPlus,
+                    UnaryExpression { Operator: UnaryOperator.Minus } => TokenSequence.UnaryMinus,
+                    UnaryExpression { Operator: UnaryOperator.Decrement, Prefix: false } => TokenSequence.UnaryPostfixDecrement,
+                    _ => TokenSequence.None
+                };
+            }
+        }
+        else
+        {
+            _lookbehind = TokenSequence.None;
+        }
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -465,5 +517,6 @@ public partial class JavaScriptTextWriter
     public virtual void Finish()
     {
         OnTokenWritten(TokenType.EOF, TokenFlags.None);
+        _lookbehind = TokenSequence.None;
     }
 }

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -632,6 +632,50 @@ if (b == 2) {
     }
 
     [Theory]
+    [InlineData("a && b ?? c", true)]
+    [InlineData("(a && b) ?? c", false)]
+    [InlineData("a && (b ?? c)", false)]
+    [InlineData("a ?? b && c", true)]
+    [InlineData("(a ?? b) && c", false)]
+    [InlineData("a ?? (b && c)", false)]
+    [InlineData("a || b ?? c", true)]
+    [InlineData("(a || b) ?? c", false)]
+    [InlineData("a || (b ?? c)", false)]
+    [InlineData("a ?? b || c", true)]
+    [InlineData("(a ?? b) || c", false)]
+    [InlineData("a ?? (b || c)", false)]
+    [InlineData("a ?? b || c ?? d", true)]
+    [InlineData("(a ?? b) || c ?? d", true)]
+    [InlineData("a ?? (b || c) ?? d", false)]
+    [InlineData("a ?? b || (c ?? d)", true)]
+    [InlineData("(a ?? b) || (c ?? d)", false)]
+    [InlineData("void a && b ?? c", true)]
+    [InlineData("(void a && b) ?? c", false)]
+    [InlineData("a ?? void b && c", true)]
+    [InlineData("a ?? (void b && c)", false)]
+    [InlineData("a ?? void (b && c)", false)]
+    [InlineData("function* f() {\n  yield a && b ?? c;\n}", true)]
+    [InlineData("function* f() {\n  (yield a && b) ?? c;\n}", false)]
+    [InlineData("function* f() {\n  a ?? yield b && c;\n}", true)]
+    [InlineData("function* f() {\n  a ?? (yield b && c);\n}", false)]
+    [InlineData("function* f() {\n  a ?? yield (b && c);\n}", true)]
+    public void ToJavaScriptTest_NullishCoalescingMixedWithLogicalAndOr_ShouldBeParenthesized(string source, bool expectParseError)
+    {
+        source = source.Replace("\n", Environment.NewLine);
+        var parser = new JavaScriptParser();
+        if (!expectParseError)
+        {
+            var program = parser.ParseExpression(source);
+            var code = AstToJavaScript.ToJavaScriptString(program, format: true);
+            Assert.Equal(source, code);
+        }
+        else
+        {
+            Assert.Throws<ParserException>(() => parser.ParseExpression(source));
+        }
+    }
+
+    [Theory]
     [InlineData(true,
 @"<>AAA <el attr1=""a"" attr2='b' attr3={x ? 'c' : 'd'} {...(x + 2, [y])}> &lt; {} &gt; </el> BBB <c.el {...[z]}>member</c.el> <ns:el>member</ns:el> DDD </>",
 @"<>AAA <el attr1=""a""attr2='b'attr3={x?'c':'d'}{...(x+2,[y])}> &lt; {} &gt; </el> BBB <c.el{...[z]}>member</c.el> <ns:el>member</ns:el> DDD </>")]

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -632,6 +632,65 @@ if (b == 2) {
     }
 
     [Theory]
+    [InlineData("a + -b", false, "a+-b")]
+    [InlineData("a + +b", false, "a+ +b")]
+    [InlineData("a + +b", true, null)]
+    [InlineData("a + --b", false, "a+--b")]
+    [InlineData("a + ++b", false, "a+ ++b")]
+    [InlineData("a + ++b", true, null)]
+    [InlineData("a + -b * 2", false, "a+-b*2")]
+    [InlineData("a + +b * 2", false, "a+ +b*2")]
+    [InlineData("a + +b * 2", true, null)]
+    [InlineData("a + --b * 2", false, "a+--b*2")]
+    [InlineData("a + ++b * 2", false, "a+ ++b*2")]
+    [InlineData("a + ++b * 2", true, null)]
+    [InlineData("a + (+b) ** 2", false, "a+(+b)**2")]
+    [InlineData("a + (+b) ** 2", true, null)]
+    [InlineData("a + ++b ** 2", false, "a+ ++b**2")]
+    [InlineData("a + ++b ** 2", true, null)]
+    [InlineData("a++ - b", false, "a++-b")]
+    [InlineData("a++ + b", false, "a+++b")]
+    [InlineData("a++ + b", true, null)]
+    [InlineData("a++ + +b", false, "a+++ +b")]
+    [InlineData("a++ + +b", true, null)]
+    [InlineData("a++ + ++b", false, "a+++ ++b")]
+    [InlineData("a++ + ++b", true, null)]
+
+    [InlineData("a - +b", false, "a-+b")]
+    [InlineData("a - -b", false, "a- -b")]
+    [InlineData("a - -b", true, null)]
+    [InlineData("a - ++b", false, "a-++b")]
+    [InlineData("a - --b", false, "a- --b")]
+    [InlineData("a - --b", true, null)]
+    [InlineData("a - +b * 2", false, "a-+b*2")]
+    [InlineData("a - -b * 2", false, "a- -b*2")]
+    [InlineData("a - -b * 2", true, null)]
+    [InlineData("a - ++b * 2", false, "a-++b*2")]
+    [InlineData("a - --b * 2", false, "a- --b*2")]
+    [InlineData("a - --b * 2", true, null)]
+    [InlineData("a - (-b) ** 2", false, "a-(-b)**2")]
+    [InlineData("a - (-b) ** 2", true, null)]
+    [InlineData("a - --b ** 2", false, "a- --b**2")]
+    [InlineData("a - --b ** 2", true, null)]
+    [InlineData("a-- + b", false, "a--+b")]
+    [InlineData("a-- - b", false, "a---b")]
+    [InlineData("a-- - b", true, null)]
+    [InlineData("a-- - -b", false, "a--- -b")]
+    [InlineData("a-- - -b", true, null)]
+    [InlineData("a-- - --b", false, "a--- --b")]
+    [InlineData("a-- - --b", true, null)]
+    public void ToJavaScriptTest_AmbiguousBinaryOperators_ShouldBeDisambiguatedWithWhiteSpace(string source, bool format, string? expectedCode)
+    {
+        var parser = new JavaScriptParser();
+        var program = parser.ParseExpression(source);
+        var code = AstToJavaScript.ToJavaScriptString(program, format);
+        Assert.Equal(expectedCode ?? source, code);
+
+        var programReparsed = parser.ParseExpression(code);
+        Assert.Equal(program.DescendantNodesAndSelf(), programReparsed.DescendantNodesAndSelf(), NodeTypeEqualityComparer.Default);
+    }
+
+    [Theory]
     [InlineData("a && b ?? c", true)]
     [InlineData("(a && b) ?? c", false)]
     [InlineData("a && (b ?? c)", false)]

--- a/test/Esprima.Tests/AstToJavascriptTests.cs
+++ b/test/Esprima.Tests/AstToJavascriptTests.cs
@@ -679,8 +679,61 @@ if (b == 2) {
     [InlineData("a-- - -b", true, null)]
     [InlineData("a-- - --b", false, "a--- --b")]
     [InlineData("a-- - --b", true, null)]
-    public void ToJavaScriptTest_AmbiguousBinaryOperators_ShouldBeDisambiguatedWithWhiteSpace(string source, bool format, string? expectedCode)
+
+    [InlineData("a + +(+b)", false, "a+ + +b")]
+    [InlineData("a + +(+b)", true, null)]
+    [InlineData("a + +(-b)", false, "a+ +-b")]
+    [InlineData("a + +(-b)", true, null)]
+    [InlineData("a + -(+b)", false, "a+-+b")]
+    [InlineData("a + -(+b)", true, null)]
+    [InlineData("a + -(-b)", false, "a+- -b")]
+    [InlineData("a + -(-b)", true, null)]
+    [InlineData("a + +(++b)", false, "a+ + ++b")]
+    [InlineData("a + +(++b)", true, null)]
+    [InlineData("a + -(++b)", false, "a+-++b")]
+    [InlineData("a + -(++b)", true, null)]
+    [InlineData("a + -(~b)", false, "a+-~b")]
+    [InlineData("a + -(~b)", true, null)]
+
+    [InlineData("a - -(-b)", false, "a- - -b")]
+    [InlineData("a - -(-b)", true, null)]
+    [InlineData("a - -(+b)", false, "a- -+b")]
+    [InlineData("a - -(+b)", true, null)]
+    [InlineData("a - +(-b)", false, "a-+-b")]
+    [InlineData("a - +(-b)", true, null)]
+    [InlineData("a - +(+b)", false, "a-+ +b")]
+    [InlineData("a - +(+b)", true, null)]
+    [InlineData("a - -(--b)", false, "a- - --b")]
+    [InlineData("a - -(--b)", true, null)]
+    [InlineData("a - +(--b)", false, "a-+--b")]
+    [InlineData("a - +(--b)", true, null)]
+    [InlineData("a - +(~b)", false, "a-+~b")]
+    [InlineData("a - +(~b)", true, null)]
+
+    [InlineData("a / (/x/, b)", false, "a/(/x/,b)")]
+    [InlineData("a / (/x/, b)", true, null)]
+    [InlineData("a / /x/", false, "a/ /x/")]
+    [InlineData("a / /x/", true, null)]
+
+    [InlineData("a < --b", false, "a<--b")]
+    [InlineData("a < --b", true, null)]
+    [InlineData("a < !(--b, c)", false, "a<!(--b,c)")]
+    [InlineData("a < !(--b, c)", true, null)]
+    [InlineData("a < !(--b)", false, "a<! --b")]
+    [InlineData("a < !(--b)", true, null)]
+    [InlineData("(a, b--) > c", false, "(a,b--)>c")]
+    [InlineData("(a, b--) > c", true, null)]
+    [InlineData("b-- > c", false, "b-- >c")]
+    [InlineData("b-- > c", true, null)]
+
+    [InlineData("+(-(~(!x++))), -(-x)", false, "+-~!x++,- -x")]
+    [InlineData("+(-(~(!x++))), -(-x)", true, null)]
+    [InlineData("(() => {\n  if (true)\n    +(-(~(!x++))), -(-x);\n})()", false, "(()=>{if(true)+-~!x++,- -x})()")]
+    [InlineData("(() => {\n  if (true)\n    +(-(~(!x++))), -(-x);\n})()", true, null)]
+    public void ToJavaScriptTest_AmbiguousOperatorSequence_ShouldBeDisambiguated(string source, bool format, string? expectedCode)
     {
+        source = source.Replace("\n", Environment.NewLine);
+
         var parser = new JavaScriptParser();
         var program = parser.ParseExpression(source);
         var code = AstToJavaScript.ToJavaScriptString(program, format);
@@ -718,6 +771,7 @@ if (b == 2) {
     [InlineData("function* f() {\n  a ?? yield b && c;\n}", true)]
     [InlineData("function* f() {\n  a ?? (yield b && c);\n}", false)]
     [InlineData("function* f() {\n  a ?? yield (b && c);\n}", true)]
+    [InlineData("n || o === \"back\" ? (n ?? \"\") || \"back\" : \"\"", false)]
     public void ToJavaScriptTest_NullishCoalescingMixedWithLogicalAndOr_ShouldBeParenthesized(string source, bool expectParseError)
     {
         source = source.Replace("\n", Environment.NewLine);


### PR DESCRIPTION
Makes changes to `AstToJsonConverter` to correctly parenthesize logical expressions which mix nullish coalescing and logical AND/OR operations (e.g. `a ?? b && c`).

Also, fixes formatting of plus/minus binary operations having a right side that starts with an ambiguous punctuator (e.g. `a+++b` vs `a+ ++b`).

