### PR TITLE
Enable code analysis with latest-Recommended

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,18 @@ indent_size = 2
 # IDE0055: Fix formatting
 dotnet_diagnostic.IDE0055.severity = warning
 
+# Error CA1051 : Do not declare visible instance fields
+dotnet_diagnostic.CA1051.severity = none
+
+#  Error CA1711: Identifiers should not have incorrect suffix
+dotnet_diagnostic.CA1711.severity = none
+
+#  Error CA1716: Identifiers should have correct suffix
+dotnet_diagnostic.CA1716.severity = none
+
+#  Error CA1720 : Identifiers should not contain type names
+dotnet_diagnostic.CA1720.severity = none
+
 # Sort using and Import directives with System.* appearing first
 dotnet_sort_system_directives_first = true
 dotnet_separate_import_directive_groups = false

--- a/src/Esprima/ArrayList.cs
+++ b/src/Esprima/ArrayList.cs
@@ -193,7 +193,9 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     }
 
     [Conditional("DEBUG")]
+#pragma warning disable CA1822
     private void AssertUnchanged()
+#pragma warning restore CA1822
     {
 #if DEBUG
         if (_localVersion != (_sharedVersion?[0] ?? 0))
@@ -204,7 +206,9 @@ internal struct ArrayList<T> : IReadOnlyList<T>
     }
 
     [Conditional("DEBUG")]
+#pragma warning disable CA1822
     private void OnChanged()
+#pragma warning restore CA1822
     {
 #if DEBUG
         _sharedVersion ??= new[] { 0 };

--- a/src/Esprima/Ast/ArrayExpression.cs
+++ b/src/Esprima/Ast/ArrayExpression.cs
@@ -18,7 +18,7 @@ public sealed partial class ArrayExpression : Expression
     public ref readonly NodeList<Expression?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ArrayExpression Rewrite(in NodeList<Expression?> elements)
+    private static ArrayExpression Rewrite(in NodeList<Expression?> elements)
     {
         return new ArrayExpression(elements);
     }

--- a/src/Esprima/Ast/ArrayPattern.cs
+++ b/src/Esprima/Ast/ArrayPattern.cs
@@ -18,7 +18,7 @@ public sealed partial class ArrayPattern : BindingPattern
     public ref readonly NodeList<Node?> Elements { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _elements; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ArrayPattern Rewrite(in NodeList<Node?> elements)
+    private static ArrayPattern Rewrite(in NodeList<Node?> elements)
     {
         return new ArrayPattern(elements);
     }

--- a/src/Esprima/Ast/AssignmentPattern.cs
+++ b/src/Esprima/Ast/AssignmentPattern.cs
@@ -20,7 +20,7 @@ public sealed partial class AssignmentPattern : Node
     public Expression Right { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => _right; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private AssignmentPattern Rewrite(Node left, Expression right)
+    private static AssignmentPattern Rewrite(Node left, Expression right)
     {
         return new AssignmentPattern(left, right);
     }

--- a/src/Esprima/Ast/AwaitExpression.cs
+++ b/src/Esprima/Ast/AwaitExpression.cs
@@ -13,7 +13,7 @@ public sealed partial class AwaitExpression : Expression
     public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private AwaitExpression Rewrite(Expression argument)
+    private static AwaitExpression Rewrite(Expression argument)
     {
         return new AwaitExpression(argument);
     }

--- a/src/Esprima/Ast/BlockStatement.cs
+++ b/src/Esprima/Ast/BlockStatement.cs
@@ -15,7 +15,7 @@ public sealed partial class BlockStatement : Statement
     public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private BlockStatement Rewrite(in NodeList<Statement> body)
+    private static BlockStatement Rewrite(in NodeList<Statement> body)
     {
         return new BlockStatement(body);
     }

--- a/src/Esprima/Ast/BreakStatement.cs
+++ b/src/Esprima/Ast/BreakStatement.cs
@@ -13,7 +13,7 @@ public sealed partial class BreakStatement : Statement
     public Identifier? Label { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private BreakStatement Rewrite(Identifier? label)
+    private static BreakStatement Rewrite(Identifier? label)
     {
         return new BreakStatement(label);
     }

--- a/src/Esprima/Ast/CatchClause.cs
+++ b/src/Esprima/Ast/CatchClause.cs
@@ -19,7 +19,7 @@ public sealed partial class CatchClause : Node
     public BlockStatement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private CatchClause Rewrite(Node? param, BlockStatement body)
+    private static CatchClause Rewrite(Node? param, BlockStatement body)
     {
         return new CatchClause(param, body);
     }

--- a/src/Esprima/Ast/ChainExpression.cs
+++ b/src/Esprima/Ast/ChainExpression.cs
@@ -16,7 +16,7 @@ public sealed partial class ChainExpression : Expression
     public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ChainExpression Rewrite(Expression expression)
+    private static ChainExpression Rewrite(Expression expression)
     {
         return new ChainExpression(expression);
     }

--- a/src/Esprima/Ast/ClassBody.cs
+++ b/src/Esprima/Ast/ClassBody.cs
@@ -18,7 +18,7 @@ public sealed partial class ClassBody : Node
     public ref readonly NodeList<ClassElement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ClassBody Rewrite(in NodeList<ClassElement> body)
+    private static ClassBody Rewrite(in NodeList<ClassElement> body)
     {
         return new ClassBody(body);
     }

--- a/src/Esprima/Ast/ClassDeclaration.cs
+++ b/src/Esprima/Ast/ClassDeclaration.cs
@@ -22,7 +22,7 @@ public sealed partial class ClassDeclaration : Declaration, IClass
     public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ClassDeclaration Rewrite(in NodeList<Decorator> decorators, Identifier? id, Expression? superClass, ClassBody body)
+    private static ClassDeclaration Rewrite(in NodeList<Decorator> decorators, Identifier? id, Expression? superClass, ClassBody body)
     {
         return new ClassDeclaration(id, superClass, body, decorators);
     }

--- a/src/Esprima/Ast/ClassExpression.cs
+++ b/src/Esprima/Ast/ClassExpression.cs
@@ -25,7 +25,7 @@ public sealed partial class ClassExpression : Expression, IClass
     public ref readonly NodeList<Decorator> Decorators { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _decorators; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ClassExpression Rewrite(in NodeList<Decorator> decorators, Identifier? id, Expression? superClass, ClassBody body)
+    private static ClassExpression Rewrite(in NodeList<Decorator> decorators, Identifier? id, Expression? superClass, ClassBody body)
     {
         return new ClassExpression(id, superClass, body, decorators);
     }

--- a/src/Esprima/Ast/ComputedMemberExpression.cs
+++ b/src/Esprima/Ast/ComputedMemberExpression.cs
@@ -7,8 +7,8 @@ public sealed class ComputedMemberExpression : MemberExpression
     {
     }
 
-    protected override MemberExpression Rewrite(Expression obj, Expression property)
+    protected override MemberExpression Rewrite(Expression @object, Expression property)
     {
-        return new ComputedMemberExpression(obj, property, Optional);
+        return new ComputedMemberExpression(@object, property, Optional);
     }
 }

--- a/src/Esprima/Ast/ConditionalExpression.cs
+++ b/src/Esprima/Ast/ConditionalExpression.cs
@@ -20,7 +20,7 @@ public sealed partial class ConditionalExpression : Expression
     public Expression Alternate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ConditionalExpression Rewrite(Expression test, Expression consequent, Expression alternate)
+    private static ConditionalExpression Rewrite(Expression test, Expression consequent, Expression alternate)
     {
         return new ConditionalExpression(test, consequent, alternate);
     }

--- a/src/Esprima/Ast/ContinueStatement.cs
+++ b/src/Esprima/Ast/ContinueStatement.cs
@@ -13,7 +13,7 @@ public sealed partial class ContinueStatement : Statement
     public Identifier? Label { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ContinueStatement Rewrite(Identifier? label)
+    private static ContinueStatement Rewrite(Identifier? label)
     {
         return new ContinueStatement(label);
     }

--- a/src/Esprima/Ast/Decorator.cs
+++ b/src/Esprima/Ast/Decorator.cs
@@ -13,7 +13,7 @@ public sealed partial class Decorator : Node
     public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private Decorator Rewrite(Expression expression)
+    private static Decorator Rewrite(Expression expression)
     {
         return new Decorator(expression);
     }

--- a/src/Esprima/Ast/DoWhileStatement.cs
+++ b/src/Esprima/Ast/DoWhileStatement.cs
@@ -15,7 +15,7 @@ public sealed partial class DoWhileStatement : Statement
     public Expression Test { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private DoWhileStatement Rewrite(Statement body, Expression test)
+    private static DoWhileStatement Rewrite(Statement body, Expression test)
     {
         return new DoWhileStatement(body, test);
     }

--- a/src/Esprima/Ast/ExportAllDeclaration.cs
+++ b/src/Esprima/Ast/ExportAllDeclaration.cs
@@ -26,7 +26,7 @@ public sealed partial class ExportAllDeclaration : ExportDeclaration
     public ref readonly NodeList<ImportAttribute> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ExportAllDeclaration Rewrite(Expression? exported, Literal source, in NodeList<ImportAttribute> attributes)
+    private static ExportAllDeclaration Rewrite(Expression? exported, Literal source, in NodeList<ImportAttribute> attributes)
     {
         return new ExportAllDeclaration(source, exported, attributes);
     }

--- a/src/Esprima/Ast/ExportDefaultDeclaration.cs
+++ b/src/Esprima/Ast/ExportDefaultDeclaration.cs
@@ -16,7 +16,7 @@ public sealed partial class ExportDefaultDeclaration : ExportDeclaration
     public StatementListItem Declaration { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ExportDefaultDeclaration Rewrite(StatementListItem declaration)
+    private static ExportDefaultDeclaration Rewrite(StatementListItem declaration)
     {
         return new ExportDefaultDeclaration(declaration);
     }

--- a/src/Esprima/Ast/ExportNamedDeclaration.cs
+++ b/src/Esprima/Ast/ExportNamedDeclaration.cs
@@ -30,7 +30,7 @@ public sealed partial class ExportNamedDeclaration : ExportDeclaration
     public ref readonly NodeList<ImportAttribute> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ExportNamedDeclaration Rewrite(Declaration? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> attributes)
+    private static ExportNamedDeclaration Rewrite(Declaration? declaration, in NodeList<ExportSpecifier> specifiers, Literal? source, in NodeList<ImportAttribute> attributes)
     {
         return new ExportNamedDeclaration(declaration, specifiers, source, attributes);
     }

--- a/src/Esprima/Ast/ExportSpecifier.cs
+++ b/src/Esprima/Ast/ExportSpecifier.cs
@@ -23,7 +23,7 @@ public sealed partial class ExportSpecifier : Node, IModuleSpecifier
     internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => enumerator.MoveNextExportSpecifier(Local, Exported);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ExportSpecifier Rewrite(Expression local, Expression exported)
+    private static ExportSpecifier Rewrite(Expression local, Expression exported)
     {
         return new ExportSpecifier(local, exported);
     }

--- a/src/Esprima/Ast/ForInStatement.cs
+++ b/src/Esprima/Ast/ForInStatement.cs
@@ -23,7 +23,7 @@ public sealed partial class ForInStatement : Statement
     public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ForInStatement Rewrite(Node left, Expression right, Statement body)
+    private static ForInStatement Rewrite(Node left, Expression right, Statement body)
     {
         return new ForInStatement(left, right, body);
     }

--- a/src/Esprima/Ast/ForStatement.cs
+++ b/src/Esprima/Ast/ForStatement.cs
@@ -27,7 +27,7 @@ public sealed partial class ForStatement : Statement
     public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ForStatement Rewrite(StatementListItem? init, Expression? test, Expression? update, Statement body)
+    private static ForStatement Rewrite(StatementListItem? init, Expression? test, Expression? update, Statement body)
     {
         return new ForStatement(init, test, update, body);
     }

--- a/src/Esprima/Ast/IfStatement.cs
+++ b/src/Esprima/Ast/IfStatement.cs
@@ -21,7 +21,7 @@ public sealed partial class IfStatement : Statement
     public Statement? Alternate { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private IfStatement Rewrite(Expression test, Statement consequent, Statement? alternate)
+    private static IfStatement Rewrite(Expression test, Statement consequent, Statement? alternate)
     {
         return new IfStatement(test, consequent, alternate);
     }

--- a/src/Esprima/Ast/ImportAttribute.cs
+++ b/src/Esprima/Ast/ImportAttribute.cs
@@ -18,7 +18,7 @@ public sealed partial class ImportAttribute : Node
     public Literal Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportAttribute Rewrite(Expression key, Literal value)
+    private static ImportAttribute Rewrite(Expression key, Literal value)
     {
         return new ImportAttribute(key, value);
     }

--- a/src/Esprima/Ast/ImportDeclaration.cs
+++ b/src/Esprima/Ast/ImportDeclaration.cs
@@ -24,7 +24,7 @@ public sealed partial class ImportDeclaration : Declaration
     public ref readonly NodeList<ImportAttribute> Attributes { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _attributes; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportDeclaration Rewrite(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> attributes)
+    private static ImportDeclaration Rewrite(in NodeList<ImportDeclarationSpecifier> specifiers, Literal source, in NodeList<ImportAttribute> attributes)
     {
         return new ImportDeclaration(specifiers, source, attributes);
     }

--- a/src/Esprima/Ast/ImportDefaultSpecifier.cs
+++ b/src/Esprima/Ast/ImportDefaultSpecifier.cs
@@ -10,7 +10,7 @@ public sealed partial class ImportDefaultSpecifier : ImportDeclarationSpecifier
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportDefaultSpecifier Rewrite(Identifier local)
+    private static ImportDefaultSpecifier Rewrite(Identifier local)
     {
         return new ImportDefaultSpecifier(local);
     }

--- a/src/Esprima/Ast/ImportExpression.cs
+++ b/src/Esprima/Ast/ImportExpression.cs
@@ -19,7 +19,7 @@ public sealed partial class ImportExpression : Expression
     public Expression? Options { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportExpression Rewrite(Expression source, Expression? options)
+    private static ImportExpression Rewrite(Expression source, Expression? options)
     {
         return new ImportExpression(source, options);
     }

--- a/src/Esprima/Ast/ImportNamespaceSpecifier.cs
+++ b/src/Esprima/Ast/ImportNamespaceSpecifier.cs
@@ -10,7 +10,7 @@ public sealed partial class ImportNamespaceSpecifier : ImportDeclarationSpecifie
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportNamespaceSpecifier Rewrite(Identifier local)
+    private static ImportNamespaceSpecifier Rewrite(Identifier local)
     {
         return new ImportNamespaceSpecifier(local);
     }

--- a/src/Esprima/Ast/ImportSpecifier.cs
+++ b/src/Esprima/Ast/ImportSpecifier.cs
@@ -18,7 +18,7 @@ public sealed partial class ImportSpecifier : ImportDeclarationSpecifier
     internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => enumerator.MoveNextImportSpecifier(Imported, Local);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ImportSpecifier Rewrite(Expression imported, Identifier local)
+    private static ImportSpecifier Rewrite(Expression imported, Identifier local)
     {
         return new ImportSpecifier(local, imported);
     }

--- a/src/Esprima/Ast/Jsx/JsxAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxAttribute.cs
@@ -16,7 +16,7 @@ public sealed partial class JsxAttribute : JsxExpression
     public Expression? Value { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxAttribute Rewrite(JsxExpression name, Expression? value)
+    private static JsxAttribute Rewrite(JsxExpression name, Expression? value)
     {
         return new JsxAttribute(name, value);
     }

--- a/src/Esprima/Ast/Jsx/JsxClosingElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxClosingElement.cs
@@ -14,7 +14,7 @@ public sealed partial class JsxClosingElement : JsxExpression
     public JsxExpression Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxClosingElement Rewrite(JsxExpression name)
+    private static JsxClosingElement Rewrite(JsxExpression name)
     {
         return new JsxClosingElement(name);
     }

--- a/src/Esprima/Ast/Jsx/JsxElement.cs
+++ b/src/Esprima/Ast/Jsx/JsxElement.cs
@@ -20,7 +20,7 @@ public sealed partial class JsxElement : JsxExpression
     public ref readonly NodeList<JsxExpression> Children { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _children; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxElement Rewrite(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement)
+    private static JsxElement Rewrite(Node openingElement, in NodeList<JsxExpression> children, Node? closingElement)
     {
         return new JsxElement(openingElement, children, closingElement);
     }

--- a/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
+++ b/src/Esprima/Ast/Jsx/JsxExpressionContainer.cs
@@ -14,7 +14,7 @@ public sealed partial class JsxExpressionContainer : JsxExpression
     public Expression Expression { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxExpressionContainer Rewrite(Expression expression)
+    private static JsxExpressionContainer Rewrite(Expression expression)
     {
         return new JsxExpressionContainer(expression);
     }

--- a/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
+++ b/src/Esprima/Ast/Jsx/JsxMemberExpression.cs
@@ -16,7 +16,7 @@ public sealed partial class JsxMemberExpression : JsxExpression
     public JsxIdentifier Property { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxMemberExpression Rewrite(JsxExpression @object, JsxIdentifier property)
+    private static JsxMemberExpression Rewrite(JsxExpression @object, JsxIdentifier property)
     {
         return new JsxMemberExpression(@object, property);
     }

--- a/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
+++ b/src/Esprima/Ast/Jsx/JsxNamespacedName.cs
@@ -16,7 +16,7 @@ public sealed partial class JsxNamespacedName : JsxExpression
     public JsxIdentifier Name { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxNamespacedName Rewrite(JsxIdentifier name, JsxIdentifier @namespace)
+    private static JsxNamespacedName Rewrite(JsxIdentifier name, JsxIdentifier @namespace)
     {
         return new JsxNamespacedName(@namespace, name);
     }

--- a/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
+++ b/src/Esprima/Ast/Jsx/JsxSpreadAttribute.cs
@@ -14,7 +14,7 @@ public sealed partial class JsxSpreadAttribute : JsxExpression
     public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private JsxSpreadAttribute Rewrite(Expression argument)
+    private static JsxSpreadAttribute Rewrite(Expression argument)
     {
         return new JsxSpreadAttribute(argument);
     }

--- a/src/Esprima/Ast/LabeledStatement.cs
+++ b/src/Esprima/Ast/LabeledStatement.cs
@@ -16,7 +16,7 @@ public sealed partial class LabeledStatement : Statement
     public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private LabeledStatement Rewrite(Identifier label, Statement body)
+    private static LabeledStatement Rewrite(Identifier label, Statement body)
     {
         return new LabeledStatement(label, body);
     }

--- a/src/Esprima/Ast/MetaProperty.cs
+++ b/src/Esprima/Ast/MetaProperty.cs
@@ -15,7 +15,7 @@ public sealed partial class MetaProperty : Expression
     public Identifier Property { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private MetaProperty Rewrite(Identifier meta, Identifier property)
+    private static MetaProperty Rewrite(Identifier meta, Identifier property)
     {
         return new MetaProperty(meta, property);
     }

--- a/src/Esprima/Ast/NewExpression.cs
+++ b/src/Esprima/Ast/NewExpression.cs
@@ -20,7 +20,7 @@ public sealed partial class NewExpression : Expression
     public ref readonly NodeList<Expression> Arguments { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _arguments; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private NewExpression Rewrite(Expression callee, in NodeList<Expression> arguments)
+    private static NewExpression Rewrite(Expression callee, in NodeList<Expression> arguments)
     {
         return new NewExpression(callee, arguments);
     }

--- a/src/Esprima/Ast/ObjectExpression.cs
+++ b/src/Esprima/Ast/ObjectExpression.cs
@@ -18,7 +18,7 @@ public sealed partial class ObjectExpression : Expression
     public ref readonly NodeList<Node> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ObjectExpression Rewrite(in NodeList<Node> properties)
+    private static ObjectExpression Rewrite(in NodeList<Node> properties)
     {
         return new ObjectExpression(properties);
     }

--- a/src/Esprima/Ast/ObjectPattern.cs
+++ b/src/Esprima/Ast/ObjectPattern.cs
@@ -18,7 +18,7 @@ public sealed partial class ObjectPattern : BindingPattern
     public ref readonly NodeList<Node> Properties { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _properties; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ObjectPattern Rewrite(in NodeList<Node> properties)
+    private static ObjectPattern Rewrite(in NodeList<Node> properties)
     {
         return new ObjectPattern(properties);
     }

--- a/src/Esprima/Ast/RestElement.cs
+++ b/src/Esprima/Ast/RestElement.cs
@@ -16,7 +16,7 @@ public sealed partial class RestElement : Node
     public Node Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private RestElement Rewrite(Node argument)
+    private static RestElement Rewrite(Node argument)
     {
         return new RestElement(argument);
     }

--- a/src/Esprima/Ast/ReturnStatement.cs
+++ b/src/Esprima/Ast/ReturnStatement.cs
@@ -13,7 +13,7 @@ public sealed partial class ReturnStatement : Statement
     public Expression? Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ReturnStatement Rewrite(Expression? argument)
+    private static ReturnStatement Rewrite(Expression? argument)
     {
         return new ReturnStatement(argument);
     }

--- a/src/Esprima/Ast/SequenceExpression.cs
+++ b/src/Esprima/Ast/SequenceExpression.cs
@@ -15,7 +15,7 @@ public sealed partial class SequenceExpression : Expression
     public ref readonly NodeList<Expression> Expressions { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _expressions; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SequenceExpression Rewrite(in NodeList<Expression> expressions)
+    private static SequenceExpression Rewrite(in NodeList<Expression> expressions)
     {
         return new SequenceExpression(expressions);
     }

--- a/src/Esprima/Ast/SpreadElement.cs
+++ b/src/Esprima/Ast/SpreadElement.cs
@@ -13,7 +13,7 @@ public sealed partial class SpreadElement : Expression
     public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SpreadElement Rewrite(Expression argument)
+    private static SpreadElement Rewrite(Expression argument)
     {
         return new SpreadElement(argument);
     }

--- a/src/Esprima/Ast/StaticBlock.cs
+++ b/src/Esprima/Ast/StaticBlock.cs
@@ -15,7 +15,7 @@ public sealed partial class StaticBlock : ClassElement
     public ref readonly NodeList<Statement> Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _body; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private StaticBlock Rewrite(in NodeList<Statement> body)
+    private static StaticBlock Rewrite(in NodeList<Statement> body)
     {
         return new StaticBlock(body);
     }

--- a/src/Esprima/Ast/StaticMemberExpression.cs
+++ b/src/Esprima/Ast/StaticMemberExpression.cs
@@ -7,8 +7,8 @@ public sealed class StaticMemberExpression : MemberExpression
     {
     }
 
-    protected override MemberExpression Rewrite(Expression obj, Expression property)
+    protected override MemberExpression Rewrite(Expression @object, Expression property)
     {
-        return new StaticMemberExpression(obj, property, Optional);
+        return new StaticMemberExpression(@object, property, Optional);
     }
 }

--- a/src/Esprima/Ast/SwitchCase.cs
+++ b/src/Esprima/Ast/SwitchCase.cs
@@ -17,7 +17,7 @@ public sealed partial class SwitchCase : Node
     public ref readonly NodeList<Statement> Consequent { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _consequent; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SwitchCase Rewrite(Expression? test, in NodeList<Statement> consequent)
+    private static SwitchCase Rewrite(Expression? test, in NodeList<Statement> consequent)
     {
         return new SwitchCase(test, consequent);
     }

--- a/src/Esprima/Ast/SwitchStatement.cs
+++ b/src/Esprima/Ast/SwitchStatement.cs
@@ -17,7 +17,7 @@ public sealed partial class SwitchStatement : Statement
     public ref readonly NodeList<SwitchCase> Cases { [MethodImpl(MethodImplOptions.AggressiveInlining)] get => ref _cases; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private SwitchStatement Rewrite(Expression discriminant, in NodeList<SwitchCase> cases)
+    private static SwitchStatement Rewrite(Expression discriminant, in NodeList<SwitchCase> cases)
     {
         return new SwitchStatement(discriminant, cases);
     }

--- a/src/Esprima/Ast/TaggedTemplateExpression.cs
+++ b/src/Esprima/Ast/TaggedTemplateExpression.cs
@@ -15,7 +15,7 @@ public sealed partial class TaggedTemplateExpression : Expression
     public TemplateLiteral Quasi { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private TaggedTemplateExpression Rewrite(Expression tag, TemplateLiteral quasi)
+    private static TaggedTemplateExpression Rewrite(Expression tag, TemplateLiteral quasi)
     {
         return new TaggedTemplateExpression(tag, quasi);
     }

--- a/src/Esprima/Ast/TemplateLiteral.cs
+++ b/src/Esprima/Ast/TemplateLiteral.cs
@@ -23,7 +23,7 @@ public sealed partial class TemplateLiteral : Expression
     internal override Node? NextChildNode(ref ChildNodes.Enumerator enumerator) => enumerator.MoveNextTemplateLiteral(Quasis, Expressions);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private TemplateLiteral Rewrite(in NodeList<TemplateElement> quasis, in NodeList<Expression> expressions)
+    private static TemplateLiteral Rewrite(in NodeList<TemplateElement> quasis, in NodeList<Expression> expressions)
     {
         return new TemplateLiteral(quasis, expressions);
     }

--- a/src/Esprima/Ast/ThrowStatement.cs
+++ b/src/Esprima/Ast/ThrowStatement.cs
@@ -13,7 +13,7 @@ public sealed partial class ThrowStatement : Statement
     public Expression Argument { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private ThrowStatement Rewrite(Expression argument)
+    private static ThrowStatement Rewrite(Expression argument)
     {
         return new ThrowStatement(argument);
     }

--- a/src/Esprima/Ast/TryStatement.cs
+++ b/src/Esprima/Ast/TryStatement.cs
@@ -21,7 +21,7 @@ public sealed partial class TryStatement : Statement
     public BlockStatement? Finalizer { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private TryStatement Rewrite(BlockStatement block, CatchClause? handler, BlockStatement? finalizer)
+    private static TryStatement Rewrite(BlockStatement block, CatchClause? handler, BlockStatement? finalizer)
     {
         return new TryStatement(block, handler, finalizer);
     }

--- a/src/Esprima/Ast/VariableDeclarator.cs
+++ b/src/Esprima/Ast/VariableDeclarator.cs
@@ -19,7 +19,7 @@ public sealed partial class VariableDeclarator : Node
     public Expression? Init { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private VariableDeclarator Rewrite(Node id, Expression? init)
+    private static VariableDeclarator Rewrite(Node id, Expression? init)
     {
         return new VariableDeclarator(id, init);
     }

--- a/src/Esprima/Ast/WhileStatement.cs
+++ b/src/Esprima/Ast/WhileStatement.cs
@@ -15,7 +15,7 @@ public sealed partial class WhileStatement : Statement
     public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private WhileStatement Rewrite(Expression test, Statement body)
+    private static WhileStatement Rewrite(Expression test, Statement body)
     {
         return new WhileStatement(test, body);
     }

--- a/src/Esprima/Ast/WithStatement.cs
+++ b/src/Esprima/Ast/WithStatement.cs
@@ -15,7 +15,7 @@ public sealed partial class WithStatement : Statement
     public Statement Body { [MethodImpl(MethodImplOptions.AggressiveInlining)] get; }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private WithStatement Rewrite(Expression @object, Statement body)
+    private static WithStatement Rewrite(Expression @object, Statement body)
     {
         return new WithStatement(@object, body);
     }

--- a/src/Esprima/Esprima.csproj
+++ b/src/Esprima/Esprima.csproj
@@ -20,6 +20,8 @@
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
 
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
+
     <DefineConstants Condition=" '$(TargetFramework)' == 'netstandard2.1'">$(DefineConstants);HAS_SPAN_PARSE</DefineConstants>
   </PropertyGroup>
 

--- a/src/Esprima/JavaScriptParser.cs
+++ b/src/Esprima/JavaScriptParser.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using Esprima.Ast;
 
@@ -460,7 +461,7 @@ public partial class JavaScriptParser
     private void Expect(string value)
     {
         var token = NextToken(allowIdentifierEscape: true);
-        if (token.Type != TokenType.Punctuator || !value.Equals((string) token.Value!))
+        if (token.Type != TokenType.Punctuator || !value.Equals((string) token.Value!, StringComparison.Ordinal))
         {
             ThrowUnexpectedToken(token);
         }
@@ -502,7 +503,7 @@ public partial class JavaScriptParser
     private void ExpectKeyword(string keyword)
     {
         var token = NextToken();
-        if (token.Type != TokenType.Keyword || !keyword.Equals((string) token.Value!))
+        if (token.Type != TokenType.Keyword || !keyword.Equals((string) token.Value!, StringComparison.Ordinal))
         {
             ThrowUnexpectedToken(token);
         }
@@ -516,7 +517,7 @@ public partial class JavaScriptParser
     {
         // ReSharper disable once InlineTemporaryVariable
         ref readonly var token = ref _lookahead;
-        return token.Type == TokenType.Punctuator && value.Equals((string) token.Value!);
+        return token.Type == TokenType.Punctuator && value.Equals((string) token.Value!, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -558,7 +559,7 @@ public partial class JavaScriptParser
     {
         // ReSharper disable once InlineTemporaryVariable
         ref readonly var token = ref _lookahead;
-        return token.Type == TokenType.Keyword && keyword.Equals((string) token.Value!);
+        return token.Type == TokenType.Keyword && keyword.Equals((string) token.Value!, StringComparison.Ordinal);
     }
 
     // Return true if the next token matches the specified contextual keyword
@@ -569,7 +570,7 @@ public partial class JavaScriptParser
     {
         // ReSharper disable once InlineTemporaryVariable
         ref readonly var token = ref _lookahead;
-        return token.Type == TokenType.Identifier && keyword.Equals((string) token.Value!);
+        return token.Type == TokenType.Identifier && keyword.Equals((string) token.Value!, StringComparison.Ordinal);
     }
 
     // Return true if the next token is an assignment operator
@@ -1070,11 +1071,11 @@ public partial class JavaScriptParser
     {
         if (key.Type == Nodes.Identifier)
         {
-            return value.Equals(key.As<Identifier>().Name);
+            return value.Equals(key.As<Identifier>().Name, StringComparison.Ordinal);
         }
         else if (key.Type == Nodes.Literal)
         {
-            return value.Equals(key.As<Literal>().StringValue);
+            return value.Equals(key.As<Literal>().StringValue, StringComparison.Ordinal);
         }
 
         return false;
@@ -1123,7 +1124,7 @@ public partial class JavaScriptParser
         var lookaheadPropertyKey = QualifiedPropertyName(_lookahead);
         if (token.Type == TokenType.Identifier && !isAsync && "get".Equals(token.Value) && lookaheadPropertyKey)
         {
-            if (!"get".Equals(GetTokenRaw(token)))
+            if (!"get".Equals(GetTokenRaw(token), StringComparison.Ordinal))
             {
                 TolerateError(Messages.InvalidUnicodeKeyword, "get");
             }
@@ -1135,7 +1136,7 @@ public partial class JavaScriptParser
         }
         else if (token.Type == TokenType.Identifier && !isAsync && "set".Equals(token.Value) && lookaheadPropertyKey)
         {
-            if (!"set".Equals(GetTokenRaw(token)))
+            if (!"set".Equals(GetTokenRaw(token), StringComparison.Ordinal))
             {
                 TolerateError(Messages.InvalidUnicodeKeyword, "set");
             }
@@ -2570,7 +2571,7 @@ public partial class JavaScriptParser
         };
     }
 
-    private int _assignmentDepth = 0;
+    private int _assignmentDepth;
 
     private protected Expression ParseAssignmentExpression()
     {
@@ -5542,7 +5543,7 @@ ParseValue:
 
     private ParseError CreateError(string messageFormat, params object?[] values)
     {
-        var msg = string.Format(messageFormat, values);
+        var msg = string.Format(CultureInfo.InvariantCulture, messageFormat, values);
 
         var index = _lastMarker.Index;
         var line = _lastMarker.Line;
@@ -5552,7 +5553,7 @@ ParseValue:
 
     private protected void TolerateError(string messageFormat, params object?[] values)
     {
-        var msg = string.Format(messageFormat, values);
+        var msg = string.Format(CultureInfo.InvariantCulture, messageFormat, values);
 
         var index = _lastMarker.Index;
         var line = _scanner._lineNumber;
@@ -5591,14 +5592,14 @@ ParseValue:
 
             value = token.Type == TokenType.Template
                 ? token.RawTemplate!
-                : Convert.ToString(token.Value);
+                : Convert.ToString(token.Value, CultureInfo.InvariantCulture);
         }
         else
         {
             value = "ILLEGAL";
         }
 
-        msg = string.Format(msg, value);
+        msg = string.Format(CultureInfo.InvariantCulture, msg, value);
 
         if (token.Type != TokenType.Unknown && token.LineNumber > 0)
         {

--- a/src/Esprima/Location.cs
+++ b/src/Esprima/Location.cs
@@ -74,7 +74,7 @@ public readonly struct Location : IEquatable<Location>
     {
         return Start.Equals(other.Start)
                && End.Equals(other.End)
-               && string.Equals(Source, other.Source);
+               && string.Equals(Source, other.Source, StringComparison.Ordinal);
     }
 
     bool IEquatable<Location>.Equals(Location other) => Equals(in other);

--- a/src/Esprima/ParserExtensions.cs
+++ b/src/Esprima/ParserExtensions.cs
@@ -190,6 +190,14 @@ internal static partial class ParserExtensions
         return char.MinValue;
     }
 
+#if NETFRAMEWORK || NETSTANDARD2_0
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    internal static bool Contains(this string source, char c)
+    {
+        return source.IndexOf(c) != -1;
+    }
+#endif
+
     internal static bool TryConsumeInt(this ref ReadOnlySpan<char> s, out int result)
     {
         result = 0;

--- a/src/Esprima/Scanner.RegExpParser.Unicode.cs
+++ b/src/Esprima/Scanner.RegExpParser.Unicode.cs
@@ -417,7 +417,7 @@ partial class Scanner
 
                     if (isInverted)
                     {
-                        sb.Append("^");
+                        sb.Append('^');
                     }
 
                     rangeSpan = bmpRanges.AsSpan();

--- a/src/Esprima/Scanner.cs
+++ b/src/Esprima/Scanner.cs
@@ -883,11 +883,11 @@ ParseIdentifierPart:
         {
             type = TokenType.Keyword;
         }
-        else if ("null".Equals(id))
+        else if ("null".Equals(id, StringComparison.Ordinal))
         {
             type = TokenType.NullLiteral;
         }
-        else if ("true".Equals(id) || "false".Equals(id))
+        else if ("true".Equals(id, StringComparison.Ordinal) || "false".Equals(id, StringComparison.Ordinal))
         {
             type = TokenType.BooleanLiteral;
         }
@@ -1017,7 +1017,7 @@ ParseIdentifierPart:
                 else
                 {
                     str = ParserExtensions.CharToString(c);
-                    if ("<>=!+-*%&|^/".IndexOf(c) >= 0)
+                    if ("<>=!+-*%&|^/".Contains(c))
                     {
                         ++_index;
                     }
@@ -1202,7 +1202,7 @@ ParseIdentifierPart:
         if (Character.IsOctalDigit(prefix))
         {
             octal = true;
-            sb.Append("0").Append(_source[_index++]);
+            sb.Append('0').Append(_source[_index++]);
         }
         else
         {
@@ -1421,7 +1421,7 @@ ParseIdentifierPart:
         else if (ch == 'n')
         {
             number = sb.ToString();
-            if (nonOctal || number.IndexOf('.') >= 0)
+            if (nonOctal || number.Contains('.'))
             {
                 ThrowUnexpectedToken();
             }
@@ -1529,22 +1529,22 @@ ParseIdentifierPart:
                             str.Append(unescaped2);
                             break;
                         case 'n':
-                            str.Append("\n");
+                            str.Append('\n');
                             break;
                         case 'r':
-                            str.Append("\r");
+                            str.Append('\r');
                             break;
                         case 't':
-                            str.Append("\t");
+                            str.Append('\t');
                             break;
                         case 'b':
-                            str.Append("\b");
+                            str.Append('\b');
                             break;
                         case 'f':
-                            str.Append("\f");
+                            str.Append('\f');
                             break;
                         case 'v':
-                            str.Append("\x0B");
+                            str.Append('\v');
                             break;
                         case '8':
                         case '9':
@@ -1678,13 +1678,13 @@ ParseIdentifierPart:
                     switch (ch)
                     {
                         case 'n':
-                            sb.Append("\n");
+                            sb.Append('\n');
                             break;
                         case 'r':
-                            sb.Append("\r");
+                            sb.Append('\r');
                             break;
                         case 't':
-                            sb.Append("\t");
+                            sb.Append('\t');
                             break;
                         case 'u':
                             if (_source.CharCodeAt(_index) == '{')
@@ -1724,13 +1724,13 @@ ParseIdentifierPart:
 
                             break;
                         case 'b':
-                            sb.Append("\b");
+                            sb.Append('\b');
                             break;
                         case 'f':
-                            sb.Append("\f");
+                            sb.Append('\f');
                             break;
                         case 'v':
-                            sb.Append("\v");
+                            sb.Append('\v');
                             break;
 
                         default:
@@ -1743,7 +1743,7 @@ ParseIdentifierPart:
                                 }
                                 else
                                 {
-                                    sb.Append("\0");
+                                    sb.Append('\0');
                                 }
                             }
                             else if (Character.IsDecimalDigit(ch))

--- a/src/Esprima/Utils/JavaScriptTextFormatter.cs
+++ b/src/Esprima/Utils/JavaScriptTextFormatter.cs
@@ -282,12 +282,16 @@ public abstract class JavaScriptTextFormatter : JavaScriptTextWriter
         return statementCount == 0 && KeepEmptyBlockBodyInLine;
     }
 
+#pragma warning disable CA1822 // public API cannot be changed to static
     protected void StoreStatementBodyIntoContext(Statement statement, ref WriteContext context)
+#pragma warning restore CA1822
     {
         context._additionalDataSlot.PrimaryData = statement;
     }
 
+#pragma warning disable CA1822 // public API cannot be changed to static
     protected Statement RetrieveStatementBodyFromContext(ref WriteContext context)
+#pragma warning restore CA1822
     {
         return (Statement) (context._additionalDataSlot.PrimaryData ?? throw new InvalidOperationException());
     }

--- a/src/Esprima/Utils/JavaScriptTextWriter.WriteContext.cs
+++ b/src/Esprima/Utils/JavaScriptTextWriter.WriteContext.cs
@@ -32,7 +32,9 @@ partial class JavaScriptTextWriter
     public struct WriteContext
     {
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#pragma warning disable CA1822 // public API cannot be changed to static
         public WriteContext From(Node? parentNode, Node node) =>
+#pragma warning restore CA1822
             new WriteContext(parentNode, node ?? ThrowArgumentNullException<Node>(nameof(node)));
 
         private string? _nodePropertyName;


### PR DESCRIPTION
Had some nice catches like `Append` should use `char` instead of `string`, more performant `StringComparison.Ordinal` and method could be static for example.