### PR TITLE
Enable UseArtifactsOutput

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,6 +17,8 @@
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+
   </PropertyGroup>
 
 </Project>

--- a/Esprima.sln
+++ b/Esprima.sln
@@ -8,7 +8,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
-		src\Directory.Build.props = src\Directory.Build.props
+		src\Directory.Build.props = Directory.Build.props
 		Directory.Packages.props = Directory.Packages.props
 	EndProjectSection
 EndProject

--- a/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
+++ b/samples/Esprima.Benchmark/Esprima.Benchmark.csproj
@@ -8,6 +8,7 @@
     <AssemblyOriginatorKeyFile>../../src/Esprima.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>disable</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\test\Esprima.Tests\Fixtures\3rdparty\**" CopyToOutputDirectory="PreserveNewest" LinkBase="3rdparty" />

--- a/test/Esprima.Tests.SourceGenerators/ModuleInitializer.cs
+++ b/test/Esprima.Tests.SourceGenerators/ModuleInitializer.cs
@@ -7,6 +7,6 @@ public static class ModuleInitializer
     [ModuleInitializer]
     public static void Init()
     {
-        VerifySourceGenerators.Enable();
+        VerifySourceGenerators.Initialize();
     }
 }


### PR DESCRIPTION
* move Directory.Build.props to global scope
* disable nullables in benchmarks
* update Verify API usage not to produce treat warnings as error problem