### PR TITLE
Update to NET 8 SDK

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Generate test cases
       working-directory: ./test/Esprima.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release
+      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release --framework net6.0 -- --update-allow-list
 
     - name: Test
       run: dotnet test --configuration Release --logger GitHubActions
@@ -39,7 +39,7 @@ jobs:
 
     - name: Generate test cases
       working-directory: ./test/Esprima.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release -- --update-allow-list
+      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release --framework net6.0 -- --update-allow-list
 
     - name: Test
       run: dotnet test --configuration Release --framework net6.0 --logger GitHubActions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Generate test cases
       working-directory: ./test/Esprima.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release
+      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release --framework net6.0
 
     - name: Test
       run: dotnet test --configuration Release --framework net6.0 --logger GitHubActions

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -22,7 +22,7 @@ jobs:
 
     - name: Generate test cases
       working-directory: ./test/Esprima.Tests.Test262
-      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release
+      run: dotnet tool restore && dotnet test262 generate && dotnet run -c Release --framework net6.0
 
     - name: Test
       run: dotnet test --configuration Release --logger GitHubActions

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.100",
+    "rollForward": "latestMinor"
+  }
+}

--- a/test/Esprima.Tests.SourceGenerators/SourceGeneratorTest.cs
+++ b/test/Esprima.Tests.SourceGenerators/SourceGeneratorTest.cs
@@ -10,6 +10,6 @@ public class SourceGeneratorTest
 
     protected static string ToEsprimaSourcePath(string path)
     {
-        return Path.Combine("../../../../../src/Esprima/", path);
+        return Path.Combine("../../../../src/Esprima/", path);
     }
 }

--- a/test/Esprima.Tests.Test262/Program.cs
+++ b/test/Esprima.Tests.Test262/Program.cs
@@ -16,9 +16,9 @@ public static class Program
     public static async Task<int> Main(string[] args)
     {
         var rootDirectory = Path.GetDirectoryName(Assembly.GetEntryAssembly()?.Location) ?? string.Empty;
-        var projectRoot = Path.Combine(rootDirectory, "../../..");
+        var solutionRoot = Path.Combine(rootDirectory, "../../../..");
 
-        var allowListFile = Path.Combine(projectRoot, "allow-list.txt");
+        var allowListFile = new FileInfo(Path.Combine(solutionRoot, "test", "Esprima.Tests.Test262", "allow-list.txt")).FullName;
         var lines = File.Exists(allowListFile) ? await File.ReadAllLinesAsync(allowListFile) : Array.Empty<string>();
         var knownFailing = new HashSet<string>(lines
             .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("#", StringComparison.Ordinal))

--- a/test/Esprima.Tests/Fixtures.cs
+++ b/test/Esprima.Tests/Fixtures.cs
@@ -258,8 +258,8 @@ public class Fixtures
         var assemblyPath = typeof(Fixtures).GetTypeInfo().Assembly.Location;
         var assemblyDirectory = new FileInfo(assemblyPath).Directory;
 #endif
-        var root = assemblyDirectory?.Parent?.Parent?.Parent?.FullName;
-        return root ?? "";
+        var root = assemblyDirectory?.Parent?.Parent?.Parent?.Parent?.FullName;
+        return Path.Combine(root ?? "", "test", "Esprima.Tests");
     }
 
     private sealed class FixtureMetadata


### PR DESCRIPTION
Ensures consistent test path resolution when `UseArtifactsOutput` is in use.