### PR TITLE
Return old recursion limit capabilities

### DIFF
--- a/src/Esprima/JavaScriptParser.cs
+++ b/src/Esprima/JavaScriptParser.cs
@@ -638,7 +638,7 @@ public partial class JavaScriptParser
         return result;
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    [MethodImpl(MethodImplOptions.AggressiveInlining | (MethodImplOptions) 512)]
     private T InheritCoverGrammar<T>(Func<T> parseFunction) where T : Node
     {
         var previousIsBindingElement = _context.IsBindingElement;
@@ -677,6 +677,7 @@ public partial class JavaScriptParser
 
     // https://tc39.github.io/ecma262/#sec-primary-expression
 
+    [MethodImpl((MethodImplOptions) 512)]
     private protected virtual Expression ParsePrimaryExpression()
     {
         var node = CreateNode();
@@ -2318,6 +2319,7 @@ public partial class JavaScriptParser
     private Stack<int>? _precedencesStack;
     private ArrayList<object>? _sharedStack;
 
+    [MethodImpl((MethodImplOptions) 512)]
     private Expression ParseBinaryExpression()
     {
         var startToken = _lookahead;

--- a/test/Esprima.Tests/JavaScriptParserTests.cs
+++ b/test/Esprima.Tests/JavaScriptParserTests.cs
@@ -14,7 +14,7 @@ public class JavaScriptParserTests
 #if DEBUG
         const int Depth = 205;
 #else
-        const int Depth = 385;
+        const int Depth = 520;
 #endif
         var input = $"if ({new string('(', Depth)}true{new string(')', Depth)}) {{ }}";
         parser.ParseScript(input);


### PR DESCRIPTION
Now stack limits are even better after sprinkling some aggressive optimization requests.

## main

| Method       | Runtime  | FileName            | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0     | Gen1     | Allocated  | Alloc Ratio |
|------------- |--------- |-------------------- |------------:|----------:|----------:|------:|--------:|---------:|---------:|-----------:|------------:|
| **ParseProgram** | **.NET 6.0** | **angular-1.2.5**       |  **9,098.2 μs** | **102.81 μs** |  **96.17 μs** |  **1.00** |    **0.00** | **328.1250** | **156.2500** | **4095.47 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | angular-1.2.5       |  7,049.0 μs |  99.90 μs |  93.45 μs |  0.77 |    0.01 | 328.1250 | 296.8750 | 4046.21 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **backbone-1.1.0**      |  **1,128.8 μs** |  **19.97 μs** |  **18.68 μs** |  **1.00** |    **0.00** |  **52.7344** |  **25.3906** |  **647.78 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | backbone-1.1.0      |    842.8 μs |  10.36 μs |   9.69 μs |  0.75 |    0.01 |  50.7813 |  33.2031 |  642.45 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **jquery-1.9.1**        |  **6,740.0 μs** | **133.26 μs** | **124.65 μs** |  **1.00** |    **0.00** | **281.2500** | **132.8125** | **3540.14 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | jquery-1.9.1        |  5,515.8 μs |  80.03 μs |  70.94 μs |  0.82 |    0.02 | 281.2500 | 257.8125 | 3532.38 KB |        1.00 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **jquery.mobile-1.4.2** | **10,889.8 μs** | **129.12 μs** | **120.78 μs** |  **1.00** |    **0.00** | **453.1250** | **218.7500** | **5609.25 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | jquery.mobile-1.4.2 |  8,600.8 μs | 166.33 μs | 155.59 μs |  0.79 |    0.02 | 453.1250 | 437.5000 | 5578.16 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **mootools-1.4.5**      |  **5,266.5 μs** |  **44.34 μs** |  **39.30 μs** |  **1.00** |    **0.00** | **234.3750** | **117.1875** | **2938.38 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | mootools-1.4.5      |  4,800.1 μs |  67.45 μs |  63.10 μs |  0.91 |    0.01 | 242.1875 | 218.7500 | 3013.67 KB |        1.03 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **underscore-1.5.2**    |    **936.1 μs** |   **9.04 μs** |   **8.45 μs** |  **1.00** |    **0.00** |  **44.9219** |  **16.6016** |   **555.5 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | underscore-1.5.2    |    703.8 μs |   8.09 μs |   7.56 μs |  0.75 |    0.01 |  44.9219 |  28.3203 |  552.79 KB |        1.00 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **yui-3.12.0**          |  **4,848.0 μs** |  **45.90 μs** |  **40.69 μs** |  **1.00** |    **0.00** | **218.7500** | **109.3750** | **2714.66 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | yui-3.12.0          |  3,861.8 μs |  39.05 μs |  36.53 μs |  0.80 |    0.01 | 218.7500 | 195.3125 | 2700.02 KB |        0.99 |



## PR 

| Method       | Runtime  | FileName            | Mean        | Error     | StdDev    | Ratio | RatioSD | Gen0     | Gen1     | Allocated  | Alloc Ratio |
|------------- |--------- |-------------------- |------------:|----------:|----------:|------:|--------:|---------:|---------:|-----------:|------------:|
| **ParseProgram** | **.NET 6.0** | **angular-1.2.5**       |  **8,891.7 μs** | **122.80 μs** | **114.87 μs** |  **1.00** |    **0.00** | **328.1250** | **156.2500** | **4095.47 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | angular-1.2.5       |  6,642.5 μs |  84.94 μs |  75.30 μs |  0.75 |    0.01 | 328.1250 | 296.8750 | 4046.21 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **backbone-1.1.0**      |  **1,112.2 μs** |  **18.09 μs** |  **16.04 μs** |  **1.00** |    **0.00** |  **52.7344** |  **25.3906** |  **647.78 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | backbone-1.1.0      |    862.1 μs |  10.39 μs |   9.72 μs |  0.77 |    0.01 |  51.7578 |  35.1563 |  642.45 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **jquery-1.9.1**        |  **6,805.6 μs** |  **75.95 μs** |  **71.05 μs** |  **1.00** |    **0.00** | **281.2500** | **132.8125** | **3540.13 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | jquery-1.9.1        |  5,359.1 μs |  60.33 μs |  56.43 μs |  0.79 |    0.01 | 281.2500 | 257.8125 | 3532.36 KB |        1.00 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **jquery.mobile-1.4.2** | **10,781.8 μs** | **158.29 μs** | **140.32 μs** |  **1.00** |    **0.00** | **453.1250** | **218.7500** | **5609.22 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | jquery.mobile-1.4.2 |  8,333.1 μs | 153.39 μs | 143.48 μs |  0.77 |    0.02 | 453.1250 | 437.5000 | 5578.12 KB |        0.99 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **mootools-1.4.5**      |  **5,371.2 μs** |  **71.42 μs** |  **63.31 μs** |  **1.00** |    **0.00** | **234.3750** | **117.1875** | **2938.38 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | mootools-1.4.5      |  4,772.4 μs |  76.56 μs |  71.62 μs |  0.89 |    0.01 | 242.1875 | 218.7500 | 3013.66 KB |        1.03 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **underscore-1.5.2**    |    **974.8 μs** |  **19.11 μs** |  **30.86 μs** |  **1.00** |    **0.00** |  **44.9219** |  **16.6016** |   **555.5 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | underscore-1.5.2    |    718.7 μs |  13.26 μs |  13.02 μs |  0.76 |    0.01 |  44.9219 |  28.3203 |  552.79 KB |        1.00 |
|              |          |                     |             |           |           |       |         |          |          |            |             |
| **ParseProgram** | **.NET 6.0** | **yui-3.12.0**          |  **4,735.5 μs** |  **28.83 μs** |  **22.51 μs** |  **1.00** |    **0.00** | **218.7500** | **109.3750** | **2714.66 KB** |        **1.00** |
| ParseProgram | .NET 8.0 | yui-3.12.0          |  3,737.0 μs |  34.66 μs |  30.72 μs |  0.79 |    0.01 | 218.7500 | 195.3125 | 2700.02 KB |        0.99 |
