### PR TITLE
Fix copy ctor of ParserOptions

### DIFF
--- a/src/Esprima/ParserOptions.cs
+++ b/src/Esprima/ParserOptions.cs
@@ -14,6 +14,15 @@ public record class ParserOptions
 
     public ScannerOptions GetScannerOptions() => _scannerOptions;
 
+    protected ParserOptions(ParserOptions original)
+    {
+        _scannerOptions = original._scannerOptions with { };
+        Tokens = original.Tokens;
+        AllowReturnOutsideFunction = original.AllowReturnOutsideFunction;
+        MaxAssignmentDepth = original.MaxAssignmentDepth;
+        OnNodeCreated = original.OnNodeCreated;
+    }
+
     /// <summary>
     /// Gets or sets whether the tokens are included in the parsed tree, defaults to <see langword="false"/>.
     /// </summary>

--- a/test/Esprima.Tests/ParserOptionsTests.cs
+++ b/test/Esprima.Tests/ParserOptionsTests.cs
@@ -1,0 +1,26 @@
+﻿namespace Esprima.Tests;
+
+public class ParserOptionsTests
+{
+    [Fact]
+    public void CopyCtorShouldCreateDeepClone()
+    {
+        var options1 = new ParserOptions { Tolerant = false };
+        var options2 = options1 with { Tolerant = true };
+
+        Assert.NotSame(options1.GetScannerOptions(), options2.GetScannerOptions());
+        Assert.True(options2.Tolerant);
+        Assert.False(options1.Tolerant);
+    }
+
+    [Fact]
+    public void EqualsShouldCheckStructuralEquality()
+    {
+        var options1 = new ParserOptions { Tolerant = false };
+        var options2 = options1 with { Tolerant = false };
+
+        Assert.NotSame(options1.GetScannerOptions(), options2.GetScannerOptions());
+        Assert.Equal(options1.GetScannerOptions(), options2.GetScannerOptions());
+        Assert.Equal(options1, options2);
+    }
+}


### PR DESCRIPTION
Fixes a minor glitch: default implementation doesn't deep clone record type fields, so we need to provide a custom implementation.